### PR TITLE
feat: Prefer NODE_ENV before BABEL_ENV

### DIFF
--- a/src/babel/preval-extract/__tests__/prevalStyles.spec.js
+++ b/src/babel/preval-extract/__tests__/prevalStyles.spec.js
@@ -52,7 +52,7 @@ function runAssertions(expectedReplacement) {
 
 describe('preval-extract/prevalStyles', () => {
   beforeEach(() => {
-    process.env.BABEL_ENV = '';
+    process.env.NODE_ENV = '';
     getReplacement.mockClear();
     instantiateModule.mockClear();
     clearLocalModulesFromCache.mockClear();
@@ -63,8 +63,8 @@ describe('preval-extract/prevalStyles', () => {
   });
 
   it('should eval styles and replace css with class name from filename', () => {
-    process.env.BABEL_ENV = 'production';
+    process.env.NODE_ENV = 'production';
     runAssertions("css.named('header')`color: #ffffff`");
-    process.env.BABEL_ENV = '';
+    process.env.NODE_ENV = '';
   });
 });

--- a/src/babel/preval-extract/prevalStyles.js
+++ b/src/babel/preval-extract/prevalStyles.js
@@ -39,7 +39,7 @@ export default function(
   requirements: RequirementSource[]
 ) {
   const title = path.parent.id.name;
-  const env = process.env.BABEL_ENV || process.env.NODE_ENV;
+  const env = process.env.NODE_ENV || process.env.BABEL_ENV;
 
   const replacement = getReplacement([
     ...requirements,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This enables us setting custom babel env for server rendering, while staying in `NODE_ENV=production` which calculates hash based on css content instead of filename.

**Test plan**

Updated unit tests.
