### PR TITLE
feat: add a hoist-css plugin. resolves #110

### DIFF
--- a/babel.js
+++ b/babel.js
@@ -3,6 +3,7 @@
 module.exports = function linariaBabelPreset(context, opts = {}) {
   return {
     plugins: [
+      [require('./build/babel/hoist-css').default, opts],
       [require('./build/babel/preval-extract').default, opts],
       [require('./build/babel/rewire-imports').default, opts],
     ],

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "babel-preset-env": "1.6.0",
     "babel-preset-es2015": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "benchmark": "^2.1.4",
     "cli-table": "^0.3.1",

--- a/src/babel/hoist-css/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/babel/hoist-css/__tests__/__snapshots__/index.spec.js.snap
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`hoist-css babel plugin should hoist CSS from JSX from class 1`] = `
+"
+function MyComponent() {
+  return React.createElement(\\"article\\", {
+    \\"class\\": _article
+  });
+}
+
+var _article = css\`color: \${colors.red};\`;"
+`;
+
+exports[`hoist-css babel plugin should hoist CSS from JSX from className 1`] = `
+"
+function MyComponent() {
+  return React.createElement(\\"article\\", {
+    className: _article
+  });
+}
+
+var _article = css\`color: \${colors.red};\`;"
+`;
+
+exports[`hoist-css babel plugin should hoist CSS from JSX from styles 1`] = `
+"var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+function MyComponent() {
+  return React.createElement(\\"article\\", _extends({
+    id: \\"post\\"
+  }, styles(_article, _article2)));
+}
+
+var _article = css\`color: \${colors.red};\`;
+
+var _article2 = css\`font-size: 12px;\`;"
+`;
+
+exports[`hoist-css babel plugin should noop if no styles or class present 1`] = `
+"
+function MyComponent() {
+  return React.createElement(\\"article\\", { id: \\"post\\" });
+}"
+`;
+
+exports[`hoist-css babel plugin should not affect other template literals in class 1`] = `
+"
+function MyComponent() {
+  React.createElement(\\"article\\", {
+    \\"class\\": \`color: \${colors.red};\`
+  });
+}"
+`;
+
+exports[`hoist-css babel plugin should not affect other template literals in className 1`] = `
+"
+function MyComponent() {
+  React.createElement(\\"article\\", {
+    className: sass\`color: \${colors.red};\`
+  });
+}"
+`;
+
+exports[`hoist-css babel plugin should not affect other template literals in styles 1`] = `
+"var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+function MyComponent() {
+  React.createElement(\\"article\\", _extends({
+    id: \\"post\\"
+  }, styles(sass\`color: \${colors.red};\`, \`font-size: 12px;\`)));
+}"
+`;

--- a/src/babel/hoist-css/__tests__/index.spec.js
+++ b/src/babel/hoist-css/__tests__/index.spec.js
@@ -1,0 +1,104 @@
+/* eslint-disable no-template-curly-in-string */
+/* @flow */
+
+import * as babel from 'babel-core';
+
+function transpile(source) {
+  return babel.transform(source, {
+    presets: ['react'],
+    plugins: [require.resolve('../index')],
+    babelrc: false,
+  });
+}
+
+describe('hoist-css babel plugin', () => {
+  it('should hoist CSS from JSX from styles', () => {
+    const { code } = transpile(`
+      function MyComponent() {
+        return (
+          <article
+            id="post"
+            {...styles(css\`color: \${colors.red};\`, css\`font-size: 12px;\`)}
+          />
+        );
+      }
+    `);
+
+    expect(code).toMatchSnapshot();
+  });
+
+  it('should not affect other template literals in styles', () => {
+    const { code } = transpile(`
+      function MyComponent() {
+        <article
+          id="post"
+          {...styles(sass\`color: \${colors.red};\`, \`font-size: 12px;\`)}
+        />
+      }
+    `);
+
+    expect(code).toMatchSnapshot();
+  });
+
+  it('should hoist CSS from JSX from className', () => {
+    const { code } = transpile(`
+      function MyComponent() {
+        return (
+          <article
+            className={css\`color: \${colors.red};\`}
+          />
+        );
+      }
+    `);
+
+    expect(code).toMatchSnapshot();
+  });
+
+  it('should not affect other template literals in className', () => {
+    const { code } = transpile(`
+      function MyComponent() {
+        <article
+          className={sass\`color: \${colors.red};\`}
+        />
+      }
+    `);
+
+    expect(code).toMatchSnapshot();
+  });
+
+  it('should hoist CSS from JSX from class', () => {
+    const { code } = transpile(`
+      function MyComponent() {
+        return (
+          <article
+            class={css\`color: \${colors.red};\`}
+          />
+        );
+      }
+    `);
+
+    expect(code).toMatchSnapshot();
+  });
+
+  it('should not affect other template literals in class', () => {
+    const { code } = transpile(`
+      function MyComponent() {
+        <article
+          class={\`color: \${colors.red};\`}
+        />
+      }
+    `);
+
+    expect(code).toMatchSnapshot();
+  });
+
+  it('should noop if no styles or class present', () => {
+    const { code } = transpile(`
+      function MyComponent() {
+        return <article id="post" />;
+      }
+    `);
+
+    expect(code).toMatchSnapshot();
+  });
+});

--- a/src/babel/hoist-css/index.js
+++ b/src/babel/hoist-css/index.js
@@ -1,0 +1,64 @@
+/* @flow */
+
+import type { BabelTypes, NodePath } from '../types';
+
+type State = {
+  programPath: NodePath<*>,
+};
+
+const transformTaggedTemplate = (
+  t: BabelTypes,
+  path: NodePath<*>,
+  state: State,
+  expression: *
+) => {
+  if (
+    t.isTaggedTemplateExpression(expression) &&
+    expression.tag.name === 'css'
+  ) {
+    const className = path.scope.generateUidIdentifier(path.node.name.name);
+    state.programPath.node.body.push(
+      t.variableDeclaration('var', [
+        t.variableDeclarator(t.identifier(className.name), expression),
+      ])
+    );
+    return className;
+  }
+  return expression;
+};
+
+export default function({ types: t }: { types: BabelTypes }) {
+  return {
+    visitor: {
+      Program: {
+        enter(path: NodePath<*>, state: State) {
+          state.programPath = path;
+        },
+      },
+      JSXOpeningElement(path: NodePath<*>, state: State) {
+        path.node.attributes.forEach(attr => {
+          if (
+            t.isJSXSpreadAttribute(attr) &&
+            t.isCallExpression(attr.argument) &&
+            attr.argument.callee.name === 'styles'
+          ) {
+            attr.argument.arguments = attr.argument.arguments.map(arg =>
+              transformTaggedTemplate(t, path, state, arg)
+            );
+          } else if (
+            t.isJSXIdentifier(attr.name) &&
+            t.isJSXExpressionContainer(attr.value) &&
+            (attr.name.name === 'class' || attr.name.name === 'className')
+          ) {
+            attr.value.expression = transformTaggedTemplate(
+              t,
+              path,
+              state,
+              attr.value.expression
+            );
+          }
+        });
+      },
+    },
+  };
+}

--- a/src/babel/types.js
+++ b/src/babel/types.js
@@ -10,6 +10,7 @@ export type NodePath<K> = {
   parentPath: NodePath<*>,
   scope: {
     getBinding: (id: string) => Binding<any>,
+    generateUidIdentifier: (id: string) => BabelIdentifier,
   },
   isProgram: () => boolean,
   isReferenced: () => boolean,
@@ -63,6 +64,22 @@ export type BabelIdentifier = {
   type: string,
 };
 
+export type BabelJSXExpressionContainer = {
+  type: string,
+  expression: any,
+};
+
+export type BabelJSXIdentifier = {
+  name: string,
+  type: string,
+};
+
+export type BabelJSXSpreadAttribute = {
+  attr: {
+    argument: any,
+  },
+};
+
 export type BabelMemberExpression = {
   object: BabelIdentifier,
   property: BabelIdentifier,
@@ -103,16 +120,20 @@ export type BabelTypes = {
   memberExpression: BabelNodeFactory<BabelMemberExpression>,
   expressionStatement: BabelNodeFactory<any>,
   variableDeclaration: BabelNodeFactory<BabelVariableDeclaration>,
+  variableDeclarator: BabelNodeFactory<BabelVariableDeclarator<any>>,
   program: BabelNodeFactory<any>,
   isTaggedTemplateExpression: BabelIsTypeFunction<
     BabelTaggedTemplateExpression<any>
   >,
   isCallExpression: BabelIsTypeFunction<BabelCallExpression>,
-  isMemberExpression: BabelIsTypeFunction<BabelMemberExpression>,
   isIdentifier: BabelIsTypeFunction<BabelIdentifier>,
-  isVariableDeclaration: BabelIsTypeFunction<BabelVariableDeclaration>,
+  isJSXExpressionContainer: BabelIsTypeFunction<BabelJSXExpressionContainer>,
+  isJSXIdentifier: BabelIsTypeFunction<BabelJSXIdentifier>,
+  isJSXSpreadAttribute: BabelIsTypeFunction<BabelJSXSpreadAttribute>,
+  isMemberExpression: BabelIsTypeFunction<BabelMemberExpression>,
   isObjectExpression: BabelIsTypeFunction<BabelObjectExpression>,
   isObjectPattern: BabelIsTypeFunction<BabelObjectPattern>,
+  isVariableDeclaration: BabelIsTypeFunction<BabelVariableDeclaration>,
 };
 
 export type ImportStatement = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -328,6 +328,14 @@ babel-helper-builder-binary-assignment-operator-visitor@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
+babel-helper-builder-react-jsx@^6.24.1:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz#39ff8313b75c8b65dceff1f31d383e0ff2a408a0"
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    esutils "^2.0.2"
+
 babel-helper-call-delegate@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz#ece6aacddc76e41c3461f88bfc575bd0daa2df8d"
@@ -488,6 +496,10 @@ babel-plugin-syntax-exponentiation-operator@^6.8.0:
 babel-plugin-syntax-flow@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
+
+babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
 
 babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
@@ -722,6 +734,34 @@ babel-plugin-transform-object-rest-spread@^6.22.0:
     babel-plugin-syntax-object-rest-spread "^6.8.0"
     babel-runtime "^6.26.0"
 
+babel-plugin-transform-react-display-name@^6.23.0:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz#67e2bf1f1e9c93ab08db96792e05392bf2cc28d1"
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-react-jsx-self@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz#df6d80a9da2612a121e6ddd7558bcbecf06e636e"
+  dependencies:
+    babel-plugin-syntax-jsx "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-react-jsx-source@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz#66ac12153f5cd2d17b3c19268f4bf0197f44ecd6"
+  dependencies:
+    babel-plugin-syntax-jsx "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-react-jsx@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz#840a028e7df460dfc3a2d29f0c0d91f6376e66a3"
+  dependencies:
+    babel-helper-builder-react-jsx "^6.24.1"
+    babel-plugin-syntax-jsx "^6.8.0"
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-regenerator@^6.22.0, babel-plugin-transform-regenerator@^6.24.1:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f"
@@ -807,11 +847,28 @@ babel-preset-es2015@^6.24.1:
     babel-plugin-transform-es2015-unicode-regex "^6.24.1"
     babel-plugin-transform-regenerator "^6.24.1"
 
+babel-preset-flow@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz#e71218887085ae9a24b5be4169affb599816c49d"
+  dependencies:
+    babel-plugin-transform-flow-strip-types "^6.22.0"
+
 babel-preset-jest@^21.0.2:
   version "21.0.2"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-21.0.2.tgz#9db25def2329f49eace3f5ea0de42a0b898d12cc"
   dependencies:
     babel-plugin-jest-hoist "^21.0.2"
+
+babel-preset-react@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-react/-/babel-preset-react-6.24.1.tgz#ba69dfaea45fc3ec639b6a4ecea6e17702c91380"
+  dependencies:
+    babel-plugin-syntax-jsx "^6.3.13"
+    babel-plugin-transform-react-display-name "^6.23.0"
+    babel-plugin-transform-react-jsx "^6.24.1"
+    babel-plugin-transform-react-jsx-self "^6.22.0"
+    babel-plugin-transform-react-jsx-source "^6.22.0"
+    babel-preset-flow "^6.23.0"
 
 babel-preset-stage-2@^6.24.1:
   version "6.24.1"


### PR DESCRIPTION
Usually we need to think of a className every time we write some style rules. While this makes sense for rules with well-defined styles, there are many instances where we have a one off rule like `flex: 1` etc. It doesn't make sense to come up with a name for such a rule.

The babel plugin will transpile this:

```js
function MyComponent() {
  return <div {...styles(css`flex: 1`)} />;
}
```

to this:

```js
function MyComponent() {
  return <div {...styles(_div)} />;
}
var _div = css`flex: 1;`;
```

The plugin also supports `className` and `class` props (for preact) along with `styles`.

Currently we don't support such usage with our babel plugin even if it works fine in runtime, so it looks like it should work in compile time.

More context: #110