### PR TITLE
fix: guard for first frame in buildCodeFrameError

### DIFF
--- a/src/babel/lib/__tests__/errorUtils.spec.js
+++ b/src/babel/lib/__tests__/errorUtils.spec.js
@@ -132,7 +132,6 @@ describe('babel/lib/errorUtils', () => {
 
     const newError = buildCodeFrameError(error, frames);
 
-    expect(newError.message).toEqual('Test message');
-    expect(stripAnsi(newError.stack)).toBeUndefined();
+    expect(newError).toEqual(error);
   });
 });

--- a/src/babel/lib/__tests__/errorUtils.spec.js
+++ b/src/babel/lib/__tests__/errorUtils.spec.js
@@ -122,4 +122,17 @@ describe('babel/lib/errorUtils', () => {
     expect(newError.message).toEqual('Test message');
     expect(stripAnsi(newError.stack)).toMatchSnapshot();
   });
+
+  it('buildCodeFrameError should fallback if no frames are passed', () => {
+    const error = {
+      message: 'Test message',
+    };
+
+    const frames = [];
+
+    const newError = buildCodeFrameError(error, frames);
+
+    expect(newError.message).toEqual('Test message');
+    expect(stripAnsi(newError.stack)).toBeUndefined();
+  });
 });

--- a/src/babel/lib/errorUtils.js
+++ b/src/babel/lib/errorUtils.js
@@ -56,10 +56,16 @@ export function buildCodeFrameError(
   error: Error,
   frames: EnhancedFrame[]
 ): Error {
+  const firstFrame = frames[0];
+
+  if (!firstFrame) {
+    return error;
+  }
+
   const codeFrameString = codeFrame(
-    frames[0].originalSource,
-    frames[0].lineNumber,
-    frames[0].columnNumber,
+    firstFrame.originalSource,
+    firstFrame.lineNumber,
+    firstFrame.columnNumber,
     {
       highlightCode: true,
       linesAbove: 4,

--- a/src/babel/lib/errorUtils.js
+++ b/src/babel/lib/errorUtils.js
@@ -56,7 +56,7 @@ export function buildCodeFrameError(
   error: Error,
   frames: EnhancedFrame[]
 ): Error {
-  const firstFrame = frames[0];
+  const firstFrame = frames && frames[0];
 
   if (!firstFrame) {
     return error;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This came out while testing Linaria with CRA and Next.js, for some reason (didn't have time to investigate why) `frames` were passed either empty or with undefined object.

**Test plan**

covered
