### PR TITLE
chore: setup typescript-styled-plugin for vscode on website

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "website/node_modules/typescript/lib"
+}

--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ export function App() {
 
 ## Editor Plugins
 
+### CSS Autocompletion
+
+* VSCode, Atom, SublimeText – [typescript-styled-plugin](https://github.com/Microsoft/typescript-styled-plugin/issues/10)
+
 ### VSCode
 
 * Syntax Highlighting - [Styled Components Plugin](https://marketplace.visualstudio.com/items?itemName=jpoissonnier.vscode-styled-components)

--- a/website/package.json
+++ b/website/package.json
@@ -38,6 +38,8 @@
     "eslint-plugin-react": "^7.3.0",
     "extract-text-webpack-plugin": "^3.0.0",
     "style-loader": "^0.18.2",
+    "typescript": "^2.5.3",
+    "typescript-styled-plugin": "^0.1.0",
     "webpack": "^3.5.5",
     "webpack-dev-server": "^2.7.1"
   }

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -4390,6 +4390,16 @@ type-is@~1.6.15:
     media-typer "0.3.0"
     mime-types "~2.1.15"
 
+typescript-styled-plugin@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/typescript-styled-plugin/-/typescript-styled-plugin-0.1.0.tgz#d563516db7c6955675f71d6169c097e8330d6121"
+  dependencies:
+    vscode-css-languageservice "^2.1.10"
+
+typescript@^2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
+
 ua-parser-js@^0.7.9:
   version "0.7.14"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.14.tgz#110d53fa4c3f326c121292bbeac904d2e03387ca"
@@ -4551,6 +4561,21 @@ vm-browserify@0.0.4:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
   dependencies:
     indexof "0.0.1"
+
+vscode-css-languageservice@^2.1.10:
+  version "2.1.10"
+  resolved "https://registry.yarnpkg.com/vscode-css-languageservice/-/vscode-css-languageservice-2.1.10.tgz#465ca0dddc3c53f498bb353674755329b16a5e6e"
+  dependencies:
+    vscode-languageserver-types "^3.4.0"
+    vscode-nls "^2.0.1"
+
+vscode-languageserver-types@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.4.0.tgz#5043ae47ee4ac16af07bb3d0ca561235e0c0d2fa"
+
+vscode-nls@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-2.0.2.tgz#808522380844b8ad153499af5c3b03921aea02da"
 
 watchpack@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This is just a proof of concept, that Linaria works with `typescript-styled-plugin` without additional config. Someday they'll create extensions, but until then we can use this approach.
Added a VS Code config so it's already set up if someone uses it.
