### PR TITLE
fix: recursively check for variable declarator

### DIFF
--- a/src/babel/__integration-tests__/preval-extract/__snapshots__/errors.spec.js.snap
+++ b/src/babel/__integration-tests__/preval-extract/__snapshots__/errors.spec.js.snap
@@ -10,6 +10,7 @@ SyntaxError: test.js: Couldn't determine the class name for CSS template literal
 - Assigned to a variable
 - Is an object property
 - Is a prop in a JSX element
+
   1 | import css from '<<CWD>>/build/css.js';
   2 | 
 > 3 |     css\`
@@ -18,7 +19,7 @@ SyntaxError: test.js: Couldn't determine the class name for CSS template literal
   5 | \`;
     at File.buildCodeFrameError (<<CWD>>/node_modules/babel-core/lib/transformation/file/index.js:427:15)
     at NodePath.buildCodeFrameError (<<CWD>>/node_modules/babel-traverse/lib/path/index.js:140:26)
-    at PluginPass.TaggedTemplateExpression (<<CWD>>/build/babel/preval-extract/index.js:105:26)
+    at PluginPass.TaggedTemplateExpression (<<CWD>>/build/babel/preval-extract/index.js:106:24)
     at newFn (<<CWD>>/node_modules/babel-traverse/lib/visitors.js:276:21)
     at NodePath._call (<<CWD>>/node_modules/babel-traverse/lib/path/context.js:76:18)
     at NodePath.call (<<CWD>>/node_modules/babel-traverse/lib/path/context.js:48:17)

--- a/src/babel/__integration-tests__/preval-extract/with-inline-rules.spec.js
+++ b/src/babel/__integration-tests__/preval-extract/with-inline-rules.spec.js
@@ -24,7 +24,22 @@ function assertAndCheckForDuplications(
   }
 }
 
-describe('with object and JSX properties', () => {
+describe('with inline rules', () => {
+  it('should preval inside function call assigned to variable', () => {
+    const { code, getCSSForClassName } = transpile(dedent`
+      const header = styled('div', css\`
+        font-size: 3em;
+      \`);
+      `);
+
+    const match = /header = styled\(div, \/\*.+\*\/'(_header__[a-z0-9]+)'/g.exec(
+      code
+    );
+    expect(match).not.toBeNull();
+    const css = getCSSForClassName(match[1]);
+    expect(css).toMatch('font-size: 3em');
+  });
+
   it('should preval with object properties', () => {
     const { code, getCSSForClassName } = transpile(dedent`
       const styles = {

--- a/src/babel/preval-extract/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/babel/preval-extract/__tests__/__snapshots__/index.spec.js.snap
@@ -4,5 +4,6 @@ exports[`preval-extract/index TaggedTemplateExpression should not process templa
 "Couldn't determine the class name for CSS template literal. Ensure that it's either:
 - Assigned to a variable
 - Is an object property
-- Is a prop in a JSX element"
+- Is a prop in a JSX element
+"
 `;

--- a/src/babel/types.js
+++ b/src/babel/types.js
@@ -53,6 +53,15 @@ export type BabelObjectPattern = {
   type: string,
 };
 
+export type BabelObjectProperty = {
+  type: string,
+  method: false,
+  shorthand: false,
+  computed: false,
+  key: BabelIdentifier | BabelStringLiteral,
+  value: any,
+};
+
 export type BabelTaggedTemplateElement = {
   value: {
     raw: string,
@@ -89,6 +98,13 @@ export type BabelJSXExpressionContainer = {
 export type BabelJSXIdentifier = {
   name: string,
   type: string,
+};
+
+export type BabelJSXOpeningElement = {
+  type: string,
+  properties: any[],
+  name: BabelJSXIdentifier,
+  selfClosing: boolean,
 };
 
 export type BabelJSXSpreadAttribute = {
@@ -147,12 +163,15 @@ export type BabelTypes = {
   isIdentifier: BabelIsTypeFunction<BabelIdentifier>,
   isJSXExpressionContainer: BabelIsTypeFunction<BabelJSXExpressionContainer>,
   isJSXIdentifier: BabelIsTypeFunction<BabelJSXIdentifier>,
+  isJSXOpeningElement: BabelIsTypeFunction<BabelJSXOpeningElement>,
   isJSXSpreadAttribute: BabelIsTypeFunction<BabelJSXSpreadAttribute>,
   isMemberExpression: BabelIsTypeFunction<BabelMemberExpression>,
   isObjectExpression: BabelIsTypeFunction<BabelObjectExpression>,
   isObjectPattern: BabelIsTypeFunction<BabelObjectPattern>,
+  isObjectProperty: BabelIsTypeFunction<BabelObjectProperty>,
   isStringLiteral: BabelIsTypeFunction<BabelStringLiteral>,
   isVariableDeclaration: BabelIsTypeFunction<BabelVariableDeclaration>,
+  isVariableDeclarator: BabelIsTypeFunction<BabelVariableDeclarator<any>>,
 };
 
 export type ImportStatement = {


### PR DESCRIPTION
This allows to have the template literal inside expressions such as function calls before assigning to a variable.

For example, one could write helper function to generate components with already assigned class names,

```js
const Header = styled('h1', css`
  font-weight: bold;
`);
```
