### PR TITLE
fix: use babel-generator to get the source

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ export function App() {
 ## Recommended Libraries
 
 * [linaria-jest](https://github.com/thymikee/linaria-jest) – Jest testing utilities for Linaria.
+* [babel-plugin-object-styles-to-template](https://github.com/satya164/babel-plugin-object-styles-to-template) - Babel plugin to write styles in object syntax with linaria
 * [polished.js](https://polished.js.org/) - A lightweight toolset for writing styles in JavaScript.
 
 ## Inspiration

--- a/src/babel/preval-extract/prevalStyles.js
+++ b/src/babel/preval-extract/prevalStyles.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import { resolve } from 'path';
+import generate from 'babel-generator';
 
 import type {
   BabelCore,
@@ -40,11 +41,12 @@ export default function(
   requirements: RequirementSource[]
 ) {
   const { name } = path.scope.generateUidIdentifier(title);
+  const source = path.getSource() || generate(path.node).code;
+
   const replacement = getReplacement([
     ...requirements,
     {
-      code: `module.exports = ${path
-        .getSource()
+      code: `module.exports = ${source
         .replace(/css(?!\.named)/g, `css.named('${name}', '${state.filename}')`)
         .replace(
           /css\.named\(([^,]+)\)/,


### PR DESCRIPTION
when the node was generated by another babel plugin, getSource method returns empty string. we can use babel-generator to get the resulting string instead