### PR TITLE
Webpack loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,18 @@ Install it like a regular npm package:
 yarn add linaria
 ```
 
-Add the `linaria/babel` preset to your Babel configuration:
-
+We recommend to use `linaria/loader` as long as you use __Webpack__:
+```js
+module: {
+  rules: [
+    {
+      test: /\.js$/,
+      use: ['babel-loader', 'linaria-loader'],
+    },
+  ],
+},
+```
+or add the `linaria/babel` preset to your Babel configuration:
 ```json
 {
   "presets": [

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Install it like a regular npm package:
 yarn add linaria
 ```
 
-We recommend to use `linaria/loader` as long as you use __Webpack__:
+We recommend to use `linaria/loader` if you use __Webpack__:
+
 ```js
 module: {
   rules: [
@@ -52,7 +53,9 @@ module: {
   ],
 },
 ```
-or add the `linaria/babel` preset to your Babel configuration:
+
+If you don't use Webpack, you can add the `linaria/babel` preset to your Babel configuration:
+
 ```json
 {
   "presets": [

--- a/docs/BABEL_PRESET.md
+++ b/docs/BABEL_PRESET.md
@@ -1,5 +1,9 @@
 # `linaria/babel` preset
 
+__If you use Webpack__, we highly recommend to add `linaria/loader` to your JS rule in Webpack config. It supports the same options as the preset. For more information go [here](./BUNDLERS_INTEGRATION.md#loader).
+
+---
+
 In order to have styles in `css` tagged template literals evaluated and extracted you need to add the `linaria/babel` preset to your Babel configuration.
 
 `.babelrc`:

--- a/docs/BABEL_PRESET.md
+++ b/docs/BABEL_PRESET.md
@@ -1,6 +1,6 @@
 # `linaria/babel` preset
 
-__If you use Webpack__, we highly recommend to add `linaria/loader` to your JS rule in Webpack config. It supports the same options as the preset. For more information go [here](./BUNDLERS_INTEGRATION.md#loader).
+__If you use Webpack__, we highly recommend to use `linaria/loader`. It supports the same options as the preset. [See here](./BUNDLERS_INTEGRATION.md#loader) for instructions on configuring the loader.
 
 ---
 

--- a/docs/BUNDLERS_INTEGRATION.md
+++ b/docs/BUNDLERS_INTEGRATION.md
@@ -2,6 +2,54 @@
 
 ## webpack
 
+### Loader
+
+For the best user experience while working with Linaria we recommend to use our custom loader.
+
+Just add it to a JS rule after `babel-loader` in webpack config:
+
+```js
+/* rest of your config */
+module: {
+  /* rest of your module config */
+  rules: [
+    /* rest of your rules */
+    {
+      test: /\.js$/,
+      use: [{ loader: 'babel-loader' }, { loader: 'linaria/loader' }],
+    },
+  ],
+},
+```
+
+It serves the following purposes:
+* no stale CSS
+* omits `babel-loader`'s cache, so you always get CSS generated
+* it triggers CSS generation, when external modules used in `css` tagged template changes
+
+If you use loader, you can remove `linaria/babel` from your Babel config and pass options directly to the loader:
+
+```js
+module: {
+  rules: [
+    {
+      test: /\.js$/,
+      use: [
+        { loader: 'babel-loader' },
+        {
+          loader: 'linaria/loader',
+          options: {
+            single: true,
+            filename: 'styles.css',
+            outDir: 'static'
+          }
+        }
+      ],
+    },
+  ],
+},
+```
+
 ### Development
 
 In order for webpack to pick up extracted CSS files, you need to setup [style-loader](https://github.com/webpack-contrib/style-loader) and [css-loader](https://github.com/webpack-contrib/css-loader).

--- a/docs/BUNDLERS_INTEGRATION.md
+++ b/docs/BUNDLERS_INTEGRATION.md
@@ -4,9 +4,9 @@
 
 ### Loader
 
-For the best user experience while working with Linaria we recommend to use our custom loader.
+For the best developer experience with Linaria, we recommend to use our Webpack loader.
 
-Just add it to a JS rule after `babel-loader` in webpack config:
+In your Webpack config, you'll need to add `linaria/loader` to run Linaria on `.js` files:
 
 ```js
 /* rest of your config */
@@ -21,11 +21,6 @@ module: {
   ],
 },
 ```
-
-It serves the following purposes:
-* no stale CSS
-* omits `babel-loader`'s cache, so you always get CSS generated
-* it triggers CSS generation, when external modules used in `css` tagged template changes
 
 If you use loader, you can remove `linaria/babel` from your Babel config and pass options directly to the loader:
 

--- a/loader.js
+++ b/loader.js
@@ -1,0 +1,1 @@
+module.exports = require('./build/tools/webpack-loader').default;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "/build",
     "/babel.js",
     "/server.js",
+    "/loader.js",
     "/stylelint-config.js",
     "/stylelint-preprocessor.js"
   ],

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "cssom": "^0.3.2",
     "dedent": "^0.7.0",
     "error-stack-parser": "^2.0.1",
+    "loader-utils": "^1.1.0",
     "mkdirp": "^0.5.1",
     "postcss": "^6.0.10",
     "short-hash": "^1.0.0",

--- a/src/tools/webpack-loader.js
+++ b/src/tools/webpack-loader.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import * as babel from 'babel-core';
+import loaderUtils from 'loader-utils';
 
 function shouldRunLinaria(source: string) {
   return (
@@ -14,6 +15,7 @@ function transpile(
   source: string,
   map: any,
   filename: string,
+  loaderOptions: Object,
   babelLoaderOptions: Object
 ) {
   const file = new babel.File(
@@ -38,6 +40,7 @@ function transpile(
       presets: [require.resolve('../../babel.js')],
       parserOpts: file.parserOpts,
       babelrc: false,
+      ...loaderOptions,
     }
   );
 }
@@ -85,6 +88,7 @@ export default function linariaLoader(
   inputMap: any,
   meta: any
 ) {
+  const options = loaderUtils.getOptions(this) || {};
   try {
     // If the module has linaria styles, we build it and we're done here.
     if (shouldRunLinaria(source)) {
@@ -92,6 +96,7 @@ export default function linariaLoader(
         source,
         inputMap,
         this.resourcePath,
+        options,
         getBabelLoaderOptions(this.loaders)
       );
       builtLinariaModules.push(this.resourcePath);
@@ -113,6 +118,7 @@ export default function linariaLoader(
           item.source,
           null,
           item.filename,
+          options,
           getBabelLoaderOptions(this.loaders)
         );
       }

--- a/src/tools/webpack-loader.js
+++ b/src/tools/webpack-loader.js
@@ -37,10 +37,9 @@ function transpile(
       filename,
       sourceMaps: true,
       inputSourceMap: map,
-      presets: [require.resolve('../../babel.js')],
+      presets: [[require.resolve('../../babel.js'), loaderOptions]],
       parserOpts: file.parserOpts,
       babelrc: false,
-      ...loaderOptions,
     }
   );
 }

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -50,7 +50,15 @@ module.exports = (env = { NODE_ENV: 'development' }) => ({
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        use: [{ loader: 'babel-loader' }, { loader: 'linaria/loader' }],
+        use: [
+          {
+            loader: 'babel-loader',
+            options: { cacheDirectory: true },
+          },
+          {
+            loader: 'linaria/loader',
+          },
+        ],
       },
     ].concat(
       env.NODE_ENV === 'production'

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -50,7 +50,7 @@ module.exports = (env = { NODE_ENV: 'development' }) => ({
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        use: { loader: 'babel-loader' },
+        use: [{ loader: 'babel-loader' }, { loader: 'linaria/loader' }],
       },
     ].concat(
       env.NODE_ENV === 'production'

--- a/yarn.lock
+++ b/yarn.lock
@@ -975,6 +975,10 @@ benchmark@^2.1.4:
     lodash "^4.17.4"
     platform "^1.3.3"
 
+big.js@^3.1.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
+
 binary-extensions@^1.0.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.10.0.tgz#9aeb9a6c5e88638aad171e167f5900abe24835d0"
@@ -1474,6 +1478,10 @@ electron-to-chromium@^1.3.18:
 emoji-regex@^6.1.0:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.5.1.tgz#9baea929b155565c11ea41c6626eaa65cef992c2"
+
+emojis-list@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
 
 encoding@^0.1.11:
   version "0.1.12"
@@ -2879,7 +2887,7 @@ json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
-json5@^0.5.1:
+json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
@@ -2975,6 +2983,14 @@ load-json-file@^2.0.0:
     parse-json "^2.2.0"
     pify "^2.0.0"
     strip-bom "^3.0.0"
+
+loader-utils@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
+  dependencies:
+    big.js "^3.1.3"
+    emojis-list "^2.0.0"
+    json5 "^0.5.0"
 
 locate-path@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes #73, #169 

Documentation is missing, but I'll make it once the code will be done.

So the JS rule looks like this:
```js
{
  test: /\.js$/,
  use: [
    { loader: 'babel-loader', options: { cacheDirectory: true } },
    { loader: 'linaria/loader' }
  ],
},
```

Then while testing on website:
* changing `theme.js` rebuilds CSS so HMR updates styles
* babel cache is not a problem anymore
* deleting `.linaria-cache` doesn't break anything
