### PR TITLE
Use relative filename when getting styles in stylelint preprocessor

### DIFF
--- a/src/tools/stylelint-preprocessor.js
+++ b/src/tools/stylelint-preprocessor.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import path from 'path';
 import * as babel from 'babel-core';
 import { SourceMapConsumer } from 'source-map';
 
@@ -37,7 +38,7 @@ export default function linariaStylelintPreprocessor(/* options */) {
         require.resolve('../sheet.js')
       ).exports.default.rawStyles();
 
-      const relativeFilename = filename.replace(`${process.cwd()}/`, '');
+      const relativeFilename = path.relative(process.cwd(), filename);
 
       if (!Object.keys(rawStyles).length || !rawStyles[relativeFilename]) {
         return '';

--- a/src/tools/stylelint-preprocessor.js
+++ b/src/tools/stylelint-preprocessor.js
@@ -37,11 +37,13 @@ export default function linariaStylelintPreprocessor(/* options */) {
         require.resolve('../sheet.js')
       ).exports.default.rawStyles();
 
-      if (!Object.keys(rawStyles).length || !rawStyles[filename]) {
+      const relativeFilename = filename.replace(`${process.cwd()}/`, '');
+
+      if (!Object.keys(rawStyles).length || !rawStyles[relativeFilename]) {
         return '';
       }
 
-      const css = rawStyles[filename].reduce(
+      const css = rawStyles[relativeFilename].reduce(
         (acc, { template, expressions, classname }) => {
           const styles = toString(
             template,


### PR DESCRIPTION
`filename` is absolute (from stylelint) but `rawStyles` has relative paths.
Example:
`filename`: `<CWD>/src/App.js`
`rawStyles`: `{ 'src/App.js': { /* ... */ } }`