### PR TITLE
fix: only write CSS for file that's being directly processed

### DIFF
--- a/src/babel/preval-extract/prevalStyles.js
+++ b/src/babel/preval-extract/prevalStyles.js
@@ -62,10 +62,31 @@ export default function(
   ]);
 
   clearLocalModulesFromCache();
+
+  const overrides = process.env.LINARIA_BABEL_PRESET_OVERRIDES || '';
+
+  let parsed;
+
+  try {
+    parsed = JSON.parse(overrides || '{}');
+  } catch (e) {
+    parsed = null;
+  }
+
+  // Avoid writing css from the dependencies
+  // We should only write the CSS for the file the user ran through Babel
+  process.env.LINARIA_BABEL_PRESET_OVERRIDES = JSON.stringify({
+    ...parsed,
+    extract: false,
+  });
+
   const { exports: className } = instantiateModule(
     replacement,
     resolve(state.filename)
   );
+
+  // Restore the plugin options
+  process.env.LINARIA_BABEL_PRESET_OVERRIDES = overrides;
 
   const { minifyClassnames } = state.opts;
 


### PR DESCRIPTION
When evaluating imported modules, they are run through the babel preset, as a result, CSS output for those files are also written.
This could overwrite previously generated CSS with a partially evaluated CSS depending on what's used.
This also resulted in multiple hot reloads in webpack since same files are written multiple times.

Fixes #204
