### PR TITLE
feat: apply correct specificity when wrapping a styled component with another

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,28 +189,6 @@ Dynamic styles will be applied using CSS custom properties (aka CSS variables) a
 ## Trade-offs
 
 * No IE11 support when using dynamic styles components since it uses CSS custom properties
-* The cascade is still there.
-
-  For example, the following code can produce a div with `color: red;` or `color: blue;` depending on generated the order of CSS rules:
-
-  ```js
-  // First.js
-  import { styled } from 'linaria/react';
-
-  const First = styled.div`
-    color: blue;
-  `;
-
-  // Second.js
-  import { styled } from 'linaria/react';
-  import { First } from './First';
-
-  const Second = styled(First)`
-    color: red;
-  `;
-  ```
-
-  Libraries like `styled-components` can get around the cascade because they can control the order of the CSS insertion during the runtime. It's not possible when statically extracting the CSS at build time.
 * Dynamic styles are not supported with `css` tag. See [Dynamic Styles](/docs/DYNAMIC_STYLES.md) for alternative approaches.
 * Modules used in the CSS rules cannot have side-effects.
   For example:

--- a/src/__tests__/__snapshots__/babel.test.js.snap
+++ b/src/__tests__/__snapshots__/babel.test.js.snap
@@ -20,7 +20,7 @@ CSS OUTPUT TEXT START
 
 CSS OUTPUT TEXT END
 
-CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":3,\\"column\\":6},\\"name\\":\\"Title_th73eyu\\"}]
+CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":3,\\"column\\":6},\\"name\\":\\".Title_th73eyu\\"}]
 CSS OUTPUT DEPENDENCIES:[]
 */"
 `;
@@ -34,7 +34,7 @@ CSS OUTPUT TEXT START
 
 CSS OUTPUT TEXT END
 
-CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":13},\\"name\\":\\"Title_th73eyu\\"}]
+CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":13},\\"name\\":\\".Title_th73eyu\\"}]
 CSS OUTPUT DEPENDENCIES:[]
 */"
 `;
@@ -50,7 +50,7 @@ CSS OUTPUT TEXT START
 
 CSS OUTPUT TEXT END
 
-CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":2,\\"column\\":2},\\"name\\":\\"title_th73eyu\\"}]
+CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":2,\\"column\\":2},\\"name\\":\\".title_th73eyu\\"}]
 CSS OUTPUT DEPENDENCIES:[]
 */"
 `;
@@ -86,7 +86,7 @@ CSS OUTPUT TEXT START
 
 CSS OUTPUT TEXT END
 
-CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":6},\\"name\\":\\"Title_th73eyu\\"}]
+CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":6},\\"name\\":\\".Title_th73eyu\\"}]
 CSS OUTPUT DEPENDENCIES:[]
 */"
 `;
@@ -108,7 +108,7 @@ CSS OUTPUT TEXT START
 
 CSS OUTPUT TEXT END
 
-CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":6},\\"name\\":\\"Button_bh73eyu\\"}]
+CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":6},\\"name\\":\\".Button_bh73eyu\\"}]
 CSS OUTPUT DEPENDENCIES:[]
 */"
 `;
@@ -142,7 +142,7 @@ CSS OUTPUT TEXT START
 
 CSS OUTPUT TEXT END
 
-CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":18,\\"column\\":6},\\"name\\":\\"Title_th73eyu\\"}]
+CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":18,\\"column\\":6},\\"name\\":\\".Title_th73eyu\\"}]
 CSS OUTPUT DEPENDENCIES:[]
 */"
 `;
@@ -178,7 +178,7 @@ CSS OUTPUT TEXT START
 
 CSS OUTPUT TEXT END
 
-CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":6},\\"name\\":\\"Title_th73eyu\\"},{\\"generated\\":{\\"line\\":2,\\"column\\":0},\\"original\\":{\\"line\\":7,\\"column\\":8},\\"name\\":\\"Title_t462dh3\\"}]
+CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":6},\\"name\\":\\".Title_th73eyu\\"},{\\"generated\\":{\\"line\\":2,\\"column\\":0},\\"original\\":{\\"line\\":7,\\"column\\":8},\\"name\\":\\".Title_t462dh3\\"}]
 CSS OUTPUT DEPENDENCIES:[]
 */"
 `;
@@ -201,7 +201,7 @@ CSS OUTPUT TEXT START
 
 CSS OUTPUT TEXT END
 
-CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":6},\\"name\\":\\"Title_th73eyu\\"}]
+CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":6},\\"name\\":\\".Title_th73eyu\\"}]
 CSS OUTPUT DEPENDENCIES:[]
 */"
 `;
@@ -236,7 +236,7 @@ CSS OUTPUT TEXT START
 
 CSS OUTPUT TEXT END
 
-CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":6},\\"name\\":\\"title_th73eyu\\"}]
+CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":6},\\"name\\":\\".title_th73eyu\\"}]
 CSS OUTPUT DEPENDENCIES:[]
 */"
 `;
@@ -255,7 +255,7 @@ CSS OUTPUT TEXT START
 
 CSS OUTPUT TEXT END
 
-CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":6},\\"name\\":\\"Title_th73eyu\\"}]
+CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":6},\\"name\\":\\".Title_th73eyu\\"}]
 CSS OUTPUT DEPENDENCIES:[]
 */"
 `;
@@ -274,7 +274,7 @@ CSS OUTPUT TEXT START
 
 CSS OUTPUT TEXT END
 
-CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":6},\\"name\\":\\"Title_th73eyu\\"}]
+CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":6},\\"name\\":\\".Title_th73eyu\\"}]
 CSS OUTPUT DEPENDENCIES:[]
 */"
 `;
@@ -293,7 +293,7 @@ CSS OUTPUT TEXT START
 
 CSS OUTPUT TEXT END
 
-CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":6},\\"name\\":\\"Title_th73eyu\\"}]
+CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":6},\\"name\\":\\".Title_th73eyu\\"}]
 CSS OUTPUT DEPENDENCIES:[]
 */"
 `;
@@ -315,7 +315,7 @@ CSS OUTPUT TEXT START
 
 CSS OUTPUT TEXT END
 
-CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":6},\\"name\\":\\"Box_bh73eyu\\"}]
+CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":6},\\"name\\":\\".Box_bh73eyu\\"}]
 CSS OUTPUT DEPENDENCIES:[]
 */"
 `;
@@ -337,7 +337,7 @@ CSS OUTPUT TEXT START
 
 CSS OUTPUT TEXT END
 
-CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":6},\\"name\\":\\"Box_bh73eyu\\"}]
+CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":6},\\"name\\":\\".Box_bh73eyu\\"}]
 CSS OUTPUT DEPENDENCIES:[]
 */"
 `;

--- a/src/__tests__/__snapshots__/preval.test.js.snap
+++ b/src/__tests__/__snapshots__/preval.test.js.snap
@@ -25,7 +25,7 @@ CSS OUTPUT TEXT START
 
 CSS OUTPUT TEXT END
 
-CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":3,\\"column\\":6},\\"name\\":\\"Title_abcdefg\\"},{\\"generated\\":{\\"line\\":2,\\"column\\":0},\\"original\\":{\\"line\\":7,\\"column\\":6},\\"name\\":\\"Paragraph_abcdefg\\"}]
+CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":3,\\"column\\":6},\\"name\\":\\".Title_abcdefg\\"},{\\"generated\\":{\\"line\\":2,\\"column\\":0},\\"original\\":{\\"line\\":7,\\"column\\":6},\\"name\\":\\".Paragraph_abcdefg\\"}]
 CSS OUTPUT DEPENDENCIES:[\\"../react\\"]
 */"
 `;
@@ -45,7 +45,7 @@ CSS OUTPUT TEXT START
 
 CSS OUTPUT TEXT END
 
-CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":3,\\"column\\":6},\\"name\\":\\"Title_abcdefg\\"}]
+CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":3,\\"column\\":6},\\"name\\":\\".Title_abcdefg\\"}]
 CSS OUTPUT DEPENDENCIES:[\\"../slugify\\"]
 */"
 `;
@@ -70,7 +70,7 @@ CSS OUTPUT TEXT START
 
 CSS OUTPUT TEXT END
 
-CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":6,\\"column\\":6},\\"name\\":\\"Title_abcdefg\\"}]
+CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":6,\\"column\\":6},\\"name\\":\\".Title_abcdefg\\"}]
 CSS OUTPUT DEPENDENCIES:[\\"../slugify\\"]
 */"
 `;
@@ -94,7 +94,7 @@ CSS OUTPUT TEXT START
 
 CSS OUTPUT TEXT END
 
-CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":5,\\"column\\":6},\\"name\\":\\"Title_abcdefg\\"}]
+CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":5,\\"column\\":6},\\"name\\":\\".Title_abcdefg\\"}]
 CSS OUTPUT DEPENDENCIES:[]
 */"
 `;
@@ -117,7 +117,7 @@ CSS OUTPUT TEXT START
 
 CSS OUTPUT TEXT END
 
-CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":4,\\"column\\":6},\\"name\\":\\"Title_abcdefg\\"}]
+CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":4,\\"column\\":6},\\"name\\":\\".Title_abcdefg\\"}]
 CSS OUTPUT DEPENDENCIES:[]
 */"
 `;
@@ -142,7 +142,7 @@ CSS OUTPUT TEXT START
 
 CSS OUTPUT TEXT END
 
-CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":6,\\"column\\":6},\\"name\\":\\"Title_abcdefg\\"}]
+CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":6,\\"column\\":6},\\"name\\":\\".Title_abcdefg\\"}]
 CSS OUTPUT DEPENDENCIES:[\\"../slugify\\"]
 */"
 `;
@@ -166,7 +166,7 @@ CSS OUTPUT TEXT START
 
 CSS OUTPUT TEXT END
 
-CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":3,\\"column\\":6},\\"name\\":\\"Title_abcdefg\\"}]
+CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":3,\\"column\\":6},\\"name\\":\\".Title_abcdefg\\"}]
 CSS OUTPUT DEPENDENCIES:[]
 */"
 `;
@@ -188,7 +188,7 @@ CSS OUTPUT TEXT START
 
 CSS OUTPUT TEXT END
 
-CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":6},\\"name\\":\\"Title_abcdefg\\"}]
+CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":6},\\"name\\":\\".Title_abcdefg\\"}]
 CSS OUTPUT DEPENDENCIES:[]
 */"
 `;
@@ -212,7 +212,7 @@ CSS OUTPUT TEXT START
 
 CSS OUTPUT TEXT END
 
-CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":6},\\"name\\":\\"Title_abcdefg\\"}]
+CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":1,\\"column\\":6},\\"name\\":\\".Title_abcdefg\\"}]
 CSS OUTPUT DEPENDENCIES:[]
 */"
 `;
@@ -239,7 +239,7 @@ CSS OUTPUT TEXT START
 
 CSS OUTPUT TEXT END
 
-CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":9,\\"column\\":6},\\"name\\":\\"Title_abcdefg\\"}]
+CSS OUTPUT MAPPINGS:[{\\"generated\\":{\\"line\\":1,\\"column\\":0},\\"original\\":{\\"line\\":9,\\"column\\":6},\\"name\\":\\".Title_abcdefg\\"}]
 CSS OUTPUT DEPENDENCIES:[]
 */"
 `;

--- a/src/react/styled.js
+++ b/src/react/styled.js
@@ -37,6 +37,7 @@ function styled(tag) {
 
     Result.displayName = options.name;
     Result.className = options.class;
+    Result.extends = tag;
 
     return Result;
   };

--- a/src/stylelint/preprocessor.js
+++ b/src/stylelint/preprocessor.js
@@ -39,8 +39,8 @@ function preprocessor() {
       // Construct a CSS-ish file from the unprocessed style rules
       const { rules, replacements } = metadata.linaria;
 
-      Object.keys(rules).forEach(className => {
-        const rule = rules[className];
+      Object.keys(rules).forEach(selector => {
+        const rule = rules[selector];
 
         // Append new lines until we get to the start line number
         let line = cssText.split('\n').length;


### PR DESCRIPTION
Previously, if you had a `Title = styled.h1` and `Heading = styled(Title)`, and then have the same CSS properties specified in both, the styles which are later in the stylesheet would take precedence. This is one of the limitations we have (had) compared to styled-components. But if we can evaluate expressions at build time, we can get the parent className and generate a more specific selector, ensuring that the correct styles are applied. This PR aims to implement that.