### PR TITLE
Customizable Babel Configuration for Modules

### DIFF
--- a/src/__tests__/module.test.js
+++ b/src/__tests__/module.test.js
@@ -172,3 +172,10 @@ it('has __dirname available', () => {
 
   expect(mod.exports).toBe(path.dirname(mod.filename));
 });
+
+it('can alterate the babel configuration', () => {
+  const mod = new Module(path.resolve(__dirname, '../__fixtures__/test.js'));
+  const initialBabelConfig = mod.$$babelConfig;
+  mod.$$babelConfig = {};
+  expect(mod.$$babelConfig).not.toEqual(initialBabelConfig);
+});

--- a/src/babel/evaluate.js
+++ b/src/babel/evaluate.js
@@ -57,7 +57,8 @@ const resolve = (path, t, requirements) => {
 module.exports = function evaluate(
   path /* : any */,
   t /* : any */,
-  filename /* : string */
+  filename /* : string */,
+  module /* : ?Module */ = null
 ) {
   const requirements = [];
 
@@ -144,7 +145,7 @@ module.exports = function evaluate(
     t.blockStatement([expression])
   );
 
-  const m = new Module(filename);
+  const m = module || new Module(filename);
 
   m.evaluate(
     dedent`


### PR DESCRIPTION
Closes #242

This change is backwards compatible and should allow to reuse the helper from `src/babel/evaluate.js` by making the the babel configuration used in `Module` customizable.
