### PR TITLE
fix(webpack): Calculate a hash based on file contents to invalidate WDS

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const os = require('os');
 const fs = require('fs');
 const path = require('path');
@@ -18,9 +19,10 @@ module.exports = function loader(
     let { cssText } = result;
 
     const slug = slugify(this.resourcePath);
+    const hash = calculateMd5(cssText);
     const filename = `${path
       .basename(this.resourcePath)
-      .replace(/\.js$/, '')}_${slug}.css`;
+      .replace(/\.js$/, '')}_${slug}.${hash}.css`;
 
     if (sourceMap) {
       cssText += `/*# sourceMappingURL=data:application/json;base64,${Buffer.from(
@@ -58,3 +60,10 @@ module.exports = function loader(
 
   this.callback(null, result.code, result.sourceMap);
 };
+
+function calculateMd5(input) {
+  return crypto
+    .createHash('md5')
+    .update(input)
+    .digest('hex');
+}


### PR DESCRIPTION
**Summary**

Without this changes to styles won't force WDS to refresh.

**Test plan**

What's the preferred way to test this? I don't think this part is covered by tests yet and likely you should find a way to write the loader without relying on the FS. I know you use to deal with mini-css-extract-plugin but maybe there's a better approach.