### PR TITLE
feat: support specifying type of props for styled with TypeScript

### DIFF
--- a/src/core/css.js
+++ b/src/core/css.js
@@ -9,5 +9,9 @@ function css() {
 module.exports = css;
 
 /* ::
-declare module.exports: (strings: string[], ...exprs: Array<string | number | {}>) => string;
+type CSSProperties = {
+  [key: string]: string | number | CSSProperties;
+};
+
+declare module.exports: (strings: string[], ...exprs: Array<string | number | CSSProperties>) => string;
 */

--- a/src/react/styled.js
+++ b/src/react/styled.js
@@ -78,9 +78,13 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 /* ::
+type CSSProperties = {
+  [key: string]: string | number | CSSProperties;
+};
+
 type StyledComponent<T> = React.ComponentType<T & { as?: React$ElementType }>;
 
-type StyledTag<T> = (strings: string[], ...exprs: Array<string | number | {} | (T => string | number)>) => StyledComponent<T>;
+type StyledTag<T> = (strings: string[], ...exprs: Array<string | number | CSSProperties | (T => string | number)>) => StyledComponent<T>;
 
 type StyledJSXIntrinsics = $ObjMap<$JSXIntrinsics, <T>({ props: T }) => StyledTag<T>>;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 2.8
+// TypeScript Version: 2.9
 
 declare module 'linaria' {
   function css(
@@ -18,15 +18,15 @@ declare module 'linaria/react' {
     T & { as?: React.ReactType }
   >;
 
-  type StyledTag<T> = (
+  type StyledTag<T> = <Props = T>(
     strings: TemplateStringsArray,
-    ...exprs: Array<string | number | object | ((props: T) => string | number)>
-  ) => StyledComponent<T>;
+    ...exprs: Array<
+      string | number | object | ((props: Props) => string | number)
+    >
+  ) => StyledComponent<Props>;
 
   type StyledJSXIntrinsics = {
-    [P in keyof JSX.IntrinsicElements]: StyledTag<
-      JSX.IntrinsicElements[P] & { [key: string]: any }
-    >
+    [P in keyof JSX.IntrinsicElements]: StyledTag<JSX.IntrinsicElements[P]>
   };
 
   const styled: StyledJSXIntrinsics & {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,9 +1,13 @@
 // TypeScript Version: 2.9
 
 declare module 'linaria' {
+  type CSSProperties = {
+    [key: string]: string | number | CSSProperties;
+  };
+
   function css(
     strings: TemplateStringsArray,
-    ...exprs: Array<string | number | object>
+    ...exprs: Array<string | number | CSSProperties>
   ): string;
 
   function cx(
@@ -14,6 +18,10 @@ declare module 'linaria' {
 declare module 'linaria/react' {
   import * as React from 'react';
 
+  type CSSProperties = {
+    [key: string]: string | number | CSSProperties;
+  };
+
   type StyledComponent<T> = React.StatelessComponent<
     T & { as?: React.ReactType }
   >;
@@ -21,18 +29,18 @@ declare module 'linaria/react' {
   type StyledTag<T> = <Props = T>(
     strings: TemplateStringsArray,
     ...exprs: Array<
-      string | number | object | ((props: Props) => string | number)
+      string | number | CSSProperties | ((props: Props) => string | number)
     >
   ) => StyledComponent<Props>;
 
   type StyledJSXIntrinsics = {
-    [P in keyof JSX.IntrinsicElements]: StyledTag<JSX.IntrinsicElements[P]>
+    readonly [P in keyof JSX.IntrinsicElements]: StyledTag<JSX.IntrinsicElements[P]>
   };
 
   const styled: StyledJSXIntrinsics & {
     <T>(component: React.ReactType<T>): StyledTag<T>;
 
-    [key: string]: StyledTag<{
+    readonly [key: string]: StyledTag<{
       children?: React.ReactNode;
       [key: string]: any;
     }>;

--- a/types/tests/react.tsx
+++ b/types/tests/react.tsx
@@ -15,12 +15,15 @@ const absoluteFill = {
 
 const Button = styled.button`
   color: ${white};
-  background-color: ${props => props.background};
   border-width: ${border}px;
 
   &.abs {
     ${absoluteFill};
   }
+`;
+
+const ColoredButton = styled.button<{ background: string; children: string }>`
+  background-color: ${props => props.background};
 `;
 
 const CustomButton = styled(Button)`
@@ -41,6 +44,12 @@ const CustomTitle = styled(Title)`
 
 // $Expect Element
 <Button as="a">Hello world</Button>;
+
+// $Expect Element
+<ColoredButton background="blue">Hello world</ColoredButton>;
+
+// $ExpectError
+<ColoredButton background={42}>Hello world</ColoredButton>;
 
 // $ExpectError
 <Button onClick={42}>Hello world</Button>;

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -6,6 +6,7 @@
     "noImplicitThis": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
+    "strict": true,
     "noEmit": true,
     "forceConsistentCasingInFileNames": true,
     "jsx": "react"

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "dtslint/dtslint.json",
+  "rules": {
+    "interface-over-type-literal": false
+  }
+}


### PR DESCRIPTION
Currently we infer the props for the components based on the type of the base component, e.g. - for `styled.button`, it'll be the props of `button`, for `styled(Title)`, it'll be the props of `Title` etc. However, it's common to pass additional props to a styled component specifically for styling. For example:

```js
const Button = styled.button`
  background: $(props => props.primary ? 'blue' : 'white'};
`;
```

Here the user needs to pass a `primary` prop even if `button` doesn't accept it. Currently we workaround this by allowing the user to pass any extra props. However, the extra props will be typed as `any`, which is not exactly type checking.

TypeScript has this cool feature of being able to have optional type parameters, which we can use here to allow the user to specify the types manually while using the inferred types by default when a prop is not specified. So it'll basically look like this:

```js
const Button = styled.button<{ primary: boolean; children: string }>`
  background: $(props => props.primary ? 'blue' : 'white'};
`;
```