### PR TITLE
fix: add "rollup.js" to the list of distributed files

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lib/",
     "types/",
     "react.js",
+    "rollup.js",
     "server.js",
     "babel.js",
     "loader.js",


### PR DESCRIPTION
**Summary**

Present Linaria's documentation says that an associated Rollup [plugin](https://github.com/callstack/linaria/blob/master/docs/BUNDLERS_INTEGRATION.md#rollup) can be accessed by the following path: `linaria/rollup`.

Even though this file exists in the repository, it's missing from the npm package, which clearly looks like an oversight. So, this PR adds `rollup.js` to the list of distributed files.