### PR TITLE
fix: add sourcemaps to the output of Rollup plugin

### DIFF
--- a/src/rollup.js
+++ b/src/rollup.js
@@ -54,7 +54,7 @@ module.exports = function linaria({
       result.code += `\nimport ${JSON.stringify(filename)};\n`;
 
       /* eslint-disable-next-line consistent-return */
-      return result.code;
+      return { code: result.code, map: result.sourceMap };
     },
   };
 };


### PR DESCRIPTION
**Summary**

Linaria's plugin for Rollup returns only a modified code of a module, without providing its sourcemaps. This, in turn, leads to a broken source map file and the following warning can be seen when running Rollup with the `sourceMap` option enabled:
```
(!) Broken sourcemap
https://github.com/rollup/rollup/wiki/Troubleshooting#sourcemap-is-likely-to-be-incorrect
Plugins that transform code (such as 'linaria') should generate accompanying sourcemaps
```

This PR ads sourcemaps to the former plugins output, as described in the Rollup's [documentation](https://rollupjs.org/guide/en#transformers).