### PR TITLE
Fix/transform regex

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -49,13 +49,9 @@ module.exports = function transform(
   inputSourceMap /* :?Object */,
   outputFilename /* : ?string */
 ) /* : Result */ {
-  // Check if the file contains `css` or `styled` tag first
+  // Check if the file imports linaria
   // Otherwise we should skip transforming
-  if (
-    !/\b(styled[\s\n]*(\([\s\S]+\)|\.[\s\n]*[a-z0-9]+)|css)[\s\n]*`/.test(
-      content
-    )
-  ) {
+  if (!/\b(styled|css)/.test(content)) {
     return {
       code: content,
       sourceMap: inputSourceMap,

--- a/src/transform.js
+++ b/src/transform.js
@@ -49,7 +49,7 @@ module.exports = function transform(
   inputSourceMap /* :?Object */,
   outputFilename /* : ?string */
 ) /* : Result */ {
-  // Check if the file imports linaria
+  // Check if the file contains `css` or `styled` words first
   // Otherwise we should skip transforming
   if (!/\b(styled|css)/.test(content)) {
     return {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This PR fixes issue [#279](https://github.com/callstack/linaria/issues/279) where files using generic parameters in `styled` call wasn't included for processing in `transform.js`. They were skipped, because RegEx there didn't expect TypeScript's generic function syntax.

New regex just searches for words `styled` or `css`.
It is more false-positive prone, but more safe, as it should also correctly detect usages such as:
```typescript
import { styled } from "linaria/react";

export type TitleProps = {
    color: string;
}

export const Title = styled<TitleProps>.h1`
    color: ${props => props.color};
`;
```
or
```javascript
import { styled as s } from "linaria/react";

export const Title = s.h1`
    color: tomato;
`;
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Ran
```
yarn run lint && yarn run flow && yarn run test
```
no new problems introduced by the changes.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
