### PR TITLE
fix(url-rewrite): replace multiple url() in declarations

### DIFF
--- a/src/__tests__/__snapshots__/transform.test.js.snap
+++ b/src/__tests__/__snapshots__/transform.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`doesn't rewrite an absolute path in url() declarations 1`] = `
+".tpyglzj{background-image:url(/assets/test.jpg);}
+"
+`;
+
+exports[`rewrites a relative path in url() declarations 1`] = `
+".tpyglzj{background-image:url(../linaria/assets/test.jpg);}
+"
+`;
+
+exports[`rewrites multiple relative paths in url() declarations 1`] = `
+"@font-face{font-family:Test;src:url(../linaria/assets/font.woff2) format(\\"woff2\\"),url(../linaria/assets/font.woff) format(\\"woff\\");}
+"
+`;

--- a/src/__tests__/transform.test.js
+++ b/src/__tests__/transform.test.js
@@ -1,0 +1,60 @@
+import dedent from 'dedent';
+
+const transform = require('../transform');
+
+it('rewrites a relative path in url() declarations', async () => {
+  const { cssText } = await transform(
+    dedent`
+    import { css } from 'linaria';
+
+    const title = css\`
+      background-image: url(./assets/test.jpg);
+    \`;
+    `,
+    {
+      filename: './test.js',
+      outputFilename: '../.linaria-cache/test.css',
+    }
+  );
+
+  expect(cssText).toMatchSnapshot();
+});
+
+it('rewrites multiple relative paths in url() declarations', async () => {
+  const { cssText } = await transform(
+    dedent`
+    import { css } from 'linaria';
+
+    const title = css\`
+      @font-face {
+        font-family: Test;
+        src: url(./assets/font.woff2) format("woff2"), url(./assets/font.woff) format("woff");
+      }
+    \`;
+    `,
+    {
+      filename: './test.js',
+      outputFilename: '../.linaria-cache/test.css',
+    }
+  );
+
+  expect(cssText).toMatchSnapshot();
+});
+
+it("doesn't rewrite an absolute path in url() declarations", async () => {
+  const { cssText } = await transform(
+    dedent`
+    import { css } from 'linaria';
+
+    const title = css\`
+      background-image: url(/assets/test.jpg);
+    \`;
+    `,
+    {
+      filename: './test.js',
+      outputFilename: '../.linaria-cache/test.css',
+    }
+  );
+
+  expect(cssText).toMatchSnapshot();
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
It fixes file rewrites for css declarations with multiple src valus
```
css`
@font-face {
  font-family: Roboto;
  src: url(./file.woff2) format('woff2'), url(./file.woff) format('woff');
`
```
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
I've added tests to make sure it works, if you run the tests on old code you'll see that it won't do it correctly.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
