### PR TITLE
fix: use webpack's resolver to resolve files. fixes #284

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@babel/register": "^7.0.0",
     "cosmiconfig": "^5.0.7",
     "dedent": "^0.7.0",
+    "enhanced-resolve": "^4.1.0",
     "glob": "^7.1.3",
     "loader-utils": "^1.1.0",
     "mkdirp": "^0.5.1",

--- a/src/__tests__/module.test.js
+++ b/src/__tests__/module.test.js
@@ -191,3 +191,23 @@ it('has __dirname available', () => {
 
   expect(mod.exports).toBe(path.dirname(mod.filename));
 });
+
+it('changes resolve behaviour on overriding _resolveFilename', () => {
+  const originalResolveFilename = Module._resolveFilename;
+
+  Module._resolveFilename = id => (id === 'foo' ? 'bar' : id);
+
+  const mod = new Module(path.resolve(__dirname, '../__fixtures__/test.js'));
+
+  mod.evaluate(dedent`
+  module.exports = [
+    require.resolve('foo'),
+    require.resolve('test'),
+  ];
+  `);
+
+  // Restore old behavior
+  Module._resolveFilename = originalResolveFilename;
+
+  expect(mod.exports).toEqual(['bar', 'test']);
+});

--- a/src/babel/module.js
+++ b/src/babel/module.js
@@ -25,11 +25,16 @@ const NOOP = () => {};
 class Module {
   static invalidate: () => void;
 
+  static _resolveFilename: (
+    id: string,
+    options: { id: string, filename: string, paths: string[] }
+  ) => string;
+
   id: string;
 
   filename: string;
 
-  paths: string;
+  paths: string[];
 
   require: (id: string) => any;
 
@@ -85,8 +90,7 @@ class Module {
         added.push(ext);
       });
 
-      // Resolve the module using node's resolve algorithm
-      return NativeModule._resolveFilename(id, this);
+      return Module._resolveFilename(id, this);
     } finally {
       // Cleanup the extensions we added to restore previous behaviour
       added.forEach(ext => delete extensions[ext]);
@@ -166,5 +170,11 @@ class Module {
 Module.invalidate = () => {
   cache = {};
 };
+
+// Alias to resolve the module using node's resolve algorithm
+// This static property can be overriden by the webpack loader
+// This allows us to use webpack's module resolution algorithm
+Module._resolveFilename = (id, options) =>
+  NativeModule._resolveFilename(id, options);
 
 module.exports = Module;

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -4970,7 +4970,7 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
-path-parse@^1.0.5:
+path-parse@^1.0.5, path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
@@ -5734,12 +5734,19 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.3.2, resolve@^1.4.0, resolve@^1.6.0:
+resolve@^1.3.2, resolve@^1.6.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   integrity sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==
   dependencies:
     path-parse "^1.0.5"
+
+resolve@^1.4.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.9.0.tgz#a14c6fdfa8f92a7df1d996cb7105fa744658ea06"
+  integrity sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==
+  dependencies:
+    path-parse "^1.0.6"
 
 restore-cursor@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3016,6 +3016,22 @@ emojis-list@^2.0.0:
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
   integrity sha1-TapNnbAPmBmIDHn6RXrlsJof04k=
 
+enhanced-resolve@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz#41c7e0bfdfe74ac1ffe1e57ad6a5c6c9f3742a7f"
+  integrity sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==
+  dependencies:
+    graceful-fs "^4.1.2"
+    memory-fs "^0.4.0"
+    tapable "^1.0.0"
+
+errno@^0.1.3:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
+  integrity sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==
+  dependencies:
+    prr "~1.0.1"
+
 error-ex@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
@@ -5673,6 +5689,14 @@ mem@^4.0.0:
     mimic-fn "^1.0.0"
     p-is-promise "^1.1.0"
 
+memory-fs@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
+  integrity sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=
+  dependencies:
+    errno "^0.1.3"
+    readable-stream "^2.0.1"
+
 meow@^3.3.0, meow@^3.6.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
@@ -6618,6 +6642,11 @@ proxy-from-env@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
   integrity sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=
+
+prr@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
+  integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -7709,6 +7738,11 @@ table@^5.0.2:
     lodash "^4.17.10"
     slice-ansi "1.0.0"
     string-width "^2.1.1"
+
+tapable@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.1.tgz#4d297923c5a72a42360de2ab52dadfaaec00018e"
+  integrity sha512-9I2ydhj8Z9veORCw5PRm4u9uebCn0mcCa6scWoNcbZ6dAtoo2618u9UUzxgmsCOreJpqDDuv61LvwofW7hLcBA==
 
 tar-pack@^3.4.0:
   version "3.4.0"


### PR DESCRIPTION
I'm using `this._compilation.options` (private and deprecated API) to get access to webpack's resolve options such as `resolve.alias`, `resolve.extensions` etc.

There seems to be no other way to access webpack's resolver. There is `this.resolve`, but it's asynchronous. There was `this.resolveSync`, but it seems to be removed. `this._compilation` is used by many loaders/plugins such as `mini-cssextract-plugin`, so hope we're safe for a while.

Other options are:
1) read the webpack.config.js manually, but it won't work for programmatic usage. `eslint-import-resolver-webpack` does this.
2) require the user to pass the resolve options in the loader options as well. it'll duplicate webpack's config, but won't break.