### PR TITLE
feat: allow to pass babelOptions, fixes #274

### DIFF
--- a/src/__tests__/transform.test.js
+++ b/src/__tests__/transform.test.js
@@ -58,3 +58,49 @@ it("doesn't rewrite an absolute path in url() declarations", async () => {
 
   expect(cssText).toMatchSnapshot();
 });
+
+it('uses babelOptions', async () => {
+  expect(() =>
+    transform(
+      dedent`
+      import { css } from 'linaria';
+      export const error = <jsx />;
+      `,
+      {
+        filename: './test.js',
+        outputFilename: '../.linaria-cache/test.css',
+        babelOptions: {
+          babelrc: false,
+          presets: [
+            ['@babel/preset-env', { loose: true }],
+            // react preset is missing
+          ],
+        },
+      }
+    )
+  ).toThrowError('Unexpected token');
+
+  expect(() =>
+    transform(
+      dedent`
+      import { css } from 'linaria';
+      export const error = <jsx />;
+      export const title = css\`
+      background-image: url(/assets/test.jpg);
+    \`;
+      `,
+      {
+        filename: './test.js',
+        outputFilename: '../.linaria-cache/test.css',
+        babelOptions: {
+          babelrc: false,
+          presets: [
+            ['@babel/preset-env', { loose: true }],
+            '@babel/preset-react',
+            '@babel/preset-flow',
+          ],
+        },
+      }
+    )
+  ).not.toThrowError('Unexpected token');
+});

--- a/src/babel/extract.js
+++ b/src/babel/extract.js
@@ -192,6 +192,7 @@ export type Options = {
   displayName: boolean,
   evaluate: boolean,
   ignore: RegExp,
+  babelOptions: Object,
 };
 
 module.exports = function extract(babel: any, options: Options) {

--- a/src/loader.js
+++ b/src/loader.js
@@ -14,6 +14,7 @@ module.exports = function loader(content: string, inputSourceMap: ?Object) {
     sourceMap,
     cacheDirectory = '.linaria-cache',
     preprocessor,
+    babelOptions,
     ...rest
   } = loaderUtils.getOptions(this) || {};
 
@@ -59,6 +60,7 @@ module.exports = function loader(content: string, inputSourceMap: ?Object) {
       inputSourceMap: inputSourceMap != null ? inputSourceMap : undefined,
       outputFilename,
       pluginOptions: rest,
+      babelOptions,
       preprocessor,
     });
   } finally {

--- a/src/transform.js
+++ b/src/transform.js
@@ -37,6 +37,7 @@ type Options = {
   outputFilename?: string,
   inputSourceMap?: Object,
   pluginOptions?: $Shape<PluginOptions>,
+  babelOptions?: Object,
 };
 
 export type Preprocessor =
@@ -62,6 +63,7 @@ module.exports = function transform(code: string, options: Options): Result {
   const ast = babel.parseSync(code, {
     filename: options.filename,
     caller: { name: 'linaria' },
+    ...options.babelOptions,
   });
 
   const { metadata, code: transformedCode, map } = babel.transformFromAstSync(

--- a/src/transform.js
+++ b/src/transform.js
@@ -71,7 +71,12 @@ module.exports = function transform(code: string, options: Options): Result {
     code,
     {
       filename: options.filename,
-      presets: [[require.resolve('./babel'), options.pluginOptions]],
+      presets: [
+        [
+          require.resolve('./babel'),
+          { ...options.pluginOptions, babelOptions: options.babelOptions },
+        ],
+      ],
       babelrc: false,
       configFile: false,
       sourceMaps: true,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This PR adds an ability to pass `babelOptions` to linaria. This is useful in case you have centralized configuration management and don't want to have a `.babelrc` file. Please see the full discussion in #274

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

