### PR TITLE
Bug: add extension to support typescript-files

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -34,9 +34,9 @@ module.exports = function loader(content: string, inputSourceMap: ?Object) {
     // Another option is to read the webpack.config.js, but it won't work for programmatic usage
     // This API is used by many loaders/plugins, so hope we're safe for a while
     this._compilation.options.resolve
-      ? { 
+      ? {
           alias: this._compilation.options.resolve.alias,
-          extensions: ['.js', '.json', '.node', '.ts', '.tsx']
+          extensions: ['.js', '.json', '.node', '.ts', '.tsx'],
         }
       : undefined
   );

--- a/src/loader.js
+++ b/src/loader.js
@@ -36,7 +36,7 @@ module.exports = function loader(content: string, inputSourceMap: ?Object) {
     this._compilation.options.resolve
       ? {
           alias: this._compilation.options.resolve.alias,
-          extensions: ['.js', '.json', '.node', '.ts', '.tsx'],
+          extensions: ['.js', '.ts', '.tsx', '.json'],
         }
       : undefined
   );

--- a/src/loader.js
+++ b/src/loader.js
@@ -34,7 +34,10 @@ module.exports = function loader(content: string, inputSourceMap: ?Object) {
     // Another option is to read the webpack.config.js, but it won't work for programmatic usage
     // This API is used by many loaders/plugins, so hope we're safe for a while
     this._compilation.options.resolve
-      ? { alias: this._compilation.options.resolve.alias }
+      ? { 
+          alias: this._compilation.options.resolve.alias,
+          extensions: ['.js', '.json', '.node', '.ts', '.tsx']
+        }
       : undefined
   );
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Files with extension for Typescript like `.ts` or `.tsx` not able to resolve.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Error thrown wenn a file with typescript-extension was linked ```An error occurred when evaluating the expression: Can't resolve '../../theme' ```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->