### PR TITLE
Add semicolon to avoid possible crashes

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -105,7 +105,7 @@ module.exports = function loader(content: string, inputSourceMap: ?Object) {
 
     this.callback(
       null,
-      `${result.code}\n\nrequire("${normalize(outputFilename)}")`,
+      `${result.code}\n\nrequire("${normalize(outputFilename)}");`,
       result.sourceMap
     );
     return;


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Adding a semicolon makes code more robust when integrated (concatenated)
with other files

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
I tried integrating with [docz](https://github.com/pedronauck/docz) and after I added `linaria/loader` to docz bundler configuration, I got an error like this:

```
Failed to compile.

./src/ui/components/StatementList/NewItemInput/NewItemInput.tsx
SyntaxError: /sample-project/src/ui/components/StatementList/NewItemInput/NewItemInput.tsx: Unexpected token, expected ";" (20:150)

  18 | ;
  19 |
> 20 | require("/sample-project/.linaria-cache/src/ui/components/StatementList/NewItemInput/NewItemInput.linaria.css")try {
     |                                                                                                                ^
  21 |     // @ts-ignore
  22 |     NewItemInput.displayName = "NewItemInput";
  23 |     // @ts-ignore
```

As I understand, the `tsx` file that was modified by linaria got concatenated with some other file which began with a `try` statement. Therefore a syntax error was produced.

I believe that adding a semicolon after the import statement is a safe way to avoid such problems.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
