### PR TITLE
fix: filter out duplicate plugins and prestes when merging babel options

### DIFF
--- a/src/__tests__/transform.test.js
+++ b/src/__tests__/transform.test.js
@@ -1,3 +1,6 @@
+/* @flow */
+/* eslint-disable no-template-curly-in-string */
+
 import dedent from 'dedent';
 
 const transform = require('../transform');
@@ -60,6 +63,8 @@ it("doesn't rewrite an absolute path in url() declarations", async () => {
 });
 
 it('respects passed babel options', async () => {
+  expect.assertions(2);
+
   expect(() =>
     transform(
       dedent`
@@ -107,4 +112,38 @@ it('respects passed babel options', async () => {
       }
     )
   ).not.toThrowError('Unexpected token');
+});
+
+it("doesn't throw due to duplicate preset", async () => {
+  expect.assertions(1);
+
+  expect(() =>
+    transform(
+      dedent`
+      import { styled } from 'linaria/react';
+
+      const Title = styled.h1\` color: blue; \`;
+
+      const Article = styled.article\`
+        ${'${Title}'} {
+          font-size: 16px;
+        }
+      \`;
+      `,
+      {
+        filename: './test.js',
+        outputFilename: '../.linaria-cache/test.css',
+        pluginOptions: {
+          babelOptions: {
+            babelrc: false,
+            configFile: false,
+            presets: [require.resolve('../babel')],
+            plugins: [
+              require.resolve('@babel/plugin-transform-modules-commonjs'),
+            ],
+          },
+        },
+      }
+    )
+  ).not.toThrowError('Duplicate plugin/preset detected');
 });

--- a/src/babel/evaluate.js
+++ b/src/babel/evaluate.js
@@ -158,31 +158,77 @@ module.exports = function evaluate(
             return { code: text };
           }
 
-          const babelOptions =
-            options && options.babelOptions ? options.babelOptions : {};
+          const plugins = [
+            // Include these plugins to avoid extra config when using { module: false } for webpack
+            '@babel/plugin-transform-modules-commonjs',
+            '@babel/plugin-proposal-export-namespace-from',
+          ];
 
-          return babel.transformSync(text, {
-            // These shouldn't be able to override the options we pass
-            // Linaria's plugins rely on these (such as filename to generate consistent hash)
-            ...babelOptions,
+          const defaults = {
             caller: { name: 'linaria', evaluate: true },
             filename: this.filename,
-            presets: [
-              // Preset order is last to first, so add the extra presets to start
-              // This makes sure that our preset is always run first
-              ...(babelOptions.presets || []),
-              [require.resolve('./index'), options],
-            ],
+            presets: [[require.resolve('./index'), options]],
             plugins: [
-              // Include this plugin to avoid extra config when using { module: false } for webpack
-              require.resolve('@babel/plugin-transform-modules-commonjs'),
-              require.resolve('@babel/plugin-proposal-export-namespace-from'),
+              ...plugins.map(name => require.resolve(name)),
               // We don't support dynamic imports when evaluating, but don't wanna syntax error
               // This will replace dynamic imports with an object that does nothing
               require.resolve('./dynamic-import-noop'),
+            ],
+          };
+
+          const babelOptions =
+            // Shallow copy the babel options because we mutate it later
+            options && options.babelOptions ? { ...options.babelOptions } : {};
+
+          // If we programmtically pass babel options while there is a .babelrc, babel might throw
+          // We need to filter out duplicate presets and plugins so that this doesn't happen
+          // This workaround isn't full proof, but it's still better than nothing
+          ['presets', 'plugins'].forEach(field => {
+            babelOptions[field] = babelOptions[field]
+              ? babelOptions[field].filter(item => {
+                  // If item is an array it's a preset/plugin with options ([preset, options])
+                  // Get the first item to get the preset.plugin name
+                  // Otheriwse it's a plugin name (can be a function too)
+                  const name = Array.isArray(item) ? item[0] : item;
+
+                  if (
+                    // In our case, a preset might also be referring to linaria/babel
+                    // We require the file from internal path which is not the same one that we export
+                    // This case won't get caught and the preset won't filtered, even if they are same
+                    // So we add an extra check for top level linaria/babel
+                    name === 'linaria/babel' ||
+                    name === require.resolve('../../babel') ||
+                    // Also add a check for the plugin names we include for bundler support
+                    plugins.includes(name)
+                  ) {
+                    return false;
+                  }
+
+                  // Loop through the default presets/plugins to see if it already exists
+                  return !defaults[field].some(it =>
+                    // The default presets/plugins can also have nested arrays,
+                    Array.isArray(it) ? it[0] === name : it === name
+                  );
+                })
+              : [];
+          });
+
+          return babel.transformSync(text, {
+            // Passed options shouldn't be able to override the options we pass
+            // Linaria's plugins rely on these (such as filename to generate consistent hash)
+            ...babelOptions,
+            ...defaults,
+            presets: [
+              // Preset order is last to first, so add the extra presets to start
+              // This makes sure that our preset is always run first
+              ...babelOptions.presets,
+              ...defaults.presets,
+            ],
+            plugins: [
+              ...defaults.plugins,
               // Plugin order is first to last, so add the extra presets to end
               // This makes sure that the plugins we specify always run first
-              ...(babelOptions.plugins || []),
+              ...babelOptions.plugins,
             ],
           });
         };


### PR DESCRIPTION
We pass some plugins by default to make evaluation work with ES6 `import` syntax. We also pass the linaria preset during evaluation explicitly. But babel will throw if it encounters duplicate plugins or presets.

![image](https://user-images.githubusercontent.com/1174278/53379774-37164100-396b-11e9-8ac7-8acaf0b06c22.png)

This PR adds some filtering to avoid including the same plugins and presets twice.