### PR TITLE
fix: remove redundant `hyphenate` from objects interpolation

### DIFF
--- a/src/__tests__/__snapshots__/babel.test.js.snap
+++ b/src/__tests__/__snapshots__/babel.test.js.snap
@@ -200,6 +200,9 @@ const cover = {
   left: 0,
   opacity: 1,
   minHeight: 420,
+  '&.shouldNotBeChanged': {
+    borderColor: '#fff'
+  },
   '@media (min-width: 200px)': {
     WebkitOpacity: .8,
     MozOpacity: .8,
@@ -228,7 +231,7 @@ exports[`inlines object styles as CSS string 2`] = `
 CSS:
 
 .th6xni0 {
-  position: absolute; top: 0; right: 0; bottom: 0; left: 0; opacity: 1; min-height: 420px; @media (min-width: 200px) { -webkit-opacity: 0.8; -moz-opacity: 0.8; -ms-opacity: 0.8; -o-opacity: 0.8; -webkit-border-radius: 2px; -moz-border-radius: 2px; -ms-border-radius: 2px; -o-border-radius: 2px; -webkit-transition: 400ms; -moz-transition: 400ms; -o-transition: 400ms; -ms-transition: 400ms; }
+  position: absolute; top: 0; right: 0; bottom: 0; left: 0; opacity: 1; min-height: 420px; &.shouldNotBeChanged { border-color: #fff; } @media (min-width: 200px) { -webkit-opacity: 0.8; -moz-opacity: 0.8; -ms-opacity: 0.8; -o-opacity: 0.8; -webkit-border-radius: 2px; -moz-border-radius: 2px; -ms-border-radius: 2px; -o-border-radius: 2px; -webkit-transition: 400ms; -moz-transition: 400ms; -o-transition: 400ms; -ms-transition: 400ms; }
 }
 
 Dependencies: NA

--- a/src/__tests__/babel.test.js
+++ b/src/__tests__/babel.test.js
@@ -108,6 +108,10 @@ it('inlines object styles as CSS string', async () => {
       left: 0,
       opacity: 1,
       minHeight: 420,
+      
+      '&.shouldNotBeChanged': {
+        borderColor: '#fff',
+      },
 
       '@media (min-width: 200px)': {
         WebkitOpacity: .8,

--- a/src/babel/extract.js
+++ b/src/babel/extract.js
@@ -32,7 +32,7 @@ const toCSS = o =>
     )
     .map(([key, value]) => {
       if (isPlainObject(value)) {
-        return `${hyphenate(key)} { ${toCSS(value)} }`;
+        return `${key} { ${toCSS(value)} }`;
       }
 
       return `${hyphenate(key)}: ${


### PR DESCRIPTION
**Summary**

It looks like we do not need to convert keys of nested objects to kebab case because it brakes nested selectors (eg. `'&.camelCaseSelector': {…}` is converted to `&.camel-case-selector {…}`).

**Test plan**

I've added a test for this case.