### PR TITLE
fix: evaluation of functions with their own nested identifiers

### DIFF
--- a/src/__tests__/__snapshots__/preval.test.js.snap
+++ b/src/__tests__/__snapshots__/preval.test.js.snap
@@ -211,6 +211,39 @@ Dependencies: ../slugify
 
 `;
 
+exports[`evaluates functions with nested identifiers 1`] = `
+"import { styled } from 'linaria/react';
+const objects = {
+  key: {
+    fontSize: 12
+  }
+};
+
+const foo = k => {
+  const obj = objects[k];
+  return obj;
+};
+
+export const Title =
+/*#__PURE__*/
+styled(\\"h1\\")({
+  name: \\"Title\\",
+  class: \\"Title_t1xha7dm\\"
+});"
+`;
+
+exports[`evaluates functions with nested identifiers 2`] = `
+
+CSS:
+
+.Title_t1xha7dm {
+  font-size: 12px;
+}
+
+Dependencies: NA
+
+`;
+
 exports[`evaluates identifier in scope 1`] = `
 "import { styled } from 'linaria/react';
 const answer = 42;

--- a/src/__tests__/preval.test.js
+++ b/src/__tests__/preval.test.js
@@ -70,6 +70,27 @@ it('evaluates local expressions', async () => {
   expect(metadata).toMatchSnapshot();
 });
 
+it('evaluates functions with nested identifiers', async () => {
+  const { code, metadata } = await transpile(
+    dedent`
+    import { styled } from 'linaria/react';
+
+    const objects = { key: { fontSize: 12 } };
+    const foo = (k) => {
+      const obj = objects[k];
+      return obj;
+    };
+
+    export const Title = styled.h1\`
+      ${"${foo('key')}"}
+    \`;
+    `
+  );
+
+  expect(code).toMatchSnapshot();
+  expect(metadata).toMatchSnapshot();
+});
+
 it('evaluates expressions with dependencies', async () => {
   const { code, metadata } = await transpile(
     dedent`

--- a/src/babel/evaluate.js
+++ b/src/babel/evaluate.js
@@ -6,6 +6,18 @@ const generator = require('@babel/generator').default;
 const babel = require('@babel/core');
 const Module = require('./module');
 
+const isAdded = (requirements, path) => {
+  if (requirements.some(req => req.path === path)) {
+    return true;
+  }
+
+  if (path.parentPath) {
+    return isAdded(requirements, path.parentPath);
+  }
+
+  return false;
+};
+
 const resolve = (path, t, requirements) => {
   const binding = path.scope.getBinding(path.node.name);
 
@@ -13,7 +25,7 @@ const resolve = (path, t, requirements) => {
     path.isReferenced() &&
     binding &&
     binding.kind !== 'param' &&
-    !requirements.some(req => req.path === binding.path)
+    !isAdded(requirements, binding.path)
   ) {
     let result;
 


### PR DESCRIPTION
**Summary**

There is a problem with the evaluation of functions like this
```
    const foo = (k) => {
      const obj = objects[k];
      return obj;
    };
```

It will be transformed to
```
      {
        const foo = k => {
          const obj = objects[k];
          return obj;
        };

        {
          const obj = objects[k];
          {
            module.exports = foo('key');
          }
        }
      }
```

As we can see, `obj` was extracted from the function to the global scope.

**Test plan**

A new test has been added.