### PR TITLE
fix: don't suppress JS parsing errors in stylelint

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,7 @@
     "prettier": "^1.16.4",
     "react": "^16.8.3",
     "react-test-renderer": "^16.8.3",
-    "release-it": "^10.1.0",
-    "strip-ansi": "^5.0.0"
+    "release-it": "^10.1.0"
   },
   "dependencies": {
     "@babel/core": "^7.3.3",
@@ -93,6 +92,7 @@
     "mkdirp": "^0.5.1",
     "normalize-path": "^3.0.0",
     "postcss": "^7.0.14",
+    "strip-ansi": "^5.0.0",
     "react-is": "^16.8.3",
     "rollup-pluginutils": "^2.4.1",
     "source-map": "^0.7.3",

--- a/src/transform.js
+++ b/src/transform.js
@@ -7,6 +7,11 @@ const babel = require('@babel/core');
 const stylis = require('stylis');
 const { SourceMapGenerator } = require('source-map');
 
+export type Replacement = {
+  original: { start: Location, end: Location },
+  length: number,
+};
+
 type Location = {
   line: number,
   column: number,
@@ -25,10 +30,7 @@ type Result = {
       start: ?Location,
     },
   },
-  replacements?: Array<{
-    original: { start: Location, end: Location },
-    length: number,
-  }>,
+  replacements?: Replacement[],
 };
 
 type Options = {


### PR DESCRIPTION
The formatting is a bit messed up due to stylelint's pretty-printing. But all important information is there.

![screenshot 2019-03-06 at 5 07 51 pm](https://user-images.githubusercontent.com/1174278/53896340-1c5f5e80-4034-11e9-8ceb-6f9005a37ad5.png)
