### PR TITLE
fix(cli): properly process configFile if provided

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -66,6 +66,11 @@ type Options = {
 function processFiles(files: string[], options: Options) {
   let count = 0;
 
+  const configFileOptions = options.configFile
+    ? // $FlowFixMe
+      require(options.configFile)
+    : {};
+
   const resolvedFiles = files.reduce(
     (acc, pattern) => [...acc, ...glob.sync(pattern, { absolute: true })],
     []
@@ -79,9 +84,7 @@ function processFiles(files: string[], options: Options) {
       {
         filename,
         outputFilename,
-        pluginOptions: {
-          configFile: options.configFile,
-        },
+        pluginOptions: configFileOptions,
       }
     );
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -66,11 +66,6 @@ type Options = {
 function processFiles(files: string[], options: Options) {
   let count = 0;
 
-  const configFileOptions = options.configFile
-    ? // $FlowFixMe
-      require(options.configFile)
-    : {};
-
   const resolvedFiles = files.reduce(
     (acc, pattern) => [...acc, ...glob.sync(pattern, { absolute: true })],
     []
@@ -84,7 +79,9 @@ function processFiles(files: string[], options: Options) {
       {
         filename,
         outputFilename,
-        pluginOptions: configFileOptions,
+        pluginOptions: {
+          configFile: options.configFile,
+        },
       }
     );
 


### PR DESCRIPTION
**Summary**

while configFile cli was implemented it doesn't work (https://github.com/callstack/linaria/pull/336).

This PR makes it work (processes the actual config file if present).

**Before:**
![image](https://user-images.githubusercontent.com/1223799/53971428-35801200-40fd-11e9-97e3-c4bdff3f2d64.png)

**After:**

![image](https://user-images.githubusercontent.com/1223799/53971377-1a150700-40fd-11e9-8794-f911f3b3ad54.png)


> Btw using flow was really a PITA from a contributor experience 👀🤔

