### PR TITLE
fix: add missing core-js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.2.0",
     "@babel/register": "^7.0.0",
     "@emotion/is-prop-valid": "^0.7.3",
+    "core-js": "^2.0.0",
     "cosmiconfig": "^5.1.0",
     "dedent": "^0.7.0",
     "enhanced-resolve": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2237,6 +2237,11 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+core-js@^2.0.0:
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
+  integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
+
 core-js@^2.4.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.0.tgz#569c050918be6486b3837552028ae0466b717086"


### PR DESCRIPTION
See comments of https://github.com/callstack/linaria/issues/361

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This adds a dependency to `core-js@^2.0.0` which is  implicitly required through the Babel build (because of `"useBuiltIns": "usage"` in `.babelrc`).

/lib/loader.js:
```js
require("core-js/modules/es6.regexp.to-string");

require("core-js/modules/es6.regexp.replace");
```

Now that `core-js@3` is out, upgrading a project can break the linaria webpack loader because `core-js`'s import paths changed. Adding the dependency to linaria should take care of keeping a copy of `core-js@2` around.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

This can be tested by linking the modified version of linaria into a project that uses `core-js@3`