### PR TITLE
fix: fix type error with a component interpolation

### DIFF
--- a/react.d.ts
+++ b/react.d.ts
@@ -13,7 +13,7 @@ type StyledComponent<T> = React.StatelessComponent<
 type StyledTag<T> = <Props = T>(
   strings: TemplateStringsArray,
   ...exprs: Array<
-    string | number | CSSProperties | ((props: Props) => string | number)
+    string | number | CSSProperties | ((props: Props) => string | number) | StyledComponent<any>
   >
 ) => StyledComponent<Props>;
 


### PR DESCRIPTION
**Summary**

It allows using component interpolation without typescript error. (#370)