### PR TITLE
feat: Support webpack's resolve.modules

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -41,6 +41,7 @@ module.exports = function loader(content: string, inputSourceMap: ?Object) {
       ? {
           ...resolveOptions,
           alias: this._compilation.options.resolve.alias,
+          modules: this._compilation.options.resolve.modules,
         }
       : resolveOptions
   );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Currently, linaria is able resolve webpack's `alias`, but `modules` should also be supported: https://webpack.js.org/configuration/resolve#resolvemodules

**Test plan**

In our webpack.config.js, we use `resolve.modules` to be able to import modules from our root source:

```js
module.exports = {
  // ...
  resolve: {
    modules: [path.resolve(__dirname, 'src'), 'node_modules']
  },
}
```

***Before***

```js
import { css } from 'linaria'
import { rem } from '../../../utils/css'

export const cxMain = css`
  display: flex;
  margin: ${rem(12)};
`
```

***After***

```js
import { css } from 'linaria'
import { rem } from 'utils/css'

export const cxMain = css`
  display: flex;
  margin: ${rem(12)};
`
```

We've been patching linaria for the last ~20 days adding this line of code to `lib/loader.js` but I thought we could just add this to linaria's core.