### PR TITLE
Combine default HTML elements attributes with user-defined props. (TypeScript, React)

### DIFF
--- a/react.d.ts
+++ b/react.d.ts
@@ -15,7 +15,7 @@ type StyledTag<T> = <Props = T>(
   ...exprs: Array<
     string | number | CSSProperties | ((props: Props) => string | number)
   >
-) => StyledComponent<Props>;
+) => StyledComponent<Props & T>;
 
 type StyledJSXIntrinsics = {
   readonly [P in keyof JSX.IntrinsicElements]: StyledTag<


### PR DESCRIPTION
**Summary**

When you add interface with custom props to the styled component generic you will lose autocomplete for HTML element attributes. So I combine default HTML elements attributes with user-defined props.

**Test plan**

```typescript
styled.input<{ error : boolean }>
```

before:

![before](https://user-images.githubusercontent.com/8431593/56086735-61f61f00-5e5d-11e9-8d01-f31641873ef7.png)

after:

![after](https://user-images.githubusercontent.com/8431593/56086744-7e925700-5e5d-11e9-9116-c34b8c40478d.png)

