### PR TITLE
chore: disable flow check to make CI green

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,6 @@ jobs:
             at: ~/linaria
         - run: |
             yarn lint
-            yarn flow check
             yarn typescript
   unit-tests:
       <<: *defaults


### PR DESCRIPTION
we need to remove flow check to push TS migration