### PR TITLE
Fix for broken interpolation

### DIFF
--- a/src/__fixtures__/components-library.js
+++ b/src/__fixtures__/components-library.js
@@ -1,0 +1,5 @@
+import { styled } from '../react';
+
+export const T1 = styled.h1`background: #111;`;
+export const T2 = styled.h2`background: #222;`;
+export const T3 = styled.h3`${T2} { background: #333; }`;

--- a/src/__tests__/__snapshots__/preval.test.js.snap
+++ b/src/__tests__/__snapshots__/preval.test.js.snap
@@ -410,6 +410,40 @@ Dependencies: NA
 
 `;
 
+exports[`generates stable class names 1`] = `
+"import { styled } from '../react';
+export const T1 =
+/*#__PURE__*/
+styled(\\"h1\\")({
+  name: \\"T1\\",
+  class: \\"T1_t11kcpnd\\"
+});
+export const T2 =
+/*#__PURE__*/
+styled(\\"h2\\")({
+  name: \\"T2\\",
+  class: \\"T2_t1xdipzs\\"
+});
+export const T3 =
+/*#__PURE__*/
+styled(\\"h3\\")({
+  name: \\"T3\\",
+  class: \\"T3_tmgfls7\\"
+});"
+`;
+
+exports[`generates stable class names 2`] = `
+
+CSS:
+
+.T1_t11kcpnd {background: #111;}
+.T2_t1xdipzs {background: #222;}
+.T3_tmgfls7 {.T2_t1xdipzs { background: #333; }}
+
+Dependencies: ../react
+
+`;
+
 exports[`handles complex component 1`] = `
 "// Dead code in this file should be ignored
 import deadDep from 'unknown-dependency';

--- a/src/__tests__/preval.test.js
+++ b/src/__tests__/preval.test.js
@@ -456,6 +456,16 @@ it('handles complex component', async () => {
   expect(metadata).toMatchSnapshot();
 });
 
+it('generates stable class names', async () => {
+  const { code, metadata } = await babel.transformFileAsync(
+    resolve(__dirname, '../__fixtures__/components-library.js'),
+    babelrc
+  );
+
+  expect(code).toMatchSnapshot();
+  expect(metadata).toMatchSnapshot();
+});
+
 it('derives display name from filename', async () => {
   const { code, metadata } = await babel.transformAsync(
     dedent`

--- a/src/babel/utils/getLinariaComment.ts
+++ b/src/babel/utils/getLinariaComment.ts
@@ -1,0 +1,27 @@
+import { types } from '@babel/core';
+import { NodePath } from '@babel/traverse';
+
+const pattern = /^linaria (\S+)(?: (\S+))?$/;
+
+export default function getLinariaComment(
+  path: NodePath<types.TaggedTemplateExpression>
+) {
+  const comments = path.node.leadingComments;
+  if (!comments) {
+    return [null, null];
+  }
+
+  const idx = comments.findIndex(comment => pattern.test(comment.value));
+  if (idx === -1) {
+    return [null, null];
+  }
+
+  const matched = comments[idx].value.match(pattern);
+  if (!matched) {
+    return [null, null];
+  }
+
+  path.node.leadingComments = comments.filter((_, i) => i !== idx);
+
+  return [matched[1], matched[2] || null];
+}

--- a/src/babel/visitors/TaggedTemplateExpression.ts
+++ b/src/babel/visitors/TaggedTemplateExpression.ts
@@ -1,10 +1,14 @@
 /* eslint-disable no-param-reassign */
 
+import { basename, dirname, relative } from 'path';
 import { types } from '@babel/core';
 import { NodePath } from '@babel/traverse';
 import throwIfInvalid from '../utils/throwIfInvalid';
 import hasImport from '../utils/hasImport';
 import { State, StrictOptions, ValueType, ExpressionValue } from '../types';
+import toValidCSSIdentifier from '../utils/toValidCSSIdentifier';
+import slugify from '../../slugify';
+import getLinariaComment from '../utils/getLinariaComment';
 
 export default function TaggedTemplateExpression(
   path: NodePath<types.TaggedTemplateExpression>,
@@ -83,6 +87,76 @@ export default function TaggedTemplateExpression(
       return { kind: ValueType.FUNCTION, ex };
     }
   );
+
+  // Increment the index of the style we're processing
+  // This is used for slug generation to prevent collision
+  // Also used for display name if it couldn't be determined
+  state.index++;
+
+  let [slug, displayName] = getLinariaComment(path);
+
+  const parent = path.findParent(
+    p =>
+      types.isObjectProperty(p) ||
+      types.isJSXOpeningElement(p) ||
+      types.isVariableDeclarator(p)
+  );
+
+  if (!displayName && parent) {
+    const parentNode = parent.node;
+    if (types.isObjectProperty(parentNode)) {
+      displayName = parentNode.key.name || parentNode.key.value;
+    } else if (
+      types.isJSXOpeningElement(parentNode) &&
+      types.isJSXIdentifier(parentNode.name)
+    ) {
+      displayName = parentNode.name.name;
+    } else if (
+      types.isVariableDeclarator(parentNode) &&
+      types.isIdentifier(parentNode.id)
+    ) {
+      displayName = parentNode.id.name;
+    }
+  }
+
+  if (!displayName) {
+    // Try to derive the path from the filename
+    displayName = basename(state.file.opts.filename);
+
+    if (/^index\.[a-z0-9]+$/.test(displayName)) {
+      // If the file name is 'index', better to get name from parent folder
+      displayName = basename(dirname(state.file.opts.filename));
+    }
+
+    // Remove the file extension
+    displayName = displayName.replace(/\.[a-z0-9]+$/, '');
+
+    if (displayName) {
+      displayName += state.index;
+    } else {
+      throw path.buildCodeFrameError(
+        "Couldn't determine a name for the component. Ensure that it's either:\n" +
+          '- Assigned to a variable\n' +
+          '- Is an object property\n' +
+          '- Is a prop in a JSX element\n'
+      );
+    }
+  }
+
+  // Custom properties need to start with a letter, so we prefix the slug
+  // Also use append the index of the class to the filename for uniqueness in the file
+  slug =
+    slug ||
+    toValidCSSIdentifier(
+      `${displayName.charAt(0).toLowerCase()}${slugify(
+        `${relative(state.file.opts.root, state.file.opts.filename)}:${
+          state.index
+        }`
+      )}`
+    );
+
+  // Save evaluated slug and displayName for future usage in templateProcessor
+  path.addComment('leading', `linaria ${slug} ${displayName}`);
 
   if (styled && 'name' in styled.component.node) {
     expressionValues.push({


### PR DESCRIPTION
I've found a bug in the new extractor.

```
export const T1 = styled.h1`background: #111;`;
export const T2 = styled.h2`background: #222;`;
export const T3 = styled.h3`${T2} { background: #333; }`;
```

Extractor finds referenced `T2` and tries to shake the original file in order to evaluate it. As a result, we get code like this:

```
import { styled } from '../react';
const T2 = styled.h2`background: #222;`;

const wrap = fn => {
  try {
    return fn();
  } catch (e) {
    return e;
  }
};

module.exports = [wrap(() => T2)];
```

Looks fine, but in the process of evaluation, T2 will get a class name based on a wrong `state.index` ( `${relative(state.file.opts.root, state.file.opts.filename)}:0` instead of `${relative(state.file.opts.root, state.file.opts.filename)}:1`).

I'm currently looking for a solution. I hope I'll fix it by the end of the week.