### PR TITLE
Changed suggestion for hot style reloading

### DIFF
--- a/docs/BUNDLERS_INTEGRATION.md
+++ b/docs/BUNDLERS_INTEGRATION.md
@@ -45,7 +45,12 @@ Now add the following snippet in under `module.rules`:
 {
   test: /\.css$/,
   use: [
-    MiniCssExtractPlugin.loader,
+    {
+      loader: MiniCssExtractPlugin.loader,
+      options: {
+        hmr: process.env.NODE_ENV !== 'production',
+      },
+    },
     {
       loader: 'css-loader',
       options: {
@@ -66,7 +71,7 @@ new MiniCssExtractPlugin({
 
 This will extract the CSS from all files into a single `styles.css`. Then you can to link to this file in your HTML file manually or use something like [`HTMLWebpackPlugin`](https://github.com/jantimon/html-webpack-plugin).
 
-If you want to hot reload your styles when they change, you will also need to configure [`style-loader`](https://github.com/webpack-contrib/style-loader) or [`css-hot-loader`](https://github.com/shepherdwind/css-hot-loader).
+It will also hot reload your styles when in a development environment.
 
 Linaria integrates with your CSS pipeline, so you can always perform additional operations on the CSS, for example, using [postcss](https://postcss.org/) plugins such as [clean-css](https://github.com/jakubpawlowicz/clean-css) to further minify your CSS.
 
@@ -117,8 +122,12 @@ module.exports = {
       {
         test: /\.css$/,
         use: [
-          'css-hot-loader',
-          MiniCssExtractPlugin.loader,
+          {
+            loader: MiniCssExtractPlugin.loader,
+            options: {
+              hmr: process.env.NODE_ENV !== 'production',
+            },
+          },
           {
             loader: 'css-loader',
             options: { sourceMap: dev },
@@ -143,7 +152,7 @@ You can copy this file to your project if you are starting from scratch.
 To install the dependencies used in the example config, run:
 
 ```sh
-yarn add --dev webpack webpack-cli webpack-dev-server mini-css-extract-plugin css-loader css-hot-loader file-loader babel-loader
+yarn add --dev webpack webpack-cli webpack-dev-server mini-css-extract-plugin css-loader file-loader babel-loader
 ```
 
 You can now run the dev server by running `webpack-dev-server` and build the files by running `webpack`.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

Updated the bundlers integration docs to replace suggestion to use  style-loader or css-hot-loader with mini-css-extract-plugin

mini-css-extract-plugin can now handle this internally and css-hot-loader has been discontinued.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This is a doc change. The example code was pulled from a functioning installation.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
