### PR TITLE
fix: use evaluated dependencies instead of extracted

### DIFF
--- a/src/__tests__/__snapshots__/preval.test.js.snap
+++ b/src/__tests__/__snapshots__/preval.test.js.snap
@@ -477,7 +477,7 @@ CSS:
    ;
 }
 
-Dependencies: NA
+Dependencies: core-js/modules/es6.string.raw
 
 `;
 

--- a/src/babel/extract.ts
+++ b/src/babel/extract.ts
@@ -62,8 +62,7 @@ export default function extract(_babel: any, options: StrictOptions) {
 
           let lazyValues: any[] = [];
           if (lazyDeps.length) {
-            const [shaken, deps] = shake(path.node, lazyDeps);
-            state.dependencies.push(...deps.map(d => d.source));
+            const [shaken] = shake(path.node, lazyDeps);
             const evaluation = evaluate(
               shaken,
               types,
@@ -72,6 +71,7 @@ export default function extract(_babel: any, options: StrictOptions) {
               options
             );
 
+            state.dependencies.push(...evaluation.dependencies);
             lazyValues = evaluation.value;
           }
 


### PR DESCRIPTION
**Summary**

New extractor used a wrong list of dependencies that could cause problems with `babel-plugin-module-resolver`.

**Test plan**

Related test from `preval.test.js` was rollbacked to pre-migration state.