### PR TITLE
fix: "[…] is not defined" for MemberExpression

### DIFF
--- a/src/__tests__/__snapshots__/shaker.test.ts.snap
+++ b/src/__tests__/__snapshots__/shaker.test.ts.snap
@@ -130,6 +130,24 @@ const wrap = fn => {
 module.exports = [wrap(() => color2)];"
 `;
 
+exports[`should keep member expression key 1`] = `
+"const key = 'blue';
+const obj = {
+  blue: '#00F'
+};
+const blue = obj[key];
+
+const wrap = fn => {
+  try {
+    return fn();
+  } catch (e) {
+    return e;
+  }
+};
+
+module.exports = [wrap(() => blue)];"
+`;
+
 exports[`should throw away any side effects 1`] = `
 "const objects = {
   key: {

--- a/src/__tests__/depsGraph.test.ts
+++ b/src/__tests__/depsGraph.test.ts
@@ -370,3 +370,26 @@ it('SequenceExpression', () => {
   expect(graph.findDependents(bool)).toHaveLength(0);
   expect(graph.findDependencies(bool)).toHaveLength(0);
 });
+
+it('MemberExpression', () => {
+  const graph = _buildGraph`
+    const key = 'blue';
+    const obj = { blue: '#00F' };
+    const blue = obj[key];
+  `;
+
+  const memberExprDeps = graph.findDependencies({
+    type: 'MemberExpression',
+  });
+
+  expect(memberExprDeps).toMatchObject([
+    {
+      type: 'Identifier',
+      name: 'obj',
+    },
+    {
+      type: 'Identifier',
+      name: 'key',
+    },
+  ]);
+});

--- a/src/__tests__/shaker.test.ts
+++ b/src/__tests__/shaker.test.ts
@@ -82,6 +82,16 @@ it('shakes imports', () => {
   expect(shaken).toMatchSnapshot();
 });
 
+it('should keep member expression key', () => {
+  const [shaken] = _shake(['blue'])`
+    const key = 'blue';
+    const obj = { blue: '#00F' };
+    const blue = obj[key];
+  `;
+
+  expect(shaken).toMatchSnapshot();
+});
+
 it('shakes exports', () => {
   const [shaken] = _shake(['a'])`
     import { whiteColor as color, anotherColor } from '…';

--- a/src/babel/evaluate/identifierHandlers.ts
+++ b/src/babel/evaluate/identifierHandlers.ts
@@ -81,6 +81,7 @@ batchDefineHandlers(
     ['Function', 'body'],
     ['LogicalExpression', 'left'],
     ['LogicalExpression', 'right'],
+    ['MemberExpression', 'property'],
     ['MemberExpression', 'object'],
     ['NewExpression', 'callee'],
     ['ReturnStatement', 'argument'],


### PR DESCRIPTION
**Summary**

```
    const key = 'blue';
    const obj = { blue: '#00F' };
    const blue = obj[key];
```
In cases like this, shaker threw away `key` declaration.

**Test plan**

New tests were added.