### PR TITLE
fix: add ignore option to cli

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -33,3 +33,4 @@ where `source-root` is directory with source JS files and `insert-css-requires` 
 * `-r, --source-root <dir>` - Directory containing the source JS files
 * `-i, --insert-css-requires <dir>` - Directory containing JS files to insert require statements for the CSS files (__works only if `-r, --source-root` is provided__)
 * `-c, --config-file <filepath>` - Path to the configuration file. If a relative path is given, it'll be resolved relative to the current working directory.
+* `-x, --ignore "<pattern>"` - Pattern of files to ignore. Be sure to wrap with quotes.

--- a/src/cli.js
+++ b/src/cli.js
@@ -43,6 +43,12 @@ const { argv } = yargs
     requiresArg: true,
   })
   .implies('insert-css-requires', 'source-root')
+  .option('ignore', {
+    alias: 'x',
+    type: 'string',
+    description: 'Pattern of files to ignore. Be sure to provide a string',
+    requiresArg: true,
+  })
   .alias('help', 'h')
   .alias('version', 'v')
   .strict();
@@ -53,6 +59,7 @@ processFiles(argv._, {
   sourceRoot: argv['source-root'],
   insertCssRequires: argv['insert-css-requires'],
   configFile: argv.config,
+  ignore: argv.ignore,
 });
 
 type Options = {
@@ -61,13 +68,17 @@ type Options = {
   sourceRoot?: string,
   insertCssRequires?: string,
   configFile?: string,
+  ignore?: string,
 };
 
 function processFiles(files: string[], options: Options) {
   let count = 0;
 
   const resolvedFiles = files.reduce(
-    (acc, pattern) => [...acc, ...glob.sync(pattern, { absolute: true })],
+    (acc, pattern) => [
+      ...acc,
+      ...glob.sync(pattern, { absolute: true, ignore: options.ignore }),
+    ],
     []
   );
 


### PR DESCRIPTION
**Summary**

Forwards CLI argument `ignore` to node-glob.

**Test plan**

All tests still passing.
![image](https://user-images.githubusercontent.com/5799163/61192246-e9734a00-a667-11e9-827e-855ac7b37418.png)

