### PR TITLE
[docs][webpack] Use hash in CSS filename

### DIFF
--- a/docs/BUNDLERS_INTEGRATION.md
+++ b/docs/BUNDLERS_INTEGRATION.md
@@ -73,6 +73,16 @@ This will extract the CSS from all files into a single `styles.css`. Then you ca
 
 It will also hot reload your styles when in a development environment.
 
+For production usage, you should include a hash in the filename:
+
+```js
+new MiniCssExtractPlugin({
+  filename: 'styles-[contenthash].css',
+});
+```
+
+To link to the correct filename, you can either use [`HTMLWebpackPlugin`](https://github.com/jantimon/html-webpack-plugin) for a static HTML file or [`assets-webpack-plugin`](https://yarn.pm/assets-webpack-plugin) to save the filename to a JSON file for a server-rendered page.
+
 Linaria integrates with your CSS pipeline, so you can always perform additional operations on the CSS, for example, using [postcss](https://postcss.org/) plugins such as [clean-css](https://github.com/jakubpawlowicz/clean-css) to further minify your CSS.
 
 #### Full example

--- a/docs/BUNDLERS_INTEGRATION.md
+++ b/docs/BUNDLERS_INTEGRATION.md
@@ -81,7 +81,7 @@ new MiniCssExtractPlugin({
 });
 ```
 
-To link to the correct filename, you can either use [`HTMLWebpackPlugin`](https://github.com/jantimon/html-webpack-plugin) for a static HTML file or [`assets-webpack-plugin`](https://yarn.pm/assets-webpack-plugin) to save the filename to a JSON file for a server-rendered page.
+Using a hash like this allows for a far future `Expires` header to be used, to improve cache efficiency. To link to the correct filename, you can either use [`HTMLWebpackPlugin`](https://github.com/jantimon/html-webpack-plugin) for a static HTML file, or [`assets-webpack-plugin`](https://yarn.pm/assets-webpack-plugin) to save the filename to a JSON file which you can then read in your server-side code.
 
 Linaria integrates with your CSS pipeline, so you can always perform additional operations on the CSS, for example, using [postcss](https://postcss.org/) plugins such as [clean-css](https://github.com/jakubpawlowicz/clean-css) to further minify your CSS.
 


### PR DESCRIPTION
**Summary**

Best practice for Webpack assets is to include a hash in the filename. This allows far future expires headers to be used, as the filename changes whenever the contents change.

**Test plan**
👀 	