### PR TITLE
Add classNameSlug option

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -226,6 +226,17 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "chrisabrams",
+      "name": "Chris Abrams",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/527740?s=460&v=4",
+      "profile": "https://github.com/chrisabrams",
+      "contributions": [
+        "code",
+        "doc",
+        "ideas"
+      ]
     }
   ],
   "repoType": "github",

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -26,6 +26,19 @@ module.exports = {
 
   Enabling this will add a display name to generated class names, e.g. `.Title_abcdef` instead of `.abcdef'. It is disabled by default to generate smaller CSS files.
 
+- `classNameSlug: string` (default: `default`):
+
+  Using this will provide an interface to customize the output of the CSS class name. Example:
+
+      classNameSlug: '[title]',
+
+  Would generate a class name such as `.header` instead of the default `.header_absdjfsdf` which includes a hash.
+
+  ### Variables
+
+  - `hash`: The hash of the content.
+  - `title`: The name of the class.
+
 - `ignore: RegExp` (default: `/node_modules/`):
 
   If you specify a regex here, files matching the regex won't be processed, i.e. the matching files won't be transformed with Babel during evaluation. If you need to compile certain modules under `/node_modules/`, it's recommended to do it on a module by module basis for faster transforms, e.g. `ignore: /node_modules[\/\\](?!some-module|other-module)/`.

--- a/src/babel/types.js
+++ b/src/babel/types.js
@@ -26,6 +26,7 @@ export type State = {|
 |};
 
 export type StrictOptions = {|
+  classNameSlug: string,
   displayName: boolean,
   evaluate: boolean,
   ignore: RegExp,

--- a/src/babel/visitors/TaggedTemplateExpression.js
+++ b/src/babel/visitors/TaggedTemplateExpression.js
@@ -153,16 +153,16 @@ export default function TaggedTemplateExpression(
 
     // Variables that were used in the config for `classNameSlug`
     const optionVariables = classNameSlug.match(/\[.*?\]/g) || [];
-    let _slug = classNameSlug;
+    let cnSlug = classNameSlug;
 
     for (let i = 0, l = optionVariables.length; i < l; i++) {
       const _var = optionVariables[i].slice(1, -1); // Remove the brackets around the variable name
 
       // Replace the var if it key and value exist otherwise place an empty string
-      _slug = _slug.replace(`[${_var}]`, classNameSlugVars[_var] || '');
+      cnSlug = cnSlug.replace(`[${_var}]`, classNameSlugVars[_var] || '');
     }
 
-    className = toValidCSSIdentifier(_slug);
+    className = toValidCSSIdentifier(cnSlug);
   }
 
   // Serialize the tagged template literal to a string

--- a/src/babel/visitors/TaggedTemplateExpression.js
+++ b/src/babel/visitors/TaggedTemplateExpression.js
@@ -137,9 +137,33 @@ export default function TaggedTemplateExpression(
     )}`
   );
 
-  const className = options.displayName
+  let className = options.displayName
     ? `${toValidCSSIdentifier(displayName)}_${slug}`
     : slug;
+
+  // Optionall the className can be defined by the user
+  if (typeof options.classNameSlug === 'string') {
+    const { classNameSlug } = options;
+
+    // Available variables for the square brackets used in `classNameSlug` options
+    const classNameSlugVars = {
+      hash: slug,
+      title: displayName,
+    };
+
+    // Variables that were used in the config for `classNameSlug`
+    const optionVariables = classNameSlug.match(/\[.*?\]/g) || [];
+    let _slug = classNameSlug;
+
+    for (let i = 0, l = optionVariables.length; i < l; i++) {
+      const _var = optionVariables[i].slice(1, -1); // Remove the brackets around the variable name
+
+      // Replace the var if it key and value exist otherwise place an empty string
+      _slug = _slug.replace(`[${_var}]`, classNameSlugVars[_var] || '');
+    }
+
+    className = toValidCSSIdentifier(_slug);
+  }
 
   // Serialize the tagged template literal to a string
   let cssText = '';


### PR DESCRIPTION
**Summary**

At GoDaddy we need the ability to generate a set of .css files which have consistent class names. Having the hash in/as the class name will not work for us as we have teams that only use our CSS (they don't have any React components).

This PR would enable GoDaddy to use Linaria as it provides the ability to generate a CSS class name which is consistent to the `displayName`. In using this new option, the end user takes responsibility for any class name collisions.

## How to configure

```
module.exports = {
  displayName: true,
  classNameSlug: '[title]',
};

```

## Example

A file called `header.jsx`:

```
import colors from './colors'
import { css } from 'linaria';
import { modularScale, hiDPI } from 'polished';
import fonts from './fonts';

// Write your styles in `css` tag
const header = css`
  color: ${colors.heading};
  text-transform: uppercase;
  font-family: ${fonts.heading};
  font-size: ${modularScale(2)};

  ${hiDPI(1.5)} {
    font-size: ${modularScale(2.5)};
  }
`;

export default header
```

### Current generated class name

    .header_h1h1jlnn

### Proposed generated class name with the above configuration

    .header

**Test plan**

I ran `yarn flow`, `yarn typescript`, `yarn lint`, and `yarn test`. The docs say there is a `test:integration` option but I did not see that in the `package.json`.
