### PR TITLE
linaria fails to process imported modules under certain conditions (Node is to blame)

### DIFF
--- a/src/__tests__/module.test.js
+++ b/src/__tests__/module.test.js
@@ -24,6 +24,17 @@ it('creates module for JS files', () => {
   expect(mod.filename).toBe(filename);
 });
 
+it('correctly processes export declarations in strict mode', () => {
+  const filename = '/foo/bar/test.js';
+  const mod = new Module(filename);
+
+  mod.evaluate('"use strict"; exports = module.exports = () => 42');
+
+  expect(mod.exports()).toBe(42);
+  expect(mod.id).toBe(filename);
+  expect(mod.filename).toBe(filename);
+});
+
 it('requires JS files', () => {
   const mod = new Module(path.resolve(__dirname, '../__fixtures__/test.js'));
 

--- a/src/babel/module.js
+++ b/src/babel/module.js
@@ -61,6 +61,10 @@ let cache = {};
 
 const NOOP = () => {};
 
+const wrapper = ['(function (exports) { ', '\n})(exports);'];
+
+const wrap = code => wrapper[0] + code + wrapper[1];
+
 class Module {
   static invalidate: () => void;
 
@@ -201,7 +205,7 @@ class Module {
     // For JavaScript files, we need to transpile it and to get the exports of the module
     const code = this.transform ? this.transform(text).code : text;
 
-    const script = new vm.Script(code, {
+    const script = new vm.Script(wrap(code), {
       filename: this.filename,
     });
 


### PR DESCRIPTION
Hi! Thank you for the great package.

**Summary**

linaria fails to process imported modules under certain conditions.

The problem is actually with Node, not linaria, see this issue: https://github.com/nodejs/help/issues/2094

**Conditions**

1. The module in question must be executed in strict mode.
2. The module must export a function.
3. The function must be assigned to an `exports` variable.

This may seem like a rare scenario, but I guess there are quite a few modules on NPM that use `exports` this way.

**Solution**

Wrap the module with an additional function wrapper, like so:

```js
(function (exports) {
  // code
})(exports);
```

I decided to go just with `exports` because:
  - it solves the problem
  - changes are minimal
  - other variables (`module`, etc) are not affected

**Test plan**

- `yarn test`
- `yarn link` against this repo https://github.com/dkamyshov/es5-ext-linaria-vm-reproduction

**Notes**

I would greatly appreciate a new release (like `v1.3.2`) if this PR gets merged.
