### PR TITLE
fix: compile babel and server (#420)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,23 +4,8 @@
       "@babel/preset-env",
       {
         "targets": {
-          "browsers": [
-            "last 2 versions",
-            "not ie 11",
-            "not ie_mob 11",
-            "not op_mini all",
-            "not dead"
-          ]
-        },
-        "useBuiltIns": "usage",
-        "exclude": [
-          "transform-typeof-symbol",
-          "es6.object.assign",
-          "es6.object.keys",
-          "es6.array.iterator",
-          "web.dom.iterable"
-        ],
-        "loose": true
+          "node": "8"
+        }
       }
     ],
     "@babel/preset-react",

--- a/src/__tests__/__snapshots__/preval.test.js.snap
+++ b/src/__tests__/__snapshots__/preval.test.js.snap
@@ -407,7 +407,7 @@ CSS:
    ;
 }
 
-Dependencies: core-js/modules/es6.string.raw
+Dependencies: NA
 
 `;
 

--- a/src/core/.babelrc
+++ b/src/core/.babelrc
@@ -1,0 +1,29 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "browsers": [
+            "last 2 versions",
+            "not ie 11",
+            "not ie_mob 11",
+            "not op_mini all",
+            "not dead"
+          ]
+        },
+        "useBuiltIns": "usage",
+        "exclude": [
+          "transform-typeof-symbol",
+          "es6.object.assign",
+          "es6.object.keys",
+          "es6.array.iterator",
+          "web.dom.iterable"
+        ],
+        "loose": true
+      }
+    ],
+    "@babel/preset-react",
+    "@babel/preset-flow"
+  ]
+}

--- a/src/react/.babelrc
+++ b/src/react/.babelrc
@@ -1,0 +1,29 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "browsers": [
+            "last 2 versions",
+            "not ie 11",
+            "not ie_mob 11",
+            "not op_mini all",
+            "not dead"
+          ]
+        },
+        "useBuiltIns": "usage",
+        "exclude": [
+          "transform-typeof-symbol",
+          "es6.object.assign",
+          "es6.object.keys",
+          "es6.array.iterator",
+          "web.dom.iterable"
+        ],
+        "loose": true
+      }
+    ],
+    "@babel/preset-react",
+    "@babel/preset-flow"
+  ]
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Sets `babel` up for compiling server stuff to target `node@8`. This is to remove the need to install `core-js@2` as a dependency.

**Test plan**

I've checked the build in `lib/` and unnecessary `core-js` requires are gone.
