### PR TITLE
fix: support String and Number object

### DIFF
--- a/src/babel/utils/throwIfInvalid.js
+++ b/src/babel/utils/throwIfInvalid.js
@@ -8,7 +8,9 @@ export default function throwIfInvalid(value: any, ex: any) {
   if (
     typeof value === 'function' ||
     typeof value === 'string' ||
-    (typeof value === 'number' && Number.isFinite(value)) ||
+    value instanceof String ||
+    ((typeof value === 'number' || value instanceof Number) &&
+      Number.isFinite(value)) ||
     isSerializable(value)
   ) {
     return;


### PR DESCRIPTION
## Summary

This Pull Request makes `throwIfInvalid()` pass for `String` and `Number` objects.

Before the change, the following are invalid.

```js
const style = css`
  width: ${new String('100%')};
  opacity: ${new Number(0.75)};
`;
// throw compilation error `The expression evaluated to 'xxx', which is
// probably a mistake. If you want it to be inserted into CSS, explicitly
// cast or transform the value to a string, e.g. - 'String(mq.XS)'.`
```

After the change, they are valid and the resulting CSS is:

```css
.H0A0S0H0C0L0A0S0S0N0A0M0E {
  width: 100%;
  opacity: 0.75;
}
```

## Motivation

`String` and `Number` objects are the `Object` equivalence of `string` and `number` primitives. Primitive objects are created using `new String('Hello')` and `new Number(123)`, but primitives are created using `'Hello'` and `123`.

While they are very similar, they differ in various ways. For example, `typeof new String('Hello') === 'object'`, but `typeof 'Hello' === 'string'`. And `new String('Hello').someCustomProperty = 123` is valid, but `'Hello'.someCustomProperty = 123` throws.

The use of primitive objects should be discouraged in many cases, as they can sometimes be very confusing. However, they are useful for creating a fluent API. For example, a media query utility that I recently wrote can potentially be used in the following way.

```js
const mq = createMediaQuery({ XS: '20rem', ... });

const style = css`
  width: 100%;
  ${mq.XS} {
    width: 24rem;
  }
  ${mq.XS.minHeight('20rem')} {
    width: 28rem;
  }
`;
// mq.XS === '@media (min-width: 20rem)'
// mq.XS.minHeight('20rem') === '@media (min-width: 20rem) and (min-height: 20rem)'
```

This can only be achieved by using primitive objects. Otherwise, it would be impossible to return a string-like or number-like object that allows further chaining.

Without this change, I'm forced to do the following.

```js
const mq = createMediaQuery({ XS: '20rem', ... });

const style = css`
  width: 100%;
  ${mq.XS.toString()} {
    width: 24rem;
  }
  ${mq.XS.minHeight('20rem').toString()} {
    width: 28rem;
  }
`;
```

As you can see, it is very verbose.

## Test plan

I've been using my media query utility with this change and `linaria` works flawlessly in this setup.

This change doesn't break any existing test. I'm not sure whether it's needed to write new tests for this. If yes, I'm more than willing to do so.

Please let me know if you have any question or concern.
