### PR TITLE
Fix some minor ts type related issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "files": [
     "bin/",
     "lib/",
+    "*.d.ts",
     "react.js",
     "rollup.js",
     "server.js",

--- a/src/react/styled.ts
+++ b/src/react/styled.ts
@@ -1,4 +1,4 @@
-import React from 'react'; // eslint-disable-line import/no-extraneous-dependencies
+import * as React from 'react'; // eslint-disable-line import/no-extraneous-dependencies
 import validAttr from '@emotion/is-prop-valid';
 import { cx } from '../index';
 import { StyledMeta } from '../types';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

* fixed #520
* fix the issue currently tsc will notice `Module '"/.../node_modules/@types/react/index"' can only be default-imported using the 'allowSyntheticDefaultImports' flag` when this option is not turned on

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

1. I made these changes
1. I ran `yarn pack` and use `tar --list -f linaria-v1.4.0-beta.1.tgz` to check `/react.d.ts` is already packed
1. I use `yarn link` link this repo to an existed repo to check the second commit is ok

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
