### PR TITLE
fix: allow styled import to be locally renamed

### DIFF
--- a/src/__tests__/__snapshots__/babel.test.ts.snap
+++ b/src/__tests__/__snapshots__/babel.test.ts.snap
@@ -411,6 +411,28 @@ Dependencies: NA
 
 `;
 
+exports[`transpiles renamed styled import 1`] = `
+"import { styled as custom } from 'linaria/react';
+export const Title =
+/*#__PURE__*/
+custom('h1')({
+  name: \\"Title\\",
+  class: \\"th6xni0\\"
+});"
+`;
+
+exports[`transpiles renamed styled import 2`] = `
+
+CSS:
+
+.th6xni0 {
+  font-size: 14px;
+}
+
+Dependencies: NA
+
+`;
+
 exports[`transpiles styled template literal with function and component 1`] = `
 "import { styled } from 'linaria/react';
 

--- a/src/__tests__/babel.test.ts
+++ b/src/__tests__/babel.test.ts
@@ -44,6 +44,21 @@ it('transpiles styled template literal with function and tag', async () => {
   expect(metadata).toMatchSnapshot();
 });
 
+it('transpiles renamed styled import', async () => {
+  const { code, metadata } = await transpile(
+    dedent`
+    import { styled as custom } from 'linaria/react';
+
+    export const Title = custom('h1')\`
+      font-size: 14px;
+    \`;
+    `
+  );
+
+  expect(code).toMatchSnapshot();
+  expect(metadata).toMatchSnapshot();
+});
+
 it('transpiles styled template literal with function and component', async () => {
   const { code, metadata } = await transpile(
     dedent`

--- a/src/__tests__/evaluators/__snapshots__/preeval.test.ts.snap
+++ b/src/__tests__/evaluators/__snapshots__/preeval.test.ts.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`handles locally named import 1`] = `
+"import { styled as custom } from 'linaria/react';
+const Component =
+/*linaria ca1zxek Component Component_ca1zxek*/
+custom.div\`\`;"
+`;
+
 exports[`preserves classNames 1`] = `
 "import { styled } from 'linaria/react';
 const Component =

--- a/src/__tests__/evaluators/preeval.test.ts
+++ b/src/__tests__/evaluators/preeval.test.ts
@@ -34,6 +34,18 @@ it('preserves classNames', async () => {
   expect(code).toMatchSnapshot();
 });
 
+it('handles locally named import', async () => {
+  const { code } = await transpile(
+    dedent`
+      import { styled as custom } from 'linaria/react';
+      
+      const Component = custom.div\`\`;
+      `
+  );
+
+  expect(code).toMatchSnapshot();
+});
+
 it('replaces functional component', async () => {
   const div = '<div>{props.children}</div>';
   const { code } = await transpile(

--- a/src/babel/evaluators/preeval.ts
+++ b/src/babel/evaluators/preeval.ts
@@ -5,6 +5,7 @@ import JSXElement from '../visitors/JSXElement';
 import CallExpression from '../visitors/CallExpression';
 import { State, StrictOptions } from '../types';
 import CSSTemplateExpression from '../visitors/CSSTemplateExpression';
+import ImportDeclaration from '../visitors/ImportDeclaration';
 
 function preeval(_babel: any, options: StrictOptions) {
   return {
@@ -21,6 +22,7 @@ function preeval(_babel: any, options: StrictOptions) {
           // We need our transforms to run before anything else
           // So we traverse here instead of a in a visitor
           path.traverse({
+            ImportDeclaration: p => ImportDeclaration(p, state),
             TaggedTemplateExpression: p =>
               TaggedTemplateExpression(p, state, options),
 

--- a/src/babel/evaluators/templateProcessor.ts
+++ b/src/babel/evaluators/templateProcessor.ts
@@ -259,9 +259,10 @@ export default function getTemplateProcessor(options: StrictOptions) {
 
       path.replaceWith(
         types.callExpression(
-          types.callExpression(types.identifier('styled'), [
-            styled.component.node,
-          ]),
+          types.callExpression(
+            types.identifier(state.file.metadata.localName || 'styled'),
+            [styled.component.node]
+          ),
           [types.objectExpression(props)]
         )
       );

--- a/src/babel/extract.ts
+++ b/src/babel/extract.ts
@@ -16,6 +16,7 @@ import {
   ValueCache,
 } from './types';
 import TaggedTemplateExpression from './visitors/TaggedTemplateExpression';
+import ImportDeclaration from './visitors/ImportDeclaration';
 
 function isLazyValue(v: ExpressionValue): v is LazyValue {
   return v.kind === ValueType.LAZY;
@@ -100,6 +101,7 @@ export default function extract(_babel: any, options: StrictOptions) {
           // So we traverse here instead of a in a visitor
           path.traverse({
             // Identifier: p => Identifier(p, state, options),
+            ImportDeclaration: p => ImportDeclaration(p, state),
             TaggedTemplateExpression: p =>
               TaggedTemplateExpression(p, state, options),
           });

--- a/src/babel/visitors/ImportDeclaration.ts
+++ b/src/babel/visitors/ImportDeclaration.ts
@@ -1,0 +1,20 @@
+/* eslint-disable no-param-reassign */
+
+import { types as t } from '@babel/core';
+import { NodePath } from '@babel/traverse';
+import { State } from '../types';
+
+export default function ImportDeclaration(
+  path: NodePath<t.ImportDeclaration>,
+  state: State
+) {
+  if (!t.isLiteral(path.node.source, { value: 'linaria/react' })) return;
+
+  path.node.specifiers.forEach(specifier => {
+    if (!t.isImportSpecifier(specifier)) return;
+
+    if (specifier.local.name !== specifier.imported.name) {
+      state.file.metadata.localName = specifier.local.name;
+    }
+  });
+}

--- a/src/babel/visitors/TaggedTemplateExpression.ts
+++ b/src/babel/visitors/TaggedTemplateExpression.ts
@@ -17,6 +17,8 @@ export default function TaggedTemplateExpression(
 ) {
   const { tag } = path.node;
 
+  const localName = state.file.metadata.localName || 'styled';
+
   let styled: {
     component: {
       node: t.Expression | NodePath<t.Expression>;
@@ -28,12 +30,12 @@ export default function TaggedTemplateExpression(
     t.isCallExpression(tag) &&
     t.isIdentifier(tag.callee) &&
     tag.arguments.length === 1 &&
-    tag.callee.name === 'styled' &&
+    tag.callee.name === localName &&
     hasImport(
       t,
       path.scope,
       state.file.opts.filename,
-      'styled',
+      localName,
       'linaria/react'
     )
   ) {
@@ -45,12 +47,12 @@ export default function TaggedTemplateExpression(
     t.isMemberExpression(tag) &&
     t.isIdentifier(tag.object) &&
     t.isIdentifier(tag.property) &&
-    tag.object.name === 'styled' &&
+    tag.object.name === localName &&
     hasImport(
       t,
       path.scope,
       state.file.opts.filename,
-      'styled',
+      localName,
       'linaria/react'
     )
   ) {


### PR DESCRIPTION
**Summary**

This allows the `styled` import to be locally renamed.

The ImportDeclaration is traversed to check if the imported and local names differ. If so, we store the local name in state and use it in place of the previously hard-coded `'styled'`.

I am not sure if `state.file.metadata` is an appropriate place for this — please feel free to change that.