### PR TITLE
Allow a function to be passed for classNameSlug option

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -26,13 +26,19 @@ module.exports = {
 
   Enabling this will add a display name to generated class names, e.g. `.Title_abcdef` instead of `.abcdef'. It is disabled by default to generate smaller CSS files.
 
-- `classNameSlug: string` (default: `default`):
+- `classNameSlug: string | (hash: string, title: string) => string` (default: `default`):
 
   Using this will provide an interface to customize the output of the CSS class name. Example:
 
       classNameSlug: '[title]',
 
   Would generate a class name such as `.header` instead of the default `.header_absdjfsdf` which includes a hash.
+
+  You may also use a function to define the slug. The function will be evaluated at build time and must return a string:
+
+      classNameSlug: (hash, title) => `${hash}__${7 * 6}__${title}`,
+
+  Would generate the class name `.absdjfsdf__42__header`.
 
   ### Variables
 

--- a/src/__tests__/__snapshots__/babel.test.ts.snap
+++ b/src/__tests__/__snapshots__/babel.test.ts.snap
@@ -79,6 +79,28 @@ Dependencies: NA
 
 `;
 
+exports[`handles fn passed in as classNameSlug 1`] = `
+"import { styled } from 'linaria/react';
+export const Title =
+/*#__PURE__*/
+styled('h1')({
+  name: \\"Title\\",
+  class: \\"th6xni0_42_Title\\"
+});"
+`;
+
+exports[`handles fn passed in as classNameSlug 2`] = `
+
+CSS:
+
+.th6xni0_42_Title {
+  font-size: 14px;
+}
+
+Dependencies: NA
+
+`;
+
 exports[`handles interpolation followed by unit 1`] = `
 "import { styled } from 'linaria/react';
 export const Title =
@@ -495,6 +517,28 @@ exports[`transpiles styled template literal with object 2`] = `
 CSS:
 
 .th6xni0 {
+  font-size: 14px;
+}
+
+Dependencies: NA
+
+`;
+
+exports[`uses string passed in as classNameSlug 1`] = `
+"import { styled } from 'linaria/react';
+export const Title =
+/*#__PURE__*/
+styled('h1')({
+  name: \\"Title\\",
+  class: \\"testSlug\\"
+});"
+`;
+
+exports[`uses string passed in as classNameSlug 2`] = `
+
+CSS:
+
+.testSlug {
   font-size: 14px;
 }
 

--- a/src/babel/types.ts
+++ b/src/babel/types.ts
@@ -96,8 +96,10 @@ export type EvalRule = {
   action: Evaluator | 'ignore' | string;
 };
 
+type ClassNameFn = (hash: string, title: string) => string;
+
 export type StrictOptions = {
-  classNameSlug?: string;
+  classNameSlug?: string | ClassNameFn;
   displayName: boolean;
   evaluate: boolean;
   ignore?: RegExp;

--- a/src/babel/visitors/TaggedTemplateExpression.ts
+++ b/src/babel/visitors/TaggedTemplateExpression.ts
@@ -163,7 +163,17 @@ export default function TaggedTemplateExpression(
     ? `${toValidCSSIdentifier(displayName!)}_${slug!}`
     : slug!;
 
-  // Optional the className can be defined by the user
+  // The className can be defined by the user either as fn or a string
+  if (typeof options.classNameSlug === 'function') {
+    try {
+      className = toValidCSSIdentifier(
+        options.classNameSlug(slug, displayName)
+      );
+    } catch {
+      throw new Error(`classNameSlug option must return a string`);
+    }
+  }
+
   if (typeof options.classNameSlug === 'string') {
     const { classNameSlug } = options;
 


### PR DESCRIPTION
**Summary**

Closes https://github.com/callstack/linaria/issues/541

**Test plan**

Added some snapshots to the babel tests. There were no pre-existing tests for the config options — these could do with more robust tests.