### PR TITLE
fix(evaluator): forces to use cjs for plugin-transform-runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@babel/plugin-proposal-export-namespace-from": "^7.8.3",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-transform-modules-commonjs": "^7.9.0",
+    "@babel/plugin-transform-runtime": "^7.9.0",
     "@babel/register": "^7.9.0",
     "@babel/template": "^7.8.6",
     "@babel/traverse": "^7.9.0",

--- a/src/__tests__/__snapshots__/preval.test.ts.snap
+++ b/src/__tests__/__snapshots__/preval.test.ts.snap
@@ -245,7 +245,7 @@ CSS:
   }
 }
 
-Dependencies: ../slugify
+Dependencies: @babel/runtime/helpers/interopRequireDefault, ../slugify
 
 `;
 
@@ -520,7 +520,7 @@ CSS:
    ;
 }
 
-Dependencies: NA
+Dependencies: @babel/runtime/helpers/interopRequireDefault, @babel/runtime/helpers/taggedTemplateLiteralLoose
 
 `;
 
@@ -852,7 +852,7 @@ CSS:
   color: blue;
 }
 
-Dependencies: react
+Dependencies: @babel/runtime/helpers/interopRequireDefault, react
 
 `;
 
@@ -1046,7 +1046,7 @@ CSS:
   }
 }
 
-Dependencies: NA
+Dependencies: @babel/runtime/helpers/interopRequireDefault, @babel/runtime/helpers/defineProperty
 
 `;
 
@@ -1072,7 +1072,7 @@ CSS:
 .bareIconClass_b1xha7dm {}
 .XS_x1rsdnkv {&.bareIconClass_b1xha7dm { font-size: 16.5px; }}
 
-Dependencies: NA
+Dependencies: @babel/runtime/helpers/interopRequireDefault, @babel/runtime/helpers/defineProperty
 
 `;
 
@@ -1151,7 +1151,7 @@ CSS:
   }
 }
 
-Dependencies: ../slugify
+Dependencies: @babel/runtime/helpers/interopRequireDefault, ../slugify
 
 `;
 
@@ -1426,7 +1426,7 @@ CSS:
    ;
 }
 
-Dependencies: NA
+Dependencies: @babel/runtime/helpers/interopRequireDefault, @babel/runtime/helpers/taggedTemplateLiteral
 
 `;
 
@@ -1773,7 +1773,7 @@ CSS:
   }
 }
 
-Dependencies: ../__fixtures__/complex-component
+Dependencies: @babel/runtime/helpers/interopRequireWildcard, ../__fixtures__/complex-component
 
 `;
 
@@ -1816,7 +1816,7 @@ CSS:
   color: blue;
 }
 
-Dependencies: react
+Dependencies: @babel/runtime/helpers/interopRequireDefault, react
 
 `;
 

--- a/src/__tests__/evaluators/__snapshots__/extractor.test.ts.snap
+++ b/src/__tests__/evaluators/__snapshots__/extractor.test.ts.snap
@@ -136,65 +136,13 @@ exports[`shakes exports 1`] = `
 
 exports[`shakes imports 1`] = `
 "{
-  function _getRequireWildcardCache() {
-    if (typeof WeakMap !== \\"function\\") return null;
-    var cache = new WeakMap();
-
-    _getRequireWildcardCache = function () {
-      return cache;
-    };
-
-    return cache;
-  }
+  var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
 
   {
-    function _interopRequireWildcard(obj) {
-      if (obj && obj.__esModule) {
-        return obj;
-      }
-
-      if (obj === null || typeof obj !== \\"object\\" && typeof obj !== \\"function\\") {
-        return {
-          default: obj
-        };
-      }
-
-      var cache = _getRequireWildcardCache();
-
-      if (cache && cache.has(obj)) {
-        return cache.get(obj);
-      }
-
-      var newObj = {};
-      var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor;
-
-      for (var key in obj) {
-        if (Object.prototype.hasOwnProperty.call(obj, key)) {
-          var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null;
-
-          if (desc && (desc.get || desc.set)) {
-            Object.defineProperty(newObj, key, desc);
-          } else {
-            newObj[key] = obj[key];
-          }
-        }
-      }
-
-      newObj.default = obj;
-
-      if (cache) {
-        cache.set(obj, newObj);
-      }
-
-      return newObj;
-    }
+    var _ = _interopRequireWildcard(require(\\"\\\\u2026\\"));
 
     {
-      var _ = _interopRequireWildcard(require(\\"\\\\u2026\\"));
-
-      {
-        exports.__linariaPreval = [_.whiteColor, _.default];
-      }
+      exports.__linariaPreval = [_.whiteColor, _.default];
     }
   }
 }"

--- a/src/__tests__/evaluators/__snapshots__/shaker.test.ts.snap
+++ b/src/__tests__/evaluators/__snapshots__/shaker.test.ts.snap
@@ -74,19 +74,11 @@ exports.__linariaPreval = [];"
 exports[`shakes assignment patterns 1`] = `
 "\\"use strict\\";
 
-function _toArray(arr) { return _arrayWithHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableRest(); }
+var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
 
-function _nonIterableRest() { throw new TypeError(\\"Invalid attempt to destructure non-iterable instance.\\\\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.\\"); }
+var _toArray2 = _interopRequireDefault(require(\\"@babel/runtime/helpers/toArray\\"));
 
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === \\"string\\") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === \\"Object\\" && o.constructor) n = o.constructor.name; if (n === \\"Map\\" || n === \\"Set\\") return Array.from(n); if (n === \\"Arguments\\" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
-
-function _iterableToArray(iter) { if (typeof Symbol !== \\"undefined\\" && Symbol.iterator in Object(iter)) return Array.from(iter); }
-
-function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-
-function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
+var _extends2 = _interopRequireDefault(require(\\"@babel/runtime/helpers/extends\\"));
 
 var _ = 2,
     identifier = _ === void 0 ? 1 : _;
@@ -95,13 +87,11 @@ var _a$b = {
   b: 2
 };
 _a$b = _a$b === void 0 ? {} : _a$b;
-
-var object = _extends({}, _a$b);
-
+var object = (_extends2.default)({}, _a$b);
 var _ref = [1, 2, 3, 4];
 _ref = _ref === void 0 ? [] : _ref;
 
-var _ref2 = _toArray(_ref),
+var _ref2 = (_toArray2.default)(_ref),
     array = _ref2.slice(0);
 
 var obj = {
@@ -159,17 +149,13 @@ exports.__linariaPreval = [obj2];"
 exports[`shakes imports 1`] = `
 "\\"use strict\\";
 
-function _typeof(obj) { \\"@babel/helpers - typeof\\"; if (typeof Symbol === \\"function\\" && typeof Symbol.iterator === \\"symbol\\") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === \\"function\\" && obj.constructor === Symbol && obj !== Symbol.prototype ? \\"symbol\\" : typeof obj; }; } return _typeof(obj); }
+var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
 
 Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
 var _ = _interopRequireWildcard(require(\\"\\\\u2026\\"));
-
-function _getRequireWildcardCache() { if (typeof WeakMap !== \\"function\\") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
-
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== \\"object\\" && typeof obj !== \\"function\\") { return { default: obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
 exports.__linariaPreval = [_.whiteColor, _.default];"
 `;

--- a/src/babel/evaluators/extractor/index.ts
+++ b/src/babel/evaluators/extractor/index.ts
@@ -40,6 +40,10 @@ function isLinariaPrevalExport(
 const extractor: Evaluator = (filename, options, text, only = null) => {
   const transformOptions = buildOptions(filename, options);
   transformOptions.presets!.unshift([require.resolve('../preeval'), options]);
+  transformOptions.plugins!.unshift([
+    '@babel/plugin-transform-runtime',
+    { useESModules: false },
+  ]);
 
   // Expressions will be extracted only for __linariaPreval.
   // In all other cases a code will be returned as is.

--- a/src/babel/evaluators/shaker/index.ts
+++ b/src/babel/evaluators/shaker/index.ts
@@ -19,6 +19,10 @@ function prepareForShake(
   ]);
   transformOptions.presets!.unshift([require.resolve('../preeval'), options]);
   transformOptions.plugins!.unshift('transform-react-remove-prop-types');
+  transformOptions.plugins!.unshift([
+    '@babel/plugin-transform-runtime',
+    { useESModules: false },
+  ]);
 
   debug(
     'evaluator:shaker:transform',

--- a/yarn.lock
+++ b/yarn.lock
@@ -704,6 +704,16 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
+"@babel/plugin-transform-runtime@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.9.0.tgz#45468c0ae74cc13204e1d3b1f4ce6ee83258af0b"
+  integrity sha512-pUu9VSf3kI1OqbWINQ7MaugnitRss1z533436waNXp+0N3ur3zfut37sXiQMxkuCF4VUjwZucen/quskCh7NHw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.8.3"
+    "@babel/helper-plugin-utils" "^7.8.3"
+    resolve "^1.8.1"
+    semver "^5.5.1"
+
 "@babel/plugin-transform-shorthand-properties@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.3.tgz#28545216e023a832d4d3a1185ed492bcfeac08c8"
@@ -7846,7 +7856,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.3.2:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.3.2, resolve@^1.8.1:
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.1.tgz#27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
   integrity sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==
@@ -8026,7 +8036,7 @@ semver-diff@^3.1.1:
   dependencies:
     semver "^6.3.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==


### PR DESCRIPTION
## Motivation

Evaluators tried to use default Babel config which is could be configured for using ES-modules that can cause injecting the wrong versions of babel-helpers during evaluation stages. (#517)

## Summary

This PR explicitly adds `@babel/plugin-transform-runtime` to pre-evaluation transforms.
