### PR TITLE
docs: start 2.0 migration guide

### DIFF
--- a/docs/2.0_MIGRATION_GUIDE.md
+++ b/docs/2.0_MIGRATION_GUIDE.md
@@ -1,0 +1,13 @@
+# `2.0` Migration Guide
+
+## Breaking changes
+
+### `Core-js` dependency removal and _theoretical_ drop compatibility for `node` below `10`
+
+In [#569](https://github.com/callstack/linaria/pull/569) We removed `core-js` dependency.
+
+It should not effectively affect your users or build pipelines. But it was technically a breaking change.
+
+We set babel preset that makes all non-browser dependencies compatible with `node` from version `10`. But previous setup was using `browser` env so If you was able to build Linaria with previous versions of node, it should work also now. Support for browsers environment didn't change.
+
+After that you should be able to solve issues with `core-js` dependency in your project, because it will no longer collide with version used by Linaria.


### PR DESCRIPTION
## Motivation

I wanted to inform users on current status of the project since for almost a year there were `1.4.0-beta` releases without a stable version and now we are starting `2.0.0` which might be confusing. 

## Summary

Updated Readme, added Migration guide.

## Test plan

n/a
