### PR TITLE
fix(module): fixes a conflict between old ignore option and the new one

### DIFF
--- a/src/babel/module.ts
+++ b/src/babel/module.ts
@@ -259,10 +259,7 @@ class Module {
 
     let code: string | null | undefined;
     const action = matchedRules.length > 0 ? matchedRules[0].action : 'ignore';
-    if (
-      action === 'ignore' ||
-      (this.options.ignore && this.options.ignore.test(filename))
-    ) {
+    if (action === 'ignore') {
       debug('module:ignore', `${filename}`);
       code = text;
     } else {

--- a/src/babel/utils/loadOptions.ts
+++ b/src/babel/utils/loadOptions.ts
@@ -10,7 +10,7 @@ const explorer = cosmiconfig('linaria');
 export default function loadOptions(
   overrides: Partial<PluginOptions> = {}
 ): Partial<StrictOptions> {
-  const { configFile, ...rest } = overrides;
+  const { configFile, ignore, ...rest } = overrides;
 
   const result =
     configFile !== undefined
@@ -25,7 +25,8 @@ export default function loadOptions(
         action: require('../evaluators/extractor').default,
       },
       {
-        test: /\/node_modules\//,
+        // The old `ignore` option is used as a default value for `ignore` rule.
+        test: ignore ?? /\/node_modules\//,
         action: 'ignore',
       },
     ],


### PR DESCRIPTION
This PR fixes a conflict between `ignore` options (#575).