### PR TITLE
Fix empty CSS variables

### DIFF
--- a/src/react/styled.ts
+++ b/src/react/styled.ts
@@ -98,7 +98,7 @@ function styled(tag: any): any {
 
           warnIfInvalid(value, options.name);
           // skip empty values
-          if(value !== null && typeof value !== undefined && value !== "") {
+          if (value !== null && typeof value !== undefined && value !== '') {
             style[`--${name}`] = `${value}${unit}`;
           }
         }

--- a/src/react/styled.ts
+++ b/src/react/styled.ts
@@ -97,8 +97,10 @@ function styled(tag: any): any {
           const value = typeof result === 'function' ? result(props) : result;
 
           warnIfInvalid(value, options.name);
-
-          style[`--${name}`] = `${value}${unit}`;
+          // skip empty values
+          if(value !== null && typeof value !== undefined && value !== "") {
+            style[`--${name}`] = `${value}${unit}`;
+          }
         }
 
         filteredProps.style = Object.assign(style, filteredProps.style);


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

Not passing props to a component results in a list of empty CSS variables. For instance, the following component:

```tsx
export const Box = styled.div<BoxProps>`
	display: ${props => props.display || "flex"};
	background: ${props => props.background || ""};
	background-color: ${props => props.backgroundColor || ""};
	flex-wrap: ${props => props.flexWrap || ""};
	flex-direction: ${props => props.flexDirection || ""};
	margin: ${props => props.margin || ""};
	padding: ${props => props.padding || ""};
	height: ${props => props.height || ""};
	width: ${props => props.width || ""};
	border: ${props => props.border || ""};
	border-radius: ${props => props.borderRadius || ""};
	border-width: ${props => props.borderWidth || ""};
	border-color: ${props => props.borderColor || ""};
`;
```

When later used without specifying all of the props, results in a list of empty CSS variables such as the following:

![2020-04-19 20_55_35-Centige](https://user-images.githubusercontent.com/10099857/79696990-531c2680-8280-11ea-88ac-16a7976ccf9f.png)


<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->

## Summary

This fix would skip any `null`, `undefined`, or empty string variable.

<!--
Explain how your implementation works and your thoughts behind the solution.
It will help maintainers to review your PR.
You can skip it if PR is trivial.
-->

<!--
## Test plan


Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->
