### PR TITLE
chore: autolabeling - make typescript matching more restricted

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -401,18 +401,10 @@
       "conditions": [
         {
           "type": "titleMatches",
-          "pattern": "/type/i"
+          "pattern": "/typescript/i"
         },
         {
           "type": "titleMatches",
-          "pattern": "/TS/"
-        },
-        {
-          "type": "descriptionMatches",
-          "pattern": "/type/i"
-        },
-        {
-          "type": "descriptionMatches",
           "pattern": "/TS/"
         }
       ]


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

label `cat: typings` was matching too often

## Summary

restricted rules for typings label

## Test plan

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->
