### PR TITLE
feat: more verbose report of evaluation error

### DIFF
--- a/src/__tests__/__snapshots__/babel.test.ts.snap
+++ b/src/__tests__/__snapshots__/babel.test.ts.snap
@@ -274,9 +274,9 @@ Dependencies: NA
 
 exports[`outputs valid CSS classname 1`] = `
 "import { styled } from 'linaria/react';
-export const ᾩPage$Title = /*#__PURE__*/styled(\\"h1\\")({
-  name: \\"\\\\u1FA9Page$Title\\",
-  class: \\"\\\\u1FA1h6xni0\\"
+export const ΩPage$Title = /*#__PURE__*/styled(\\"h1\\")({
+  name: \\"\\\\u03A9Page$Title\\",
+  class: \\"\\\\u03C9h6xni0\\"
 });"
 `;
 
@@ -284,7 +284,7 @@ exports[`outputs valid CSS classname 2`] = `
 
 CSS:
 
-.ᾡh6xni0 {
+.ωh6xni0 {
   font-size: 14px;
 }
 

--- a/src/__tests__/__snapshots__/preval.test.ts.snap
+++ b/src/__tests__/__snapshots__/preval.test.ts.snap
@@ -765,7 +765,20 @@ Dependencies: NA
 `;
 
 exports[`extractor non-hoistable identifiers 1`] = `
-"<<DIRNAME>>/source.js: An error occurred when evaluating the expression: days is not defined. Make sure you are not using a browser or Node specific API.
+"<<DIRNAME>>/source.js: An error occurred when evaluating the expression: 
+
+  > days is not defined. 
+
+  Make sure you are not using a browser or Node specific API and all the variables are available in static context.
+  Linaria have to extract pieces of your code to resolve the interpolated values.
+  Defining styled component or class will not work inside:
+    - function,
+    - class,
+    - method,
+    - loop,
+  because it cannot be statically determined in which context you use them.
+  That's why some variables may be not defined during evaluation.
+      
    7 | export const Title = styled.h1\`
    8 |   &:before {
 >  9 |     content: \\"\${days}\\"
@@ -857,7 +870,20 @@ Dependencies: @babel/runtime/helpers/interopRequireDefault, react
 `;
 
 exports[`extractor throws codeframe error when evaluation fails 1`] = `
-"<<DIRNAME>>/source.js: An error occurred when evaluating the expression: This will fail. Make sure you are not using a browser or Node specific API.
+"<<DIRNAME>>/source.js: An error occurred when evaluating the expression: 
+
+  > This will fail. 
+
+  Make sure you are not using a browser or Node specific API and all the variables are available in static context.
+  Linaria have to extract pieces of your code to resolve the interpolated values.
+  Defining styled component or class will not work inside:
+    - function,
+    - class,
+    - method,
+    - loop,
+  because it cannot be statically determined in which context you use them.
+  That's why some variables may be not defined during evaluation.
+      
   4 | 
   5 | export const Title = styled.h1\`
 > 6 |   font-size: \${foo()}px;
@@ -1671,7 +1697,20 @@ Dependencies: NA
 `;
 
 exports[`shaker non-hoistable identifiers 1`] = `
-"<<DIRNAME>>/source.js: An error occurred when evaluating the expression: days is not defined. Make sure you are not using a browser or Node specific API.
+"<<DIRNAME>>/source.js: An error occurred when evaluating the expression: 
+
+  > days is not defined. 
+
+  Make sure you are not using a browser or Node specific API and all the variables are available in static context.
+  Linaria have to extract pieces of your code to resolve the interpolated values.
+  Defining styled component or class will not work inside:
+    - function,
+    - class,
+    - method,
+    - loop,
+  because it cannot be statically determined in which context you use them.
+  That's why some variables may be not defined during evaluation.
+      
    7 | export const Title = styled.h1\`
    8 |   &:before {
 >  9 |     content: \\"\${days}\\"
@@ -1821,7 +1860,20 @@ Dependencies: @babel/runtime/helpers/interopRequireDefault, react
 `;
 
 exports[`shaker throws codeframe error when evaluation fails 1`] = `
-"<<DIRNAME>>/source.js: An error occurred when evaluating the expression: This will fail. Make sure you are not using a browser or Node specific API.
+"<<DIRNAME>>/source.js: An error occurred when evaluating the expression: 
+
+  > This will fail. 
+
+  Make sure you are not using a browser or Node specific API and all the variables are available in static context.
+  Linaria have to extract pieces of your code to resolve the interpolated values.
+  Defining styled component or class will not work inside:
+    - function,
+    - class,
+    - method,
+    - loop,
+  because it cannot be statically determined in which context you use them.
+  That's why some variables may be not defined during evaluation.
+      
   4 | 
   5 | export const Title = styled.h1\`
 > 6 |   font-size: \${foo()}px;

--- a/src/__tests__/babel.test.ts
+++ b/src/__tests__/babel.test.ts
@@ -121,7 +121,7 @@ it('outputs valid CSS classname', async () => {
     dedent`
     import { styled } from 'linaria/react';
 
-    export const ᾩPage$Title = styled.h1\`
+    export const ΩPage$Title = styled.h1\`
       font-size: 14px;
     \`;
     `

--- a/src/babel/utils/throwIfInvalid.ts
+++ b/src/babel/utils/throwIfInvalid.ts
@@ -31,7 +31,7 @@ function throwIfInvalid(
     - method,
     - loop,
   because it cannot be statically determined in which context you use them.
-  That's why some variables may be not defined.
+  That's why some variables may be not defined during evaluation.
       `
     );
   }

--- a/src/babel/utils/throwIfInvalid.ts
+++ b/src/babel/utils/throwIfInvalid.ts
@@ -19,7 +19,20 @@ function throwIfInvalid(
   // We can't use instanceof here so let's use duck typing
   if (value && typeof value !== 'number' && value.stack && value.message) {
     throw ex.buildCodeFrameError(
-      `An error occurred when evaluating the expression: ${value.message}. Make sure you are not using a browser or Node specific API.`
+      `An error occurred when evaluating the expression: 
+
+  > ${value.message}. 
+
+  Make sure you are not using a browser or Node specific API and all the variables are available in static context.
+  Linaria have to extract pieces of your code to resolve the interpolated values.
+  Defining styled component or class will not work inside:
+    - function,
+    - class,
+    - method,
+    - loop,
+  because it cannot be statically determined in which context you use them.
+  That's why some variables may be not defined.
+      `
     );
   }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

It closes #581 and closes #559 

## Summary

The evaluation may fail in two ways
- it is not possible to resolve the value because it's dependencies are not available in a static context
- some part of code before actual dependencies was invalid and crashes the vm

I added more information to the first error
<img width="1057" alt="Screen Shot 2020-04-22 at 14 28 25" src="https://user-images.githubusercontent.com/11561585/80001289-7df3be00-84be-11ea-8c61-36d88fca76d7.png">


I added a stack trace to the second type of error. However, it is not ideal, because line numbers will not match in most cases. I don't know how to improve it, adding some source maps might be complicated. I assume it might not be worth fixing that because those errors will be very rare with the new shaker evaluator. Currently, the error in web back is more verbose thanks to that:
![Screen Shot 2020-04-22 at 17 32 36](https://user-images.githubusercontent.com/11561585/80002008-5d783380-84bf-11ea-8f2e-5397d1ab34f6.png)

before it skipped the original stack trace
![Screen Shot 2020-04-22 at 17 32 02](https://user-images.githubusercontent.com/11561585/80002098-800a4c80-84bf-11ea-9b35-a0a9fedc8b6a.png)


## Test plan

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->
Green CI