### PR TITLE
fix(server): add @font-face to critical, remove redundant atrules.

### DIFF
--- a/src/server/__tests__/__snapshots__/collect.test.ts.snap
+++ b/src/server/__tests__/__snapshots__/collect.test.ts.snap
@@ -124,39 +124,6 @@ exports[`collects complex css critical 1`] = `
     object-fit: contain;
   }
 }
-@supports (object-fit: contain) {
-  .lotus {
-    object-fit: contain;
-  }
-
-  .linaria::before,
-  .linaria::after {
-    content: \\"\\";
-    object-fit: contain;
-  }
-}
-@supports (object-fit: contain) {
-  .lotus {
-    object-fit: contain;
-  }
-
-  .linaria::before,
-  .linaria::after {
-    content: \\"\\";
-    object-fit: contain;
-  }
-}
-@supports (object-fit: contain) {
-  .lotus {
-    object-fit: contain;
-  }
-
-  .linaria::before,
-  .linaria::after {
-    content: \\"\\";
-    object-fit: contain;
-  }
-}
 .linaria {
   float: left;
   flex: 1;
@@ -237,6 +204,23 @@ exports[`handles top-level @font-face critical 1`] = `
 `;
 
 exports[`handles top-level @font-face other 1`] = `""`;
+
+exports[`include atrule once critical 1`] = `
+"@media screen {
+  body {
+    font-size: 10px;
+  }
+  h1 {
+    font-size: 20px;
+  }
+  .class {
+    font-size: 15px;
+  }
+}
+"
+`;
+
+exports[`include atrule once other 1`] = `""`;
 
 exports[`simple class name critical 1`] = `
 ".linaria {

--- a/src/server/__tests__/__snapshots__/collect.test.ts.snap
+++ b/src/server/__tests__/__snapshots__/collect.test.ts.snap
@@ -37,10 +37,6 @@ exports[`classname in @rule critical 1`] = `
   .linaria {
   }
 }
-@font-face() {
-  .linaria {
-  }
-}
 @viewport() {
   .linaria {
   }
@@ -90,10 +86,6 @@ exports[`classname in @rule other 1`] = `
   }
 }
 @page() {
-  .other {
-  }
-}
-@font-face() {
   .other {
   }
 }
@@ -233,6 +225,18 @@ exports[`collects complex css other 1`] = `
 }
 "
 `;
+
+exports[`handles top-level @font-face critical 1`] = `
+"@font-face {
+  font-family: MyFont;
+  font-weight: normal;
+  font-style: normal;
+  src: url(MyFont.woff);
+}
+"
+`;
+
+exports[`handles top-level @font-face other 1`] = `""`;
 
 exports[`simple class name critical 1`] = `
 ".linaria {

--- a/src/server/__tests__/collect.test.ts
+++ b/src/server/__tests__/collect.test.ts
@@ -212,3 +212,24 @@ describe('handles top-level @font-face', () => {
   test('critical', () => expect(prettyPrint(critical)).toMatchSnapshot());
   test('other', () => expect(prettyPrint(other)).toMatchSnapshot());
 });
+
+// there was a bug when the whole atrule was included for each child rule
+describe('include atrule once', () => {
+  const css = dedent`
+    @media screen {
+      body {
+        font-size: 10px;
+      }
+      h1 {
+        font-size: 20px;
+      }
+      .class {
+        font-size: 15px;
+      }
+    }
+  `;
+  const { critical, other } = collect(html, css);
+
+  test('critical', () => expect(prettyPrint(critical)).toMatchSnapshot());
+  test('other', () => expect(prettyPrint(other)).toMatchSnapshot());
+});

--- a/src/server/__tests__/collect.test.ts
+++ b/src/server/__tests__/collect.test.ts
@@ -128,7 +128,6 @@ describe('classname in @rule', () => {
     @supports () { .linaria {} }
     @document () { .linaria {} }
     @page () { .linaria {} }
-    @font-face () { .linaria {} }
     @keyframes () { .linaria {} }
     @viewport () { .linaria {} }
     @counter-style () { .linaria {} }
@@ -143,7 +142,6 @@ describe('classname in @rule', () => {
     @supports () { .other {} }
     @document () { .other {} }
     @page () { .other {} }
-    @font-face () { .other {} }
     @keyframes () { .other {} }
     @viewport () { .other {} }
     @counter-style () { .other {} }
@@ -194,6 +192,21 @@ describe('works with global css', () => {
     .other::before {}
   `;
 
+  const { critical, other } = collect(html, css);
+
+  test('critical', () => expect(prettyPrint(critical)).toMatchSnapshot());
+  test('other', () => expect(prettyPrint(other)).toMatchSnapshot());
+});
+
+describe('handles top-level @font-face', () => {
+  const css = dedent`
+    @font-face {
+      font-family: MyFont;
+      font-weight: normal;
+      font-style: normal;
+      src: url(MyFont.woff);
+    }
+  `;
   const { critical, other } = collect(html, css);
 
   test('critical', () => expect(prettyPrint(critical)).toMatchSnapshot());

--- a/src/server/collect.ts
+++ b/src/server/collect.ts
@@ -29,7 +29,7 @@ export default function collect(html: string, css: string): CollectResult {
     let addedToCritical = false;
 
     rule.each(childRule => {
-      if (isCritical(childRule)) {
+      if (isCritical(childRule) && !addedToCritical) {
         critical.append(rule.clone());
         addedToCritical = true;
       }
@@ -56,13 +56,18 @@ export default function collect(html: string, css: string): CollectResult {
     }
   });
 
+  const walkedAtRules = new Set();
+
   stylesheet.walkRules(rule => {
     if ('name' in rule.parent && rule.parent.name === 'keyframes') {
       return;
     }
 
     if (rule.parent.type === 'atrule') {
-      handleAtRule(rule.parent);
+      if (!walkedAtRules.has(rule.parent)) {
+        handleAtRule(rule.parent);
+        walkedAtRules.add(rule.parent);
+      }
       return;
     }
 

--- a/src/server/collect.ts
+++ b/src/server/collect.ts
@@ -46,6 +46,16 @@ export default function collect(html: string, css: string): CollectResult {
     }
   };
 
+  stylesheet.walkAtRules('font-face', rule => {
+    /**
+     * @font-face rules may be defined also in CSS conditional groups (eg. @media)
+     * we want only handle those from top-level, rest will be handled in stylesheet.walkRules
+     */
+    if (rule.parent.type === 'root') {
+      critical.append(rule);
+    }
+  });
+
   stylesheet.walkRules(rule => {
     if ('name' in rule.parent && rule.parent.name === 'keyframes') {
       return;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

It fixes #527 
And additionally, I fixed a bug with redundant at rules in critical.

rule
```
@media screen {
      body {
        font-size: 10px;
      }
      h1 {
        font-size: 20px;
      }
      .class {
        font-size: 15px;
      }
    }
```
was added 3 times, each time for each child-rule. Amount of repeated adding was equal to amount of child rules.

## Summary

I added additional processing for top-level @font-face rules.
I added saving processed atrules to set, to avoid re-adding them
I covered changes with additional tests

We need to merge it also to `1.4.x` branch

## Test plan

green CI
