### PR TITLE
fix: handle blank string values

### DIFF
--- a/src/__tests__/__snapshots__/babel.test.ts.snap
+++ b/src/__tests__/__snapshots__/babel.test.ts.snap
@@ -19,6 +19,24 @@ const title = String.raw\`This is something\`;"
 
 exports[`does not output CSS if none present 2`] = `Object {}`;
 
+exports[`does not output CSS property when value is a blank string 1`] = `
+"import { css } from 'linaria';
+export const title = \\"th6xni0\\";"
+`;
+
+exports[`does not output CSS property when value is a blank string 2`] = `
+
+CSS:
+
+.th6xni0 {
+  font-size: ;
+  margin: 6px;
+}
+
+Dependencies: NA
+
+`;
+
 exports[`evaluates and inlines expressions in scope 1`] = `
 "import { styled } from 'linaria/react';
 const color = 'blue';

--- a/src/__tests__/babel.test.ts
+++ b/src/__tests__/babel.test.ts
@@ -342,6 +342,22 @@ it('does not output CSS if none present', async () => {
   expect(metadata).toMatchSnapshot();
 });
 
+it('does not output CSS property when value is a blank string', async () => {
+  const { code, metadata } = await transpile(
+    dedent`
+    import { css } from 'linaria';
+
+    export const title = css\`
+      font-size: ${''};
+      margin: 6px;
+    \`;
+    `
+  );
+
+  expect(code).toMatchSnapshot();
+  expect(metadata).toMatchSnapshot();
+});
+
 it('transpiles css template literal', async () => {
   const { code, metadata } = await transpile(
     dedent`

--- a/src/babel/evaluators/templateProcessor.ts
+++ b/src/babel/evaluators/templateProcessor.ts
@@ -146,6 +146,11 @@ export default function getTemplateProcessor(options: StrictOptions) {
             const value = valueCache.get(ex.node);
             throwIfInvalid(value, ex);
 
+            // Skip the blank string instead of throwing an error
+            if (value === '') {
+              return;
+            }
+
             if (value && typeof value !== 'function') {
               // Only insert text for non functions
               // We don't touch functions because they'll be interpolated at runtime


### PR DESCRIPTION
This will handle blank string values. Sometime after version 1.3.3 the library started throwing an error about being unable to compile blank string values. Now it will just skip the value instead of throwing an error.

## Motivation

We have some mixins which will return a blank string if no conditions are met. Our expectation is that a blank string will cause the CSS property to be ignored (not included) by the compiler.

## Summary

This PR will cause Linaria to skip blank string values, aka '', instead of throwing an error that linaria does not know how to compile the value.

## Test plan

`yarn test`
