### PR TITLE
fix: pass babelOptions to initial transform

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -55,11 +55,12 @@ export default function transform(code: string, options: Options): Result {
   );
 
   const pluginOptions = loadOptions(options.pluginOptions);
+  const babelOptions = pluginOptions?.babelOptions ?? null;
 
   // Parse the code first so babel uses user's babel config for parsing
   // We don't want to use user's config when transforming the code
   const ast = babel.parseSync(code, {
-    ...(pluginOptions?.babelOptions ?? null),
+    ...babelOptions,
     filename: options.filename,
     caller: { name: 'linaria' },
   });
@@ -68,6 +69,7 @@ export default function transform(code: string, options: Options): Result {
     ast!,
     code,
     {
+      ...babelOptions,
       filename: options.filename,
       presets: [[babelPreset, pluginOptions]],
       babelrc: false,

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -69,7 +69,7 @@ export default function transform(code: string, options: Options): Result {
     ast!,
     code,
     {
-      ...babelOptions,
+      ...(babelOptions?.rootMode ? { rootMode: babelOptions.rootMode } : null),
       filename: options.filename,
       presets: [[babelPreset, pluginOptions]],
       babelrc: false,


### PR DESCRIPTION
## Motivation

When Linaria is used in monorepo, one of the possible setups assumes having one `babel.config.js` in the repo root. In order to make it work, we have to set `rootMode: upward`
```js
{
        test: /\.jsx?$/,
        exclude: [/node_modules/],
        use: [
          {
            loader: 'babel-loader',
            options: {
              rootMode: 'upward',
            }
          },
          {
            loader: 'linaria/loader',
            options: {
              sourceMap: process.env.NODE_ENV !== 'production',
              babelOptions: {
                rootMode: 'upward',
              }
            },
          },
        ],
      },
```
In webpack.

During the evaluation, we use file path to generate a `slug` that is used to generate `className`.
https://github.com/callstack/linaria/blob/fb65ee41bf569baa78affbdb2fb74d6bc8784b60/src/babel/visitors/TaggedTemplateExpression.ts#L167-L175

It happens that **different** slug is generated in basic `evaluation` comparing to `pre-evaluation` for getting dependencies. It happens because we pass `babelOptions` only in `pre-evaluation` which changes the `state.file.opts.root` (because of different rootMode) which results in different paths in these two evaluations for the same component.

So for example in 'eval' I had
`root: 'Project/app', filename: 'src/Component.js'`
and relative path: `src/Component.js`

in `pre-eval'
`root: 'Project/'`, filename 'src/Component.js'`
and relative path: `app/src/Component.js`

## Summary

I spread `babelOptions` in initial babel transform options

## Test plan

I can provide a repro is someone wants to test manually. We don't have any test for this case so CI will be green 
