### PR TITLE
patch: issue 597

### DIFF
--- a/src/__fixtures__/components-library.js
+++ b/src/__fixtures__/components-library.js
@@ -3,3 +3,4 @@ import { styled } from '../react';
 export const T1 = styled.h1`background: #111;`;
 export const T2 = styled.h2`background: #222;`;
 export const T3 = styled.h3`${T2} { background: #333; }`;
+export default styled.p`background: #333;`;

--- a/src/__tests__/__snapshots__/preval.test.ts.snap
+++ b/src/__tests__/__snapshots__/preval.test.ts.snap
@@ -851,6 +851,61 @@ Dependencies: NA
 
 `;
 
+exports[`extractor should process \`styled\` calls inside components 1`] = `
+"import React from 'react';
+import { css } from 'linaria';
+export function Component() {
+  const opacity = 0.2;
+  const MyComponent = styled.h1\`
+    opacity: \${opacity};
+  \`;
+  return React.createElement(MyComponent);
+}"
+`;
+
+exports[`extractor should process \`styled\` calls inside components 2`] = `Object {}`;
+
+exports[`extractor should process \`styled\` calls with complex interpolation inside components 1`] = `
+"import React from 'react';
+import { css } from 'linaria';
+const globalObj = {
+  opacity: 0.5
+};
+const Styled1 = styled.p\`
+  opacity: \${globalObj.opacity}
+\`;
+export function Component() {
+  const classes = {
+    value: 0.2,
+    cell: \\"cell_c1xha7dm\\"
+  };
+  const classes2 = classes;
+  const MyComponent = styled\`
+    opacity: \${globalObj.opacity};
+
+    &:hover .\${classes2.cell} {
+      opacity: \${classes.value};
+    }
+    \${Styled1} {
+      font-size: 1;
+    }
+  \`;
+  return React.createElement(MyComponent);
+}"
+`;
+
+exports[`extractor should process \`styled\` calls with complex interpolation inside components 2`] = `
+
+CSS:
+
+.cell_c1xha7dm {
+      opacity: 0;
+    }
+
+Dependencies: NA
+
+`;
+
 exports[`extractor should work with String and Number object 1`] = `
 "import { css } from 'linaria';
 export const style = \\"style_s1xha7dm\\";"
@@ -1880,6 +1935,61 @@ CSS:
       opacity: 0.2;
     }
   }
+
+Dependencies: NA
+
+`;
+
+exports[`shaker should process \`styled\` calls inside components 1`] = `
+"import React from 'react';
+import { css } from 'linaria';
+export function Component() {
+  const opacity = 0.2;
+  const MyComponent = styled.h1\`
+    opacity: \${opacity};
+  \`;
+  return React.createElement(MyComponent);
+}"
+`;
+
+exports[`shaker should process \`styled\` calls inside components 2`] = `Object {}`;
+
+exports[`shaker should process \`styled\` calls with complex interpolation inside components 1`] = `
+"import React from 'react';
+import { css } from 'linaria';
+const globalObj = {
+  opacity: 0.5
+};
+const Styled1 = styled.p\`
+  opacity: \${globalObj.opacity}
+\`;
+export function Component() {
+  const classes = {
+    value: 0.2,
+    cell: \\"cell_c1xha7dm\\"
+  };
+  const classes2 = classes;
+  const MyComponent = styled\`
+    opacity: \${globalObj.opacity};
+
+    &:hover .\${classes2.cell} {
+      opacity: \${classes.value};
+    }
+    \${Styled1} {
+      font-size: 1;
+    }
+  \`;
+  return React.createElement(MyComponent);
+}"
+`;
+
+exports[`shaker should process \`styled\` calls with complex interpolation inside components 2`] = `
+
+CSS:
+
+.cell_c1xha7dm {
+      opacity: 0;
+    }
 
 Dependencies: NA
 

--- a/src/__tests__/__snapshots__/preval.test.ts.snap
+++ b/src/__tests__/__snapshots__/preval.test.ts.snap
@@ -442,6 +442,10 @@ export const T2 = /*#__PURE__*/styled(\\"h2\\")({
 export const T3 = /*#__PURE__*/styled(\\"h3\\")({
   name: \\"T3\\",
   class: \\"T3_tmgfls7\\"
+});
+export default /*#__PURE__*/styled(\\"p\\")({
+  name: \\"components-library3\\",
+  class: \\"components-library3_c30gynh\\"
 });"
 `;
 
@@ -452,6 +456,7 @@ CSS:
 .T1_t11kcpnd {background: #111;}
 .T2_t1xdipzs {background: #222;}
 .T3_tmgfls7 {.T2_t1xdipzs { background: #333; }}
+.components-library3_c30gynh {background: #333;}
 
 Dependencies: NA
 
@@ -787,6 +792,33 @@ exports[`extractor non-hoistable identifiers 1`] = `
   11 | \`;"
 `;
 
+exports[`extractor should handle shadowed identifier inside components 1`] = `
+"import React from 'react';
+import { css } from 'linaria';
+const color = 'red';
+var _ref = 'blue';
+var _ref2 = {
+  color: _ref
+};
+export default function Component() {
+  const color = _ref;
+  const val = _ref2;
+  return React.createElement('div', {
+    className: \\"className_c1xha7dm\\"
+  });
+}"
+`;
+
+exports[`extractor should handle shadowed identifier inside components 2`] = `
+
+CSS:
+
+.className_c1xha7dm {background-color:blue;}
+
+Dependencies: NA
+
+`;
+
 exports[`extractor should process \`css\` calls inside components 1`] = `
 "import React from 'react';
 import { css } from 'linaria';
@@ -814,17 +846,20 @@ Dependencies: NA
 exports[`extractor should process \`css\` calls with complex interpolation inside components 1`] = `
 "import React from 'react';
 import { css } from 'linaria';
+import externalDep from '../__fixtures__/sample-script';
 const globalObj = {
   opacity: 0.5
 };
-var _ref = {
+var _ref = externalDep;
+var _ref2 = {
   value: 0.2,
   cell: \\"cell_c1xha7dm\\"
 };
-var _ref2 = _ref;
+var _ref3 = _ref2;
 export function Component() {
-  const classes = _ref;
-  const classes2 = _ref2;
+  const classes = _ref2;
+  const classes2 = _ref3;
+  const referencedExternalDep = _ref;
   const className = \\"className_c1rsdnkv\\";
   return React.createElement(\\"div\\", {
     className
@@ -841,13 +876,15 @@ CSS:
     }
 .className_c1rsdnkv {
     opacity: 0.5;
+    font-size: 42
+    font-size: 42
 
     &:hover .cell_c1xha7dm {
       opacity: 0.2;
     }
   }
 
-Dependencies: NA
+Dependencies: @babel/runtime/helpers/interopRequireDefault, ../__fixtures__/sample-script
 
 `;
 
@@ -1493,6 +1530,10 @@ export const T2 = /*#__PURE__*/styled(\\"h2\\")({
 export const T3 = /*#__PURE__*/styled(\\"h3\\")({
   name: \\"T3\\",
   class: \\"T3_tmgfls7\\"
+});
+export default /*#__PURE__*/styled(\\"p\\")({
+  name: \\"components-library3\\",
+  class: \\"components-library3_c30gynh\\"
 });"
 `;
 
@@ -1503,6 +1544,7 @@ CSS:
 .T1_t11kcpnd {background: #111;}
 .T2_t1xdipzs {background: #222;}
 .T3_tmgfls7 {.T2_t1xdipzs { background: #333; }}
+.components-library3_c30gynh {background: #333;}
 
 Dependencies: NA
 
@@ -1838,6 +1880,33 @@ exports[`shaker non-hoistable identifiers 1`] = `
   11 | \`;"
 `;
 
+exports[`shaker should handle shadowed identifier inside components 1`] = `
+"import React from 'react';
+import { css } from 'linaria';
+const color = 'red';
+var _ref = 'blue';
+var _ref2 = {
+  color: _ref
+};
+export default function Component() {
+  const color = _ref;
+  const val = _ref2;
+  return React.createElement('div', {
+    className: \\"className_c1xha7dm\\"
+  });
+}"
+`;
+
+exports[`shaker should handle shadowed identifier inside components 2`] = `
+
+CSS:
+
+.className_c1xha7dm {background-color:blue;}
+
+Dependencies: NA
+
+`;
+
 exports[`shaker should interpolate imported components 1`] = `
 "import { css } from \\"linaria\\";
 import { Title } from \\"../__fixtures__/complex-component\\";
@@ -1903,17 +1972,20 @@ Dependencies: NA
 exports[`shaker should process \`css\` calls with complex interpolation inside components 1`] = `
 "import React from 'react';
 import { css } from 'linaria';
+import externalDep from '../__fixtures__/sample-script';
 const globalObj = {
   opacity: 0.5
 };
-var _ref = {
+var _ref = externalDep;
+var _ref2 = {
   value: 0.2,
   cell: \\"cell_c1xha7dm\\"
 };
-var _ref2 = _ref;
+var _ref3 = _ref2;
 export function Component() {
-  const classes = _ref;
-  const classes2 = _ref2;
+  const classes = _ref2;
+  const classes2 = _ref3;
+  const referencedExternalDep = _ref;
   const className = \\"className_c1rsdnkv\\";
   return React.createElement(\\"div\\", {
     className
@@ -1930,13 +2002,15 @@ CSS:
     }
 .className_c1rsdnkv {
     opacity: 0.5;
+    font-size: 42
+    font-size: 42
 
     &:hover .cell_c1xha7dm {
       opacity: 0.2;
     }
   }
 
-Dependencies: NA
+Dependencies: @babel/runtime/helpers/interopRequireDefault, ../__fixtures__/sample-script
 
 `;
 

--- a/src/__tests__/__snapshots__/preval.test.ts.snap
+++ b/src/__tests__/__snapshots__/preval.test.ts.snap
@@ -769,6 +769,30 @@ Dependencies: NA
 
 `;
 
+exports[`extractor it should not throw location error for hoisted identifier 1`] = `
+"import React from 'react';
+import { css } from 'linaria';
+
+const size = () => 5;
+
+var _ref = size();
+
+export default function Component() {
+  const color = _ref;
+  return \\"source0_s1xha7dm\\";
+}"
+`;
+
+exports[`extractor it should not throw location error for hoisted identifier 2`] = `
+
+CSS:
+
+.source0_s1xha7dm {opacity:5;}
+
+Dependencies: NA
+
+`;
+
 exports[`extractor non-hoistable identifiers 1`] = `
 "<<DIRNAME>>/source.js: An error occurred when evaluating the expression: 
 
@@ -1852,6 +1876,30 @@ CSS:
 .Title_t1xha7dm {
   position: absolute; top: 0; right: 0; bottom: 0; left: 0;
 }
+
+Dependencies: NA
+
+`;
+
+exports[`shaker it should not throw location error for hoisted identifier 1`] = `
+"import React from 'react';
+import { css } from 'linaria';
+
+const size = () => 5;
+
+var _ref = size();
+
+export default function Component() {
+  const color = _ref;
+  return \\"source0_s1xha7dm\\";
+}"
+`;
+
+exports[`shaker it should not throw location error for hoisted identifier 2`] = `
+
+CSS:
+
+.source0_s1xha7dm {opacity:5;}
 
 Dependencies: NA
 

--- a/src/__tests__/evaluators/__snapshots__/extractor.test.ts.snap
+++ b/src/__tests__/evaluators/__snapshots__/extractor.test.ts.snap
@@ -153,10 +153,10 @@ exports[`shakes sequence expression 1`] = `
   var _ = require(\\"\\\\u2026\\");
 
   {
-    let local = '';
-    {
-      const color1 = () => 'blue';
+    const color1 = () => 'blue';
 
+    {
+      let local = '';
       {
         const color2 = () => local;
 
@@ -171,11 +171,11 @@ exports[`shakes sequence expression 1`] = `
 
 exports[`should keep member expression key 1`] = `
 "{
-  const obj = {
-    blue: '#00F'
-  };
+  const key = 'blue';
   {
-    const key = 'blue';
+    const obj = {
+      blue: '#00F'
+    };
     {
       const blue = obj[key];
       {

--- a/src/__tests__/preval.test.ts
+++ b/src/__tests__/preval.test.ts
@@ -828,6 +828,27 @@ function run(
     expect(metadata).toMatchSnapshot();
   });
 
+  it('should process `styled` calls inside components', async () => {
+    const { code, metadata } = await transpile(
+      dedent`
+      import React from 'react'
+      import {css} from 'linaria'
+
+      export function Component() {
+        const opacity = 0.2;
+        const MyComponent = styled.h1\`
+          opacity: ${'${opacity}'};
+        \`;
+
+        return React.createElement(MyComponent);
+      }
+      `
+    );
+
+    expect(code).toMatchSnapshot();
+    expect(metadata).toMatchSnapshot();
+  });
+
   it('should process `css` calls with complex interpolation inside components', async () => {
     const { code, metadata } = await transpile(
       dedent`
@@ -859,6 +880,50 @@ function run(
         return React.createElement("div", { className });
       }
       `
+    );
+
+    expect(code).toMatchSnapshot();
+    expect(metadata).toMatchSnapshot();
+  });
+
+  it('should process `styled` calls with complex interpolation inside components', async () => {
+    const { code, metadata } = await transpile(
+      dedent`
+        import React from 'react'
+        import {css} from 'linaria'
+  
+        const globalObj = {
+          opacity: 0.5,
+        };
+        
+        const Styled1 = styled.p\`
+          opacity: ${'${globalObj.opacity}'}
+        \`
+
+        export function Component() {
+          const classes = {
+            value: 0.2,
+            cell: css\`
+              opacity: 0;
+            \`,
+          };
+  
+          const classes2 = classes;
+  
+          const MyComponent = styled\`
+            opacity: ${'${globalObj.opacity}'};
+  
+            &:hover .${'${classes2.cell}'} {
+              opacity: ${'${classes.value}'};
+            }
+            ${'${Styled1}'} {
+              font-size: 1;
+            }
+          \`;
+  
+          return React.createElement(MyComponent);
+        }
+        `
     );
 
     expect(code).toMatchSnapshot();

--- a/src/__tests__/preval.test.ts
+++ b/src/__tests__/preval.test.ts
@@ -854,7 +854,7 @@ function run(
       dedent`
       import React from 'react'
       import {css} from 'linaria'
-
+      import externalDep from '../__fixtures__/sample-script';
       const globalObj = {
         opacity: 0.5,
       };
@@ -868,9 +868,12 @@ function run(
         };
 
         const classes2 = classes;
+        const referencedExternalDep = externalDep
 
         const className = css\`
           opacity: ${'${globalObj.opacity}'};
+          font-size: ${'${externalDep}'}
+          font-size: ${'${referencedExternalDep}'}
 
           &:hover .${'${classes2.cell}'} {
             opacity: ${'${classes.value}'};
@@ -922,6 +925,26 @@ function run(
           \`;
   
           return React.createElement(MyComponent);
+        }
+        `
+    );
+
+    expect(code).toMatchSnapshot();
+    expect(metadata).toMatchSnapshot();
+  });
+
+  it('should handle shadowed identifier inside components', async () => {
+    const { code, metadata } = await transpile(
+      dedent`
+        import React from 'react'
+        import {css} from 'linaria'
+        
+        const color = 'red';
+
+        export default function Component() {
+          const color = 'blue'
+          const val = { color };
+          return React.createElement('div', {className: css\`background-color:${'${val.color}'};\`});
         }
         `
     );

--- a/src/__tests__/preval.test.ts
+++ b/src/__tests__/preval.test.ts
@@ -953,6 +953,24 @@ function run(
     expect(metadata).toMatchSnapshot();
   });
 
+  it('it should not throw location error for hoisted identifier', async () => {
+    const { code, metadata } = await transpile(
+      dedent`
+        import React from 'react'
+        import {css} from 'linaria'
+        
+        const size = () => 5
+        export default function Component() {
+          const color = size()
+          return css\`opacity:${'${color}'};\`
+        }
+        `
+    );
+
+    expect(code).toMatchSnapshot();
+    expect(metadata).toMatchSnapshot();
+  });
+
   strategyDependentTests(transpile);
 }
 

--- a/src/babel/evaluators/extractor/index.ts
+++ b/src/babel/evaluators/extractor/index.ts
@@ -62,7 +62,6 @@ const extractor: Evaluator = (filename, options, text, only = null) => {
   // reuses `NodePath` with a wrong scope.
   // There is probably a better solution, but I haven't found it yet.
   const ast = parseSync(code!, { filename: filename + '.preval' });
-
   // First of all, let's find a __linariaPreval export
   traverse(ast!, {
     // We know that export has been added to the program body,

--- a/src/babel/types.ts
+++ b/src/babel/types.ts
@@ -31,6 +31,7 @@ export type ComponentValue = {
 export type LazyValue = {
   kind: ValueType.LAZY;
   ex: NodePath<t.Expression> | t.Expression | string;
+  originalEx: NodePath<t.Expression> | t.Expression | string;
 };
 
 export type FunctionValue = {


### PR DESCRIPTION
## Motivation

Patch to PR with statements hoisting that fixes two issues:
- sometimes it happened that statements were in different orders which result in the import was defined below its usage.
- during hoisting, if an expression was an identifier, it was replaced with a new identifier that refers to a hoisted value. New identifiers didn't have `start`, `end`, `loc` which result in an error in `templateProcessor`.

## Summary

I ported sorting statements from `1.3.x`

I make Linaria use a clone of the original statement during evaluation.

Additionally, I added tests for the usage of `styled` in not top-level scope similarly to `css`

## Test plan
New tests added
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->
