### PR TITLE
Untangle core/css from babel

### DIFF
--- a/src/__tests__/styled.test.js
+++ b/src/__tests__/styled.test.js
@@ -1,6 +1,7 @@
 const React = require('react');
 const renderer = require('react-test-renderer');
 const styled = require('../react/styled').default;
+const { isStyledMeta } = require('../core/types');
 
 it('renders tag with display name and class name', () => {
   const Test = styled('h1')({
@@ -253,4 +254,9 @@ it('throws when using as tag for template literal', () => {
         color: blue;
       `
   ).toThrow('Using the "styled" tag in runtime is not supported');
+});
+
+it('returns an object that is StyledMeta', () => {
+  const Test = styled('div')({});
+  expect(isStyledMeta(Test)).toBe(true);
 });

--- a/src/babel/evaluators/templateProcessor.ts
+++ b/src/babel/evaluators/templateProcessor.ts
@@ -10,7 +10,7 @@ import generator from '@babel/generator';
 
 import { units } from '../units';
 import { State, StrictOptions, TemplateExpression, ValueCache } from '../types';
-import { StyledMeta } from '../../types';
+import { isStyledMeta } from '../../core/types';
 
 import isSerializable from '../utils/isSerializable';
 import { debug } from '../utils/logger';
@@ -28,10 +28,6 @@ type Interpolation = {
   source: string;
   unit: string;
 };
-
-function hasMeta(value: any): value is StyledMeta {
-  return value && typeof value === 'object' && (value as any).__linaria;
-}
 
 const processedPaths = new WeakSet();
 
@@ -165,7 +161,7 @@ export default function getTemplateProcessor(options: StrictOptions) {
               // Only insert text for non functions
               // We don't touch functions because they'll be interpolated at runtime
 
-              if (hasMeta(value)) {
+              if (isStyledMeta(value)) {
                 // If it's an React component wrapped in styled, get the class name
                 // Useful for interpolating components
                 cssText += `.${value.__linaria.className}`;
@@ -214,7 +210,7 @@ export default function getTemplateProcessor(options: StrictOptions) {
       // it'll ensure that styles are overridden properly
       if (options.evaluate && types.isIdentifier(styled.component.node)) {
         let value = valueCache.get(styled.component.node.name);
-        while (hasMeta(value)) {
+        while (isStyledMeta(value)) {
           selector += `.${value.__linaria.className}`;
           value = value.__linaria.extends;
         }

--- a/src/babel/evaluators/templateProcessor.ts
+++ b/src/babel/evaluators/templateProcessor.ts
@@ -209,7 +209,7 @@ export default function getTemplateProcessor(options: StrictOptions) {
       // get its class name to create a more specific selector
       // it'll ensure that styles are overridden properly
       if (options.evaluate && types.isIdentifier(styled.component.node)) {
-        let value = valueCache.get(styled.component.node.name);
+        let value: unknown = valueCache.get(styled.component.node.name);
         while (isStyledMeta(value)) {
           selector += `.${value.__linaria.className}`;
           value = value.__linaria.extends;

--- a/src/babel/types.ts
+++ b/src/babel/types.ts
@@ -1,6 +1,6 @@
 import { types as t, TransformOptions } from '@babel/core';
 import { NodePath } from '@babel/traverse';
-import { StyledMeta } from '../types';
+import { StyledMeta } from '../core/types';
 
 export type JSONValue = string | number | boolean | JSONObject | JSONArray;
 

--- a/src/babel/utils/throwIfInvalid.ts
+++ b/src/babel/utils/throwIfInvalid.ts
@@ -1,17 +1,26 @@
 import generator from '@babel/generator';
 import isSerializable from './isSerializable';
 import { Serializable } from '../types';
+import { StyledMeta, isStyledMeta } from '../../core/types';
 
 // Throw if we can't handle the interpolated value
 function throwIfInvalid(
-  value: Error | Function | string | number | Serializable | undefined,
+  value:
+    | Error
+    | Function
+    | string
+    | number
+    | StyledMeta
+    | Serializable
+    | undefined,
   ex: any
 ): void {
   if (
     typeof value === 'function' ||
     typeof value === 'string' ||
     (typeof value === 'number' && Number.isFinite(value)) ||
-    isSerializable(value)
+    isSerializable(value) ||
+    isStyledMeta(value)
   ) {
     return;
   }

--- a/src/core/css.ts
+++ b/src/core/css.ts
@@ -1,4 +1,4 @@
-import { StyledMeta } from '../types';
+import { StyledMeta } from './types';
 
 type CSSProperties = {
   [key: string]: string | number | CSSProperties;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,20 @@
+/**
+ * Styled Components created by 'styled' from linaria/react have type
+ * 'React.ComponentType & StyledMeta'. We allow these values in `css()`
+ * interpolations to support cases like this:
+ *
+ *     const Button = styled.button`color: red;`;
+ *     const className = css`& .${Button} {color: blue;}`;
+ *
+ * Users of the linaria library are not expected to create values of this
+ * type manually.
+ */
+export interface StyledMeta {
+  __linaria: {
+    className: string;
+    extends: StyledMeta;
+  };
+}
+
+export const isStyledMeta = (x: unknown): x is StyledMeta =>
+  typeof (x as any)?.__linaria === 'object';

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -12,7 +12,7 @@
 export interface StyledMeta {
   __linaria: {
     className: string;
-    extends: StyledMeta;
+    extends: null | StyledMeta;
   };
 }
 

--- a/src/react/styled.ts
+++ b/src/react/styled.ts
@@ -7,7 +7,7 @@
 import * as React from 'react'; // eslint-disable-line import/no-extraneous-dependencies
 import validAttr from '@emotion/is-prop-valid';
 import { cx } from '../index';
-import { StyledMeta } from '../types';
+import { StyledMeta } from '../core/types';
 
 type Options = {
   name: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,12 +43,5 @@ export type Options = {
   pluginOptions?: Partial<PluginOptions>;
 };
 
-export type StyledMeta = {
-  __linaria: {
-    className: string;
-    extends: StyledMeta;
-  };
-};
-
 export type PreprocessorFn = (selector: string, cssText: string) => string;
 export type Preprocessor = 'none' | 'stylis' | PreprocessorFn | void;


### PR DESCRIPTION
Alternative fix for #599, much simpler than my previous attempt.

After this change, core/css.ts does not have any imports, it's a fully self-contained module. This very likely also improves typechecking performance for Linaria users as TypeScript won't have to load all the other modules (from Linaria or its dependencies, in particular babel).