### PR TITLE
feat: inlined styles composition

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "typescript.tsdk": "website/node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/src/__tests__/__snapshots__/babel.test.ts.snap
+++ b/src/__tests__/__snapshots__/babel.test.ts.snap
@@ -42,7 +42,11 @@ exports[`evaluates and inlines expressions in scope 1`] = `
 const color = 'blue';
 export const Title = /*#__PURE__*/styled(\\"h1\\")({
   name: \\"Title\\",
-  class: \\"th6xni0\\"
+  class: \\"th6xni0\\",
+  vars: {
+    \\"th6xni0-0\\": [color],
+    \\"th6xni0-1\\": [100 / 3, \\"%\\"]
+  }
 });"
 `;
 
@@ -51,8 +55,8 @@ exports[`evaluates and inlines expressions in scope 2`] = `
 CSS:
 
 .th6xni0 {
-  color: blue;
-  width: 33.333333333333336%;
+  color: var(--th6xni0-0);
+  width: var(--th6xni0-1);
 }
 
 Dependencies: NA
@@ -228,7 +232,10 @@ const styles = [{
 }];
 export const Title = /*#__PURE__*/styled(\\"h1\\")({
   name: \\"Title\\",
-  class: \\"th6xni0\\"
+  class: \\"th6xni0\\",
+  vars: {
+    \\"th6xni0-0\\": [styles]
+  }
 });"
 `;
 
@@ -237,7 +244,7 @@ exports[`inlines array styles as CSS string 2`] = `
 CSS:
 
 .th6xni0 {
-  flex: 1; display: block; height: 24px;
+  var(--th6xni0-0)
 }
 
 Dependencies: NA
@@ -274,7 +281,10 @@ const cover = {
 };
 export const Title = /*#__PURE__*/styled(\\"h1\\")({
   name: \\"Title\\",
-  class: \\"th6xni0\\"
+  class: \\"th6xni0\\",
+  vars: {
+    \\"th6xni0-0\\": [cover]
+  }
 });"
 `;
 
@@ -283,7 +293,7 @@ exports[`inlines object styles as CSS string 2`] = `
 CSS:
 
 .th6xni0 {
-  position: absolute; top: 0; right: 0; bottom: 0; left: 0; opacity: 1; min-height: 420px; &.shouldNotBeChanged { border-color: #fff; } @media (min-width: 200px) { -webkit-opacity: 0.8; -moz-opacity: 0.8; -ms-opacity: 0.8; -o-opacity: 0.8; -webkit-border-radius: 2px; -moz-border-radius: 2px; -ms-border-radius: 2px; -o-border-radius: 2px; -webkit-transition: 400ms; -moz-transition: 400ms; -o-transition: 400ms; -ms-transition: 400ms; }
+  var(--th6xni0-0)
 }
 
 Dependencies: NA

--- a/src/__tests__/__snapshots__/preval.test.ts.snap
+++ b/src/__tests__/__snapshots__/preval.test.ts.snap
@@ -816,6 +816,82 @@ exports[`extractor non-hoistable identifiers 1`] = `
   11 | \`;"
 `;
 
+exports[`extractor should compose class name 1`] = `
+"import { css } from \\"linaria\\";
+export const text = \\"text_t1xha7dm\\";
+export const fragment = \\"fragment_f1rsdnkv\\";
+export const square = \\"square_sdu5vkq\\";"
+`;
+
+exports[`extractor should compose class name 2`] = `
+
+CSS:
+
+.text_t1xha7dm {}
+.fragment_f1rsdnkv {
+  color: bluish;
+}
+.square_sdu5vkq {
+  .text_t1xha7dm {
+    color: red;
+  }
+  
+  color: bluish;
+
+}
+
+Dependencies: NA
+
+`;
+
+exports[`extractor should compose with css 1`] = `
+"import { css } from \\"linaria\\";
+export const fragment = \\"fragment_f1xha7dm\\";
+export const square = \\"square_s1rsdnkv fragment_f1xha7dm\\";"
+`;
+
+exports[`extractor should compose with css 2`] = `
+
+CSS:
+
+.fragment_f1xha7dm {
+  color: blue;
+}
+.square_s1rsdnkv {
+  color: red;
+  composes: ;
+}
+
+Dependencies: NA
+
+`;
+
+exports[`extractor should compose with styled 1`] = `
+"import { css } from \\"linaria\\";
+import { styled } from \\"linaria/react\\";
+export const fragment = \\"fragment_f1xha7dm\\";
+export const Component = /*#__PURE__*/styled(\\"h1\\")({
+  name: \\"Component\\",
+  class: \\"Component_c1rsdnkv fragment_f1xha7dm\\"
+});"
+`;
+
+exports[`extractor should compose with styled 2`] = `
+
+CSS:
+
+.fragment_f1xha7dm {
+  color: blue;
+}
+.Component_c1rsdnkv {
+  composes:;
+  color: red;
+}
+
+Dependencies: NA
+
+`;
+
 exports[`extractor should handle shadowed identifier inside components 1`] = `
 "import React from 'react';
 import { css } from 'linaria';
@@ -846,8 +922,9 @@ Dependencies: NA
 exports[`extractor should process \`css\` calls inside components 1`] = `
 "import React from 'react';
 import { css } from 'linaria';
+var _ref = 0.2;
 export function Component() {
-  const opacity = 0.2;
+  const opacity = _ref;
   const className = \\"className_c1xha7dm\\";
   return React.createElement(\\"div\\", {
     className
@@ -1928,6 +2005,82 @@ exports[`shaker non-hoistable identifiers 1`] = `
   11 | \`;"
 `;
 
+exports[`shaker should compose class name 1`] = `
+"import { css } from \\"linaria\\";
+export const text = \\"text_t1xha7dm\\";
+export const fragment = \\"fragment_f1rsdnkv\\";
+export const square = \\"square_sdu5vkq\\";"
+`;
+
+exports[`shaker should compose class name 2`] = `
+
+CSS:
+
+.text_t1xha7dm {}
+.fragment_f1rsdnkv {
+  color: bluish;
+}
+.square_sdu5vkq {
+  .text_t1xha7dm {
+    color: red;
+  }
+  
+  color: bluish;
+
+}
+
+Dependencies: NA
+
+`;
+
+exports[`shaker should compose with css 1`] = `
+"import { css } from \\"linaria\\";
+export const fragment = \\"fragment_f1xha7dm\\";
+export const square = \\"square_s1rsdnkv fragment_f1xha7dm\\";"
+`;
+
+exports[`shaker should compose with css 2`] = `
+
+CSS:
+
+.fragment_f1xha7dm {
+  color: blue;
+}
+.square_s1rsdnkv {
+  color: red;
+  composes: ;
+}
+
+Dependencies: NA
+
+`;
+
+exports[`shaker should compose with styled 1`] = `
+"import { css } from \\"linaria\\";
+import { styled } from \\"linaria/react\\";
+export const fragment = \\"fragment_f1xha7dm\\";
+export const Component = /*#__PURE__*/styled(\\"h1\\")({
+  name: \\"Component\\",
+  class: \\"Component_c1rsdnkv fragment_f1xha7dm\\"
+});"
+`;
+
+exports[`shaker should compose with styled 2`] = `
+
+CSS:
+
+.fragment_f1xha7dm {
+  color: blue;
+}
+.Component_c1rsdnkv {
+  composes:;
+  color: red;
+}
+
+Dependencies: NA
+
+`;
+
 exports[`shaker should handle shadowed identifier inside components 1`] = `
 "import React from 'react';
 import { css } from 'linaria';
@@ -1996,8 +2149,9 @@ Dependencies: ../__fixtures__/complex-component
 exports[`shaker should process \`css\` calls inside components 1`] = `
 "import React from 'react';
 import { css } from 'linaria';
+var _ref = 0.2;
 export function Component() {
-  const opacity = 0.2;
+  const opacity = _ref;
   const className = \\"className_c1xha7dm\\";
   return React.createElement(\\"div\\", {
     className

--- a/src/__tests__/evaluators/__snapshots__/preeval.test.ts.snap
+++ b/src/__tests__/evaluators/__snapshots__/preeval.test.ts.snap
@@ -3,14 +3,14 @@
 exports[`handles locally named import 1`] = `
 "import { styled as custom } from 'linaria/react';
 const Component =
-/*linaria ca1zxek Component Component_ca1zxek*/
+/*linaria ca1zxek Component*/
 custom.div\`\`;"
 `;
 
 exports[`preserves classNames 1`] = `
 "import { styled } from 'linaria/react';
 const Component =
-/*linaria ca1zxek Component Component_ca1zxek*/
+/*linaria ca1zxek Component*/
 styled.div\`\`;"
 `;
 

--- a/src/__tests__/preval.test.ts
+++ b/src/__tests__/preval.test.ts
@@ -807,6 +807,48 @@ function run(
     expect(metadata).toMatchSnapshot();
   });
 
+  it('should compose with css', async () => {
+    const { code, metadata } = await transpile(
+      dedent`
+      import { css } from "linaria";
+
+      export const fragment = css\`
+        color: blue;
+      \`;
+
+      export const square = css\`
+        color: red;
+        composes: ${'${fragment}'};
+      \`;
+    `
+    );
+
+    expect(code).toMatchSnapshot();
+    expect(metadata).toMatchSnapshot();
+  });
+
+  it('should compose with styled', async () => {
+    const { code, metadata } = await transpile(
+      dedent`
+      import { css } from "linaria";
+      import { styled } from "linaria/react";
+
+
+      export const fragment = css\`
+        color: blue;
+      \`;
+
+      export const Component = styled.h1\`
+        composes:${'${fragment}'};
+        color: red;
+      \`;
+    `
+    );
+
+    expect(code).toMatchSnapshot();
+    expect(metadata).toMatchSnapshot();
+  });
+
   it('should process `css` calls inside components', async () => {
     const { code, metadata } = await transpile(
       dedent`

--- a/src/babel/evaluators/collectCompose.ts
+++ b/src/babel/evaluators/collectCompose.ts
@@ -1,0 +1,41 @@
+export default `
+function __linariaHasCSSMeta(value) {
+  return value && typeof value === 'object' && value?.__linaria?.type === 'css';
+}
+
+const __linariaCollectCompose = (strings, ...values) => className => {
+  const stylesArr = [];
+  let replacements = {};
+  let replacementCounter = 0;
+
+  // need to get non-primitive types and then create places for replacements
+  // need to pass fileNameHash to identify nested replacements
+
+  strings.forEach((string, index) => {
+    // is reference to a class, not prepended with a dot
+    stylesArr.push(string);
+    if (index < strings.length - 1) {
+      const value = values[index];
+      if (
+        __linariaHasCSSMeta(value) &&
+        strings[index].charAt(strings[index].length - 1) !== '.'
+      ) {
+        replacements = {
+          ...replacements,
+          ...value.__linaria.composes.replacements,
+        };
+        stylesArr.push(value.__linaria.composes.styles);
+      } else {
+        if (typeof value !== 'object' && typeof value !== 'function') {
+          stylesArr.push(value);
+        } else {
+          const replacementID = className + replacementCounter++;
+          stylesArr.push('%%' + replacementID + '%%');
+          replacements[replacementID] = value;
+        }
+      }
+    }
+  });
+  return { styles: stylesArr.join(''), replacements };
+};
+`;

--- a/src/babel/evaluators/extractor/index.ts
+++ b/src/babel/evaluators/extractor/index.ts
@@ -73,6 +73,7 @@ const extractor: Evaluator = (filename, options, text, only = null) => {
   // because there is some kind of cache inside `traverse` which
   // reuses `NodePath` with a wrong scope.
   // There is probably a better solution, but I haven't found it yet.
+
   const ast = parseSync(code!, { filename: filename + '.preval' });
   // First of all, let's find a __linariaPreval export
   traverse(ast!, {
@@ -110,6 +111,7 @@ const extractor: Evaluator = (filename, options, text, only = null) => {
             // Use String.raw to preserve escapes such as '\n' in the code
             String.raw`${generator(wrapped).code}`,
           ].join('\n');
+
           break;
         }
       }

--- a/src/babel/evaluators/preeval.ts
+++ b/src/babel/evaluators/preeval.ts
@@ -2,14 +2,19 @@
  * This file is a babel preset used to transform files inside evaluators.
  * It works the same as main `babel/extract` preset, but do not evaluate lazy dependencies.
  */
+
 import { NodePath } from '@babel/traverse';
 import { types } from '@babel/core';
+import {} from '@babel/template';
+
 import GenerateClassNames from '../visitors/GenerateClassNames';
 import DetectStyledImportName from '../visitors/DetectStyledImportName';
 import JSXElement from './visitors/JSXElement';
 import ProcessStyled from './visitors/ProcessStyled';
 import ProcessCSS from './visitors/ProcessCSS';
 import { State, StrictOptions } from '../types';
+
+import collectCompose from './collectCompose';
 
 function preeval(_babel: any, options: StrictOptions) {
   return {
@@ -22,6 +27,9 @@ function preeval(_babel: any, options: StrictOptions) {
           state.index = -1;
           state.dependencies = [];
           state.replacements = [];
+
+          // maybe would be easier to add it to vm context - we will avoid storing it as string
+          path.node.body.unshift(..._babel.parse(collectCompose).program.body);
 
           // We need our transforms to run before anything else
           // So we traverse here instead of a in a visitor

--- a/src/babel/evaluators/visitors/ProcessCSS.ts
+++ b/src/babel/evaluators/visitors/ProcessCSS.ts
@@ -5,15 +5,45 @@
 
 import { NodePath } from '@babel/traverse';
 import { types as t } from '@babel/core';
-import getLinariaComment from '../../utils/getLinariaComment';
+import { getLinariaComment } from '../../utils/linariaComment';
+import { expression } from '@babel/template';
+
+const collectComposeFnName = '__linariaCollectCompose';
+
+const linariaCSSTpl = expression(
+  `{
+    displayName: %%displayName%%,
+    __linaria: {
+      className: %%className%%,
+      type: 'css',
+      composes: %%composes%%,
+    },
+    toString() {
+      return className
+    }
+  }`
+);
 
 export default function ProcessCSS(path: NodePath<t.TaggedTemplateExpression>) {
   if (t.isIdentifier(path.node.tag) && path.node.tag.name === 'css') {
-    const [, , className] = getLinariaComment(path);
-    if (!className) {
+    const [slug, displayName, className] = getLinariaComment(path);
+    if (!slug) {
       return;
     }
 
-    path.replaceWith(t.stringLiteral(className));
+    // replace `css` with `__linariaCollectCompose` to be able to process nested interpolations in VM
+    const originalTaggedTemplateExpression = t.cloneNode(path.node);
+    originalTaggedTemplateExpression.tag = t.identifier(collectComposeFnName);
+    const callExpr = t.callExpression(originalTaggedTemplateExpression, [
+      t.stringLiteral(className || ''),
+    ]);
+
+    path.replaceWith(
+      linariaCSSTpl({
+        displayName: displayName ? t.stringLiteral(displayName) : null,
+        className: className ? t.stringLiteral(className) : null,
+        composes: callExpr,
+      })
+    );
   }
 }

--- a/src/babel/evaluators/visitors/ProcessStyled.ts
+++ b/src/babel/evaluators/visitors/ProcessStyled.ts
@@ -9,13 +9,14 @@
 
 import { NodePath } from '@babel/traverse';
 import { types } from '@babel/core';
-import getLinariaComment from '../../utils/getLinariaComment';
+import { getLinariaComment } from '../../utils/linariaComment';
 import { expression } from '@babel/template';
 
 const linariaComponentTpl = expression(
   `{
     displayName: %%displayName%%,
     __linaria: {
+      type: 'styled',
       className: %%className%%,
       extends: %%extends%%
     }
@@ -30,7 +31,7 @@ export default function ProcessStyled(path: NodePath<types.CallExpression>) {
 
   path.replaceWith(
     linariaComponentTpl({
-      className: types.stringLiteral(className),
+      className: className ? types.stringLiteral(className) : null,
       displayName: displayName ? types.stringLiteral(displayName) : null,
       extends: types.isCallExpression(path.node.callee)
         ? path.node.callee.arguments[0]

--- a/src/babel/types.ts
+++ b/src/babel/types.ts
@@ -1,8 +1,14 @@
 import { types as t, TransformOptions } from '@babel/core';
 import { NodePath } from '@babel/traverse';
-import { StyledMeta } from '../types';
+import { DefinitionMeta } from '../types';
 
-export type JSONValue = string | number | boolean | JSONObject | JSONArray;
+export type JSONValue =
+  | string
+  | number
+  | boolean
+  | JSONObject
+  | JSONArray
+  | null;
 
 export interface JSONObject {
   [x: string]: JSONValue;
@@ -19,7 +25,7 @@ export enum ValueType {
   VALUE,
 }
 
-export type Value = Function | StyledMeta | string | number;
+export type Value = Function | DefinitionMeta | string | number;
 
 export type ValueCache = Map<t.Expression | string, Value>;
 

--- a/src/babel/utils/linariaComment.ts
+++ b/src/babel/utils/linariaComment.ts
@@ -1,10 +1,10 @@
-import { types } from '@babel/core';
+import { types as t } from '@babel/core';
 import { NodePath } from '@babel/traverse';
 
 const pattern = /^linaria (.+)$/;
 
-export default function getLinariaComment(
-  path: NodePath<types.Node>,
+export function getLinariaComment(
+  path: NodePath<t.Node>,
   remove: boolean = true
 ) {
   const comments = path.node.leadingComments;
@@ -27,4 +27,13 @@ export default function getLinariaComment(
   }
 
   return matched[1].split(' ').map(i => (i ? i : null));
+}
+
+export function addLinariaComment(
+  path: NodePath<t.TaggedTemplateExpression>,
+  slug: string,
+  displayName: string,
+  className: string
+) {
+  path.addComment('leading', `linaria ${slug} ${displayName} ${className}`);
 }

--- a/src/babel/utils/throwIfInvalid.ts
+++ b/src/babel/utils/throwIfInvalid.ts
@@ -1,21 +1,30 @@
 import generator from '@babel/generator';
 import isSerializable from './isSerializable';
 import { Serializable } from '../types';
-
+import { DefinitionMeta } from '../../types';
+import { hasDefinitionMeta } from '../evaluators/templateProcessor';
 // Throw if we can't handle the interpolated value
 function throwIfInvalid(
-  value: Error | Function | string | number | Serializable | undefined,
+  value:
+    | Error
+    | Function
+    | string
+    | number
+    | Serializable
+    | undefined
+    | DefinitionMeta,
   ex: any
 ): void {
   if (
     typeof value === 'function' ||
     typeof value === 'string' ||
     (typeof value === 'number' && Number.isFinite(value)) ||
-    isSerializable(value)
+    isSerializable(value) ||
+    hasDefinitionMeta(value as DefinitionMeta)
   ) {
     return;
   }
-
+  value = value as Exclude<typeof value, DefinitionMeta>;
   // We can't use instanceof here so let's use duck typing
   if (value && typeof value !== 'number' && value.stack && value.message) {
     throw ex.buildCodeFrameError(

--- a/src/babel/utils/toCSS.ts
+++ b/src/babel/utils/toCSS.ts
@@ -15,6 +15,10 @@ const hyphenate = (s: string) =>
 // Some tools such as polished.js output JS objects
 // To support them transparently, we convert JS objects to CSS strings
 export default function toCSS(o: JSONValue): string {
+  if (o === null) {
+    return '';
+  }
+
   if (Array.isArray(o)) {
     return o.map(toCSS).join('\n');
   }

--- a/src/babel/visitors/CollectDependencies.ts
+++ b/src/babel/visitors/CollectDependencies.ts
@@ -9,7 +9,6 @@ import throwIfInvalid from '../utils/throwIfInvalid';
 import { State, StrictOptions, ValueType, ExpressionValue } from '../types';
 import { debug } from '../utils/logger';
 import isStyledOrCss from '../utils/isStyledOrCss';
-
 /**
  * Hoist the node and its dependencies to the highest scope possible
  */
@@ -64,7 +63,8 @@ export default function CollectDependencies(
   const expressionValues: ExpressionValue[] = expressions.map(
     (ex: NodePath<t.Expression>) => {
       const result = ex.evaluate();
-      if (result.confident) {
+      // eslint-disable-next-line
+      if (false && result.confident) {
         throwIfInvalid(result.value, ex);
         return { kind: ValueType.VALUE, value: result.value };
       }

--- a/src/babel/visitors/GenerateClassNames.ts
+++ b/src/babel/visitors/GenerateClassNames.ts
@@ -11,7 +11,7 @@ import { NodePath } from '@babel/traverse';
 import { State, StrictOptions } from '../types';
 import toValidCSSIdentifier from '../utils/toValidCSSIdentifier';
 import slugify from '../../slugify';
-import getLinariaComment from '../utils/getLinariaComment';
+import { getLinariaComment, addLinariaComment } from '../utils/linariaComment';
 import { debug } from '../utils/logger';
 import isStyledOrCss from '../utils/isStyledOrCss';
 
@@ -142,5 +142,5 @@ export default function GenerateClassNames(
   );
 
   // Save evaluated slug and displayName for future usage in templateProcessor
-  path.addComment('leading', `linaria ${slug} ${displayName} ${className}`);
+  addLinariaComment(path, slug, displayName, className);
 }

--- a/src/core/css.ts
+++ b/src/core/css.ts
@@ -1,4 +1,4 @@
-import { StyledMeta } from '../types';
+import { DefinitionMeta } from '../types';
 
 type CSSProperties = {
   [key: string]: string | number | CSSProperties;
@@ -6,7 +6,7 @@ type CSSProperties = {
 
 export default function css(
   _strings: TemplateStringsArray,
-  ..._exprs: Array<string | number | CSSProperties | StyledMeta>
+  ..._exprs: Array<string | number | CSSProperties | DefinitionMeta>
 ): string {
   throw new Error(
     'Using the "css" tag in runtime is not supported. Make sure you have set up the Babel plugin correctly.'

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -100,7 +100,6 @@ export default function loader(
 
   if (result.cssText) {
     let { cssText } = result;
-
     if (sourceMap) {
       cssText += `/*# sourceMappingURL=data:application/json;base64,${Buffer.from(
         result.cssSourceMapText || ''

--- a/src/react/styled.ts
+++ b/src/react/styled.ts
@@ -7,7 +7,7 @@
 import * as React from 'react'; // eslint-disable-line import/no-extraneous-dependencies
 import validAttr from '@emotion/is-prop-valid';
 import { cx } from '../index';
-import { StyledMeta } from '../types';
+import { DefinitionMeta } from '../types';
 
 type Options = {
   name: string;
@@ -142,12 +142,12 @@ type CSSProperties = {
   [key: string]: string | number | CSSProperties;
 };
 
-type StyledComponent<T> = StyledMeta &
+type StyledComponent<T> = DefinitionMeta &
   (T extends React.FunctionComponent<any>
     ? T
     : React.FunctionComponent<T & { as?: React.ElementType }>);
 
-type StaticPlaceholder = string | number | CSSProperties | StyledMeta;
+type StaticPlaceholder = string | number | CSSProperties | DefinitionMeta;
 
 type HtmlStyledTag<TName extends keyof JSX.IntrinsicElements> = <
   TAdditionalProps = {}
@@ -172,7 +172,7 @@ type ComponentStyledTag<T> = <
     ? Array<StaticPlaceholder | ((props: Props) => string | number)>
     : StaticPlaceholder[]
 ) => T extends React.FunctionComponent<any>
-  ? StyledMeta & T
+  ? DefinitionMeta & T
   : StyledComponent<Props>;
 
 type StyledJSXIntrinsics = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,12 +43,28 @@ export type Options = {
   pluginOptions?: Partial<PluginOptions>;
 };
 
-export type StyledMeta = {
+export type CSSMeta = {
+  displayName: string | null;
   __linaria: {
+    type: 'css';
     className: string;
-    extends: StyledMeta;
+    composes: {
+      styles: string;
+      replacements: { [key: string]: Function | Object };
+    };
   };
 };
 
+export type StyledMeta = {
+  displayName: string | null;
+  __linaria: {
+    type: 'styled';
+    className: string;
+    composes: CSSMeta | Array<CSSMeta> | null;
+    extends: StyledMeta | null;
+  };
+};
+
+export type DefinitionMeta = CSSMeta | StyledMeta;
 export type PreprocessorFn = (selector: string, cssText: string) => string;
 export type Preprocessor = 'none' | 'stylis' | PreprocessorFn | void;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

#244 
And being able to share styles between web and native in future RN support

## Summary

Todo:
- [ ] fix existing tests
- [ ] add new tests
- [ ] optimize if possible

Features:
- can compose `css` with other `css` or `styled`
- styles are composed by inlining, so place of the composition affects styling (intentional behaviour)
- `css` can contain dynamic interpolation, it has no effect once used as a class, it has effect once interpolated in styled component
- composition inside sub-selectors is possible
- composition of multiple tags together is possible

the following code is an example of valid usage

```js
const fragment = css`
  color: red;
  font-size: 40px;
  padding-top: ${(props) => props.height || '200px'}; 
`

const anotherFragment = css`
  color: yellow;
  ${fragment};
  border: 10px solid black;
`

const component styled.h1`
color: black;
${anotherFragment}
.sub-class {
    ${fragment}
}
`

```

Cons:
Increases build time by 15% comparing to `2.0.0-alpha.5` (with shaker as default)

implementation details: 
TBD


## Test plan

Green CI, new tests added
