### PR TITLE
Mark package as side-effect free

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "linaria",
   "version": "2.0.0-alpha.5",
   "description": "Blazing fast zero-runtime CSS in JS library",
+  "sideEffects": false,
   "main": "lib/index.js",
   "module": "esm/index.js",
   "bin": "bin/linaria.js",


### PR DESCRIPTION
## Motivation

If a package is marked side-effect free, bundlers are free to drop import declarations which import unused bindings.

For example, without this option enabled, the import declaration `import { css } from linaria` may be retained in the bundler even if all calls to `css` are removed by the babel plugin.

## Test plan

Check that the `css` function is removed from the bundles. We'd need rollup or webpack (or another bundler which supports the `sideEffects` option), but I'm unsure if the current test setup is prepared for that.

Update: I didn't find a nice way to write a test for that without adding a lot of complexity to the project.