### PR TITLE
feat: tightened typing for Object Interpolation (CSSProperties)

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "@emotion/is-prop-valid": "^0.7.3",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "cosmiconfig": "^5.1.0",
+    "csstype": "^2.6.11",
     "debug": "^4.1.1",
     "dedent": "^0.7.0",
     "enhanced-resolve": "^4.1.0",

--- a/src/core/css.ts
+++ b/src/core/css.ts
@@ -1,8 +1,18 @@
+// 'csstype' cannot be resolved since 'main' field in its package.json is empty and no script files are exported
+// eslint-disable-next-line import/no-unresolved
+import * as csstype from 'csstype';
 import { StyledMeta } from '../StyledMeta';
 
-type CSSProperties = {
-  [key: string]: string | number | CSSProperties;
-};
+// exported so that users can extend the interface by declaration merging
+export interface Properties
+  extends csstype.Properties,
+    csstype.PropertiesHyphen {}
+
+export type CSSProperties =
+  | Properties
+  | {
+      [key: string]: Properties;
+    };
 
 export default function css(
   _strings: TemplateStringsArray,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3333,6 +3333,11 @@ csstype@^2.2.0:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.9.tgz#05141d0cd557a56b8891394c1911c40c8a98d098"
   integrity sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==
 
+csstype@^2.6.11:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.11.tgz#452f4d024149ecf260a852b025e36562a253ffc5"
+  integrity sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->

[Object Interpolation](https://github.com/callstack/linaria/blob/master/docs/BASICS.md#object-interpolations) is very useful especially for creating _sass-like mixins_ such as

```ts
function margin(px: number): CSSProperties {
  return { margin: px + 'px' };
}

const divStyle = css`
  ${margin(12)}
`;
```

However, currently `CSSProperties` type accepts any keys and values even outside of CSS rule stuff. This is problematic for type safety and usability (e.g. auto-completion).


## Summary

<!--
Explain how your implementation works and your thoughts behind the solution.
It will help maintainers to review your PR.
You can skip it if PR is trivial.
-->

In this PR, I've just replaced declaration of `CSSProperties`.

Concretely, replaced `[key: string]: string | number` with `csstype.Properties` which is responsible for covering all available key-value pairs of css property.

This allows us more relialbe type cheking and usable auto-completion for Object Interpolation without downside in runtime.

For extendability of property types, internal interface called `Properties` is exported so that users can merge interface at their discretion in the user-land.

## Test plan

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->

```ts
function marginTop(px: number): CSSPropreties {
  return {
    // OK
    marginTop: px + 'px',
    // OK
    'margin-top': 0,
    // ERROR
    'margin-top': 1,
    // ERROR
    'my-prop': 'hello',
  };
}

css`
  ${{
    // OK
    marginTop: px + 'px',
    // OK
    'margin-top': 0,
    // ERROR
    'margin-top': 1,
    // ERROR
    'my-prop': 'hello',
  }}
`;
```

```ts
declare module 'linaria/lib/core/css' {
  interface Properties {
    'my-prop': 'hello';
  }
}

function marginTop(px: number): CSSPropreties {
  return {
    // OK
    'my-prop': 'hello',
  };
}

css`
  ${{
    // OK
    'my-prop': 'hello',
  }}
`;
```
