### PR TITLE
fix: create rollup slug from cssText

### DIFF
--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -49,7 +49,7 @@ export default function linaria({
 
       let { cssText } = result;
 
-      const slug = slugify(id);
+      const slug = slugify(cssText);
       const filename = `${id.replace(/\.js$/, '')}_${slug}.css`;
 
       if (sourceMap && result.cssSourceMapText) {


### PR DESCRIPTION
## Motivation

Resolves #638.

## Test plan

1. Clone the demo app: https://github.com/pnfcre/nollup-linaria-demo.
2. Run `yarn start` and open the demo app at http://localhost:9001.
3. Example: Change the `font-size` of the `Title` component in `src/app.tsx` to `2rem`.
4. Notice how changes are *not* reflected in the demo app.
5. Exit the development server and run `yarn run patch`, and repeat step 2 and 3.
6. Notice how changes *are* reflected in the demo app.

Thanks!