### PR TITLE
fix(typings): export CSSProperties (closes #641)

### DIFF
--- a/src/CSSProperties.ts
+++ b/src/CSSProperties.ts
@@ -1,0 +1,3 @@
+export type CSSProperties = {
+  [key: string]: string | number | CSSProperties;
+};

--- a/src/core/css.ts
+++ b/src/core/css.ts
@@ -1,8 +1,5 @@
+import type { CSSProperties } from '../CSSProperties';
 import type { StyledMeta } from '../StyledMeta';
-
-type CSSProperties = {
-  [key: string]: string | number | CSSProperties;
-};
 
 export default function css(
   _strings: TemplateStringsArray,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { default as css } from './core/css';
 export { default as cx } from './core/cx';
+export type { CSSProperties } from './CSSProperties';

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -1,1 +1,2 @@
 export { default as styled } from './styled';
+export type { CSSProperties } from '../CSSProperties';

--- a/src/react/styled.ts
+++ b/src/react/styled.ts
@@ -7,6 +7,7 @@
 import * as React from 'react'; // eslint-disable-line import/no-extraneous-dependencies
 import validAttr from '@emotion/is-prop-valid';
 import { cx } from '../index';
+import type { CSSProperties } from '../CSSProperties';
 import type { StyledMeta } from '../StyledMeta';
 
 type Options = {
@@ -150,10 +151,6 @@ function styled(tag: any): any {
     return Result;
   };
 }
-
-type CSSProperties = {
-  [key: string]: string | number | CSSProperties;
-};
 
 type StyledComponent<T> = StyledMeta &
   (T extends React.FunctionComponent<any>


### PR DESCRIPTION
## Motivation

PR returns missed export of `CSSProperties` (issue https://github.com/callstack/linaria/issues/641)