### PR TITLE
Bump @emotion/is-prop-valid

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@babel/plugin-transform-runtime": ">=7",
     "@babel/plugin-transform-template-literals": ">=7",
     "@babel/template": ">=7",
-    "@emotion/is-prop-valid": "^0.7.3",
+    "@emotion/is-prop-valid": "^0.8.8",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "cosmiconfig": "^5.1.0",
     "debug": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1126,17 +1126,17 @@
   dependencies:
     find-up "^4.0.0"
 
-"@emotion/is-prop-valid@^0.7.3":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz#a6bf4fa5387cbba59d44e698a4680f481a8da6cc"
-  integrity sha512-uxJqm/sqwXw3YPA5GXX365OBcJGFtxUVkB6WyezqFHlNe9jqUWH5ur2O2M8dGBz61kn1g3ZBlzUunFQXQIClhA==
+"@emotion/is-prop-valid@^0.8.8":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
+  integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
   dependencies:
-    "@emotion/memoize" "0.7.1"
+    "@emotion/memoize" "0.7.4"
 
-"@emotion/memoize@0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.1.tgz#e93c13942592cf5ef01aa8297444dc192beee52f"
-  integrity sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg==
+"@emotion/memoize@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
+  integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
 
 "@iarna/toml@2.2.3":
   version "2.2.3"


### PR DESCRIPTION
## Motivation

Add support for `<img />` and `<iframe />` `loading` prop as well as few other props (https://github.com/emotion-js/emotion/blob/master/packages/is-prop-valid/CHANGELOG.md).

## Summary

This PR updates [@emotion/is-prop-valid](https://github.com/emotion-js/emotion/blob/master/packages/is-prop-valid/) to latest (0.8.8) version.
Not sure if this change can be considered breaking, `loading` seems like a pretty common name for a prop, but I guess it can be released as part of 2.0.
Current workaround:
```javascript
const Foo = styled((props) => <img {...props} />)`
  // styles
`
<Foo loading="lazy" />
```