### PR TITLE
fix(typings): styled mistakenly infers type from interpolated component

### DIFF
--- a/src/react/styled.ts
+++ b/src/react/styled.ts
@@ -10,6 +10,8 @@ import { cx } from '../index';
 import type { CSSProperties } from '../CSSProperties';
 import type { StyledMeta } from '../StyledMeta';
 
+export type NoInfer<A extends any> = [A][A extends any ? 0 : never];
+
 type Options = {
   name: string;
   class: string;
@@ -181,7 +183,8 @@ type ComponentStyledTag<T> = <
   // Expressions can contain functions only if wrapped component has style property
   ...exprs: TrgProps extends { style?: React.CSSProperties }
     ? Array<
-        StaticPlaceholder | ((props: OwnProps & TrgProps) => string | number)
+        | StaticPlaceholder
+        | ((props: NoInfer<OwnProps & TrgProps>) => string | number)
       >
     : StaticPlaceholder[]
 ) => keyof OwnProps extends never

--- a/types/styled.ts
+++ b/types/styled.ts
@@ -106,6 +106,18 @@ styled.a`
     background-color: ${(props) => (props.prop1 ? 'transparent' : 'green')};
   `;
 
+  const Custom: React.FC<{ className?: string; id: number }> = () => null;
+
+  const tag = styled(Custom);
+  const Card = tag`
+    ${Wrapper} {
+      color: green;
+    }
+  `;
+
+  // $ExpectType Validator<number> | undefined
+  Card.propTypes!.id;
+
   const styledTag = styled(Wrapper);
 
   const NewWrapper = styledTag<{ prop2: string }>`


### PR DESCRIPTION
## Motivation

Fix for #622 introduces regression in `styled`:
```
const Header = styled.h1``;
const Block = styled(/* some custom component  */)`
  ${Header} {
    /* styled */
  }
`; // type of Block here is inferred from Header and not from the original component
```

## Test plan

The new case for dtslint was added.