### PR TITLE
fix(evaluators): respect environment variables during evaluation

### DIFF
--- a/src/babel/process.ts
+++ b/src/babel/process.ts
@@ -28,6 +28,4 @@ export const memoryUsage = noop;
 export const uvCounters = noop;
 export const features = {};
 
-export const env = {
-  NODE_ENV: process.env.NODE_ENV,
-};
+export const env = process.env;


### PR DESCRIPTION
## Motivation

It fixes #666

## Summary

It looks logical to pass all env variables and not only NODE_ENV. I don't know why we had such a limitation.
