### PR TITLE
fix: css identifier cannot start with a digit

### DIFF
--- a/src/__tests__/__snapshots__/babel.test.ts.snap
+++ b/src/__tests__/__snapshots__/babel.test.ts.snap
@@ -187,6 +187,25 @@ Dependencies: NA
 
 `;
 
+exports[`handles objects with numeric keys 1`] = `
+"import { css } from 'linaria';
+export const object = {
+  stringKey: \\"sh6xni0\\",
+  42: \\"_1u0rrat\\"
+};"
+`;
+
+exports[`handles objects with numeric keys 2`] = `
+
+CSS:
+
+.sh6xni0 {}
+._1u0rrat {}
+
+Dependencies: NA
+
+`;
+
 exports[`includes unreferenced styles for :global 1`] = `
 "import { css } from 'linaria';
 import { styled } from 'linaria/react';

--- a/src/__tests__/babel.test.ts
+++ b/src/__tests__/babel.test.ts
@@ -488,3 +488,19 @@ it('includes unreferenced styles for :global', async () => {
   expect(code).toMatchSnapshot();
   expect(metadata).toMatchSnapshot();
 });
+
+it('handles objects with numeric keys', async () => {
+  const { code, metadata } = await transpile(
+    dedent`
+      import { css } from 'linaria';
+
+      export const object = {
+        stringKey: css\`\`,
+        42: css\`\`,
+      }
+      `
+  );
+
+  expect(code).toMatchSnapshot();
+  expect(metadata).toMatchSnapshot();
+});

--- a/src/babel/utils/toValidCSSIdentifier.ts
+++ b/src/babel/utils/toValidCSSIdentifier.ts
@@ -1,3 +1,3 @@
 export default function toValidCSSIdentifier(s: string) {
-  return s.replace(/[^-_a-z0-9\u00A0-\uFFFF]/gi, '_');
+  return s.replace(/[^-_a-z0-9\u00A0-\uFFFF]/gi, '_').replace(/^\d/, '_');
 }


### PR DESCRIPTION
## Motivation

In some cases, Linaria may generate class names that start with a digit, but according to specification, CSS identifier can start only with a letter, hyphen or underscore. (issue #683)

## Summary

This PR modifies `toValidCSSIdentifier` in order to catch the first digit in identifier and replace it with an underscore.

## Test plan

The new test was added.
