### PR TITLE
docs: add Sublime Text editor plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,11 @@ Take a look on [Contributing](CONTRIBUTING.md) docs to check how you can run Lin
 
 - Syntax Highlighting & Autocompletion - [webstorm-styled-components](https://github.com/styled-components/webstorm-styled-components)
 
+### Sublime Text
+
+- Syntax Highlighting & Autocompletion - [Naomi](https://packagecontrol.io/packages/Naomi), [JSCustom](https://packagecontrol.io/packages/JSCustom) (refer to document on how to turn on Styled Component syntax)
+- Linting - [SublimeLinter-stylelint](https://packagecontrol.io/packages/SublimeLinter-stylelint), [LSP Stylelint](https://packagecontrol.io/packages/LSP-stylelint)
+
 ## Recommended Libraries
 
 - [gatsby-plugin-linaria](https://github.com/silvenon/gatsby-plugin-linaria) – Gatsby plugin that sets up Babel and webpack configuration for Linaria.


### PR DESCRIPTION
## Motivation

The editor plugins section in README lack a popular editor, that is Sublime Text which happen to be my main code editor. I have tried all these plugins and can confirm they support Styled Component as well as Linaria.

## Summary

Add Sublime Text plugins README that support Linaria. 

## Test plan

No test plan since this is a documentation PR.
