### PR TITLE
Refine preset-env targets to support more browsers

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -12,18 +12,19 @@
 /*
  * Configuration for the legacy build
  * Browsers compatibility based on https://caniuse.com/css-variables
+ * Versions adjusted specifically to not include any core-js polyfills
  */
 
 const commonJSTargets = {
   browsers: [
-    'Chrome >= 49',
-    'ChromeAndroid >= 49',
-    'Edge >= 16',
-    'Firefox >= 31',
-    'iOS >= 9.3',
-    'Opera >= 36',
-    'Safari >= 9.1',
-    'Samsung >= 5',
+    'Chrome > 52',
+    'ChromeAndroid > 52',
+    'Edge > 18',
+    'Firefox > 49',
+    'iOS > 10.3',
+    'Opera > 39',
+    'Safari > 10.1',
+    'Samsung > 5',
     'last 2 versions',
     'not ie 11',
     'not ie_mob 11',

--- a/babel.config.js
+++ b/babel.config.js
@@ -11,10 +11,19 @@
 
 /*
  * Configuration for the legacy build
+ * Browsers compatibility based on https://caniuse.com/css-variables
  */
 
 const commonJSTargets = {
   browsers: [
+    'Chrome >= 49',
+    'ChromeAndroid >= 49',
+    'Edge >= 16',
+    'Firefox >= 31',
+    'iOS >= 9.3',
+    'Opera >= 36',
+    'Safari >= 9.1',
+    'Samsung >= 5',
     'last 2 versions',
     'not ie 11',
     'not ie_mob 11',


### PR DESCRIPTION
## Motivation
Looking at my logs in Sentry I found out many users are getting `SyntaxError` originating from Linaria's source code.  
Here is just one example: `SyntaxError: Unexpected token =>  at ? (./node_modules/linaria/lib/react/styled.js:26:1)`

That's because in some older browsers arrow functions are not supported: https://caniuse.com/arrow-functions  

## Summary
I assume Linaria is possibly compatible with **all browsers with CSS Variables support**: https://caniuse.com/css-variables
By taking this requirement into `targets`, we make sure Linaria builds into a JS library that works for all supported browsers.  
Babel will automatically find out all the necessary `transform` plugins, eg: `transform-arrow-functions { "firefox":"41", "ios":"9.3", "safari":"9.1", "samsung":"4" }` (from babel debug output).

## Test plan
Example of a browser that supports CSS Variables but not arrow functions: Safari 9.1 (until Safari 10)

Another example is `const declaration`:  
Error: `SyntaxError: Unexpected keyword 'const'.`  
Compatibility: https://caniuse.com/const  