### PR TITLE
fix: dedent is a devDep of @linaria/shaker, not a prod dep

### DIFF
--- a/packages/shaker/package.json
+++ b/packages/shaker/package.json
@@ -39,7 +39,8 @@
     "watch": "yarn build --watch"
   },
   "devDependencies": {
-    "@types/dedent": "^0.7.0"
+    "@types/dedent": "^0.7.0",
+    "dedent": "^0.7.0"
   },
   "dependencies": {
     "@babel/generator": ">=7",
@@ -47,8 +48,7 @@
     "@linaria/babel": "^3.0.0-beta.0",
     "@linaria/logger": "^3.0.0-beta.0",
     "@linaria/preeval": "^3.0.0-beta.0",
-    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
-    "dedent": "^0.7.0"
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
   },
   "peerDependencies": {
     "@babel/core": ">=7"


### PR DESCRIPTION
## Motivation

Remove an unsed production dep.

## Summary

Like in other packages, dedent is actually a dev dep.
`@linaria/babel`: https://github.com/callstack/linaria/blob/a4258f9ad59cf909825a71dfd2b7473a9b5d61cf/packages/babel/package.json#L41-L44
`@linaria/server`: https://github.com/callstack/linaria/blob/a4258f9ad59cf909825a71dfd2b7473a9b5d61cf/packages/server/package.json#L38-L40

Grep output:
```console
$ grep -r dedent packages/shaker/
packages/shaker/package.json:    "@types/dedent": "^0.7.0",
packages/shaker/package.json:    "dedent": "^0.7.0"
packages/shaker/__tests__/shaker.test.ts:import dedent from 'dedent';
packages/shaker/__tests__/shaker.test.ts:        dedent`
packages/shaker/__tests__/shaker.test.ts:        dedent`
packages/shaker/__tests__/shaker.test.ts:        dedent`
```

Seems to be used only in tests.

## Test plan

Regular tests should pass.
I also checked that this package still works when `dedent` module is removed from `node_modules`.