### PR TITLE
fix(babel): custom properties should not be hyphenated (#710) BREAKING CHANGE

### DIFF
--- a/packages/babel/__tests__/__snapshots__/babel.test.ts.snap
+++ b/packages/babel/__tests__/__snapshots__/babel.test.ts.snap
@@ -266,6 +266,7 @@ Dependencies: NA
 exports[`inlines object styles as CSS string 1`] = `
 "import { styled } from '@linaria/react';
 const cover = {
+  '--color-primaryText': '#222',
   position: 'absolute',
   top: 0,
   right: 0,
@@ -302,7 +303,7 @@ exports[`inlines object styles as CSS string 2`] = `
 CSS:
 
 .t17gu1mi {
-  position: absolute; top: 0; right: 0; bottom: 0; left: 0; opacity: 1; min-height: 420px; &.shouldNotBeChanged { border-color: #fff; } @media (min-width: 200px) { -webkit-opacity: 0.8; -moz-opacity: 0.8; -ms-opacity: 0.8; -o-opacity: 0.8; -webkit-border-radius: 2px; -moz-border-radius: 2px; -ms-border-radius: 2px; -o-border-radius: 2px; -webkit-transition: 400ms; -moz-transition: 400ms; -o-transition: 400ms; -ms-transition: 400ms; }
+  --color-primaryText: #222; position: absolute; top: 0; right: 0; bottom: 0; left: 0; opacity: 1; min-height: 420px; &.shouldNotBeChanged { border-color: #fff; } @media (min-width: 200px) { -webkit-opacity: 0.8; -moz-opacity: 0.8; -ms-opacity: 0.8; -o-opacity: 0.8; -webkit-border-radius: 2px; -moz-border-radius: 2px; -ms-border-radius: 2px; -o-border-radius: 2px; -webkit-transition: 400ms; -moz-transition: 400ms; -o-transition: 400ms; -ms-transition: 400ms; }
 }
 
 Dependencies: NA

--- a/packages/babel/__tests__/babel.test.ts
+++ b/packages/babel/__tests__/babel.test.ts
@@ -155,6 +155,7 @@ it('inlines object styles as CSS string', async () => {
     import { styled } from '@linaria/react';
 
     const cover = {
+      '--color-primaryText': '#222',
       position: 'absolute',
       top: 0,
       right: 0,

--- a/packages/babel/src/utils/toCSS.ts
+++ b/packages/babel/src/utils/toCSS.ts
@@ -3,12 +3,19 @@ import type { JSONValue } from '../types';
 import isSerializable from './isSerializable';
 import isBoxedPrimitive from './isBoxedPrimitive';
 
-const hyphenate = (s: string) =>
-  s
-    // Hyphenate CSS property names from camelCase version from JS string
-    .replace(/([A-Z])/g, (match, p1) => `-${p1.toLowerCase()}`)
-    // Special case for `-ms` because in JS it starts with `ms` unlike `Webkit`
-    .replace(/^ms-/, '-ms-');
+const hyphenate = (s: string) => {
+  if (s.startsWith('--')) {
+    // It's a custom property which is already well formatted.
+    return s;
+  }
+  return (
+    s
+      // Hyphenate CSS property names from camelCase version from JS string
+      .replace(/([A-Z])/g, (match, p1) => `-${p1.toLowerCase()}`)
+      // Special case for `-ms` because in JS it starts with `ms` unlike `Webkit`
+      .replace(/^ms-/, '-ms-')
+  );
+};
 
 // Some tools such as polished.js output JS objects
 // To support them transparently, we convert JS objects to CSS strings


### PR DESCRIPTION
## Motivation

Details can be found in #710 

## Summary

It can be a breaking change for someone who already uses object interpolation with custom properties.

## Test plan

One of the existed tests was modified.