### PR TITLE
fix(rollup): problem with 'css' string in generated files (#712)

### DIFF
--- a/packages/rollup/src/index.ts
+++ b/packages/rollup/src/index.ts
@@ -35,7 +35,8 @@ export default function linaria({
       if (importee in cssLookup) return importee;
     },
     transform(code: string, id: string) {
-      if (!filter(id)) return;
+      // Do not transform ignored and generated files
+      if (!filter(id) || id in cssLookup) return;
 
       const result = transform(code, {
         filename: id,


### PR DESCRIPTION
## Motivation

Rollup tries to parse generated css-files and fails if one of them contains `css` or `styled` strings.

## Summary

All generated files should be ignored.
