### PR TITLE
fix: mark core and react packages as side effects free

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,7 @@
     "access": "public"
   },
   "description": "Blazing fast zero-runtime CSS in JS library",
+  "sideEffects": false,
   "main": "lib/index.js",
   "module": "esm/index.js",
   "types": "types",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -5,6 +5,7 @@
     "access": "public"
   },
   "description": "Blazing fast zero-runtime CSS in JS library",
+  "sideEffects": false,
   "main": "lib/index.js",
   "module": "esm/index.js",
   "types": "types",


### PR DESCRIPTION
## Motivation

Initially, it was introduced by @wereHamster in #632, but we weren't sure that it was safe at that moment. Now we have different packages which can be safely marked as side effects free.
