### PR TITLE
fix(babel): rename @linaria/babel to @linaria/babel-preset (#704)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ Zero-runtime CSS in JS library.
 ## Installation
 
 ```sh
-npm install @linaria/core @linaria/react @linaria/babel @linaria/shaker
+npm install @linaria/core @linaria/react @linaria/babel-preset @linaria/shaker
 ```
 
 or
 
 ```sh
-yarn add @linaria/core @linaria/react @linaria/babel @linaria/shaker
+yarn add @linaria/core @linaria/react @linaria/babel-preset @linaria/shaker
 ```
 
 ## Setup
@@ -59,14 +59,14 @@ Or configure Linaria with one of the following integrations:
 - [Preact](/docs/CONFIGURATION.md#preact)
 - [Gatsby](/docs/CONFIGURATION.md#gatsby)
 
-Optionally, add the `linaria/babel` preset to your Babel configuration at the end of the presets list to avoid errors when importing the components in your server code or tests:
+Optionally, add the `@linaria` preset to your Babel configuration at the end of the presets list to avoid errors when importing the components in your server code or tests:
 
 ```json
 {
   "presets": [
     "@babel/preset-env",
     "@babel/preset-react",
-    "module:@linaria/babel"
+    "@linaria"
   ]
 }
 ```

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -81,11 +81,11 @@ module.exports = {
 
   If you need to specify custom babel configuration, you can pass them here. These babel options will be used by Linaria when parsing and evaluating modules.
 
-## `@linaria/babel` preset
+## `@linaria/babel-preset`
 
 The preset pre-processes and evaluates the CSS. The bundler plugins use this preset under the hood. You also might want to use this preset if you import the components outside of the files handled by your bundler, such as on your server or in unit tests.
 
-To use this preset, add `@linaria/babel` to your Babel configuration at the end of the presets list:
+To use this preset, add `@linaria/babel-preset` to your Babel configuration at the end of the presets list:
 
 `.babelrc`:
 
@@ -94,7 +94,7 @@ To use this preset, add `@linaria/babel` to your Babel configuration at the end 
   "presets": [
     "@babel/preset-env",
     "@babel/preset-react",
-+   "@linaria/babel"
++   "@linaria"
   ]
 }
 ```
@@ -129,7 +129,7 @@ After that, your `package.json` should look like the following:
     "sirv-cli": "^0.4.5"
   },
   "dependencies": {
-+   "@linaria/babel": "^3.0.0",
++   "@linaria/babel-preset": "^3.0.0",
 +   "@linaria/core": "^3.0.0",
 +   "@linaria/react": "^3.0.0",
 +   "@linaria/webpack-loader": "^3.0.0",
@@ -146,7 +146,7 @@ Now in your `preact.config.js`, we will modify the babel rule to use the necessa
 ```js
 export default config => {
   const { options, ...babelLoaderRule } = config.module.rules[0]; // Get the babel rule and options
-  options.presets.push('@babel/preset-react', '@linaria/babel'); // Push the necessary presets
+  options.presets.push('@babel/preset-react', '@linaria'); // Push the necessary presets
   config.module.rules[0] = {
     ...babelLoaderRule,
     loader: undefined, // Disable the predefined babel-loader on the rule
@@ -231,14 +231,14 @@ You can also take a look at the example [here](../examples/gatsby/plugin)
 
 This is a bit more advanced way of integrating Linaria into your Gatsby project.
 
-First, you will need to install `@linaria/babel` and `babel-preset-gatsby`. Then, create `babel.config.js` in the root of your project with the following contents:
+First, you will need to install `@linaria/babel-preset` and `babel-preset-gatsby`. Then, create `babel.config.js` in the root of your project with the following contents:
 
 ```js
 module.exports = {
   presets: [
     'babel-preset-gatsby',
     [
-      '@linaria/babel',
+      '@linaria',
       {
         evaluate: true,
         displayName: process.env.NODE_ENV !== 'production',

--- a/packages/babel/__utils__/strategy-tester.ts
+++ b/packages/babel/__utils__/strategy-tester.ts
@@ -248,7 +248,7 @@ export function run(
     const { code, metadata } = await transpile(
       dedent`
       import { styled } from '@linaria/react';
-      import slugify from '@linaria/babel/__fixtures__/slugify';
+      import slugify from '@linaria/babel-preset/__fixtures__/slugify';
 
       export const Title = styled.h1\`
         &:before {
@@ -266,7 +266,7 @@ export function run(
     const { code, metadata } = await transpile(
       dedent`
       import { styled } from '@linaria/react';
-      const slugify = require('@linaria/babel/__fixtures__/slugify').default;
+      const slugify = require('@linaria/babel-preset/__fixtures__/slugify').default;
 
       const boo = t => slugify(t) + 'boo';
       const bar = t => slugify(t) + 'bar';
@@ -287,7 +287,7 @@ export function run(
     const { code, metadata } = await transpile(
       dedent`
       import { styled } from '@linaria/react';
-      const slugify = require('@linaria/babel/__fixtures__/slugify').default;
+      const slugify = require('@linaria/babel-preset/__fixtures__/slugify').default;
 
       const boo = t => slugify(t) + 'boo';
       const bar = t => slugify(t) + 'bar';
@@ -858,7 +858,7 @@ export function run(
       dedent`
       import React from 'react'
       import {css} from '@linaria/core'
-      import externalDep from '@linaria/babel/__fixtures__/sample-script';
+      import externalDep from '@linaria/babel-preset/__fixtures__/sample-script';
       const globalObj = {
         opacity: 0.5,
       };

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@linaria/babel",
+  "name": "@linaria/babel-preset",
   "version": "3.0.0-beta.0",
   "publishConfig": {
     "access": "public"

--- a/packages/babel/src/evaluators/buildOptions.ts
+++ b/packages/babel/src/evaluators/buildOptions.ts
@@ -65,7 +65,8 @@ export default function buildOptions(
             // This case won't get caught and the preset won't filtered, even if they are same
             // So we add an extra check for top level linaria/babel
             name === 'linaria/babel' ||
-            name === '@linaria/babel' ||
+            name === '@linaria' ||
+            name === '@linaria/babel-preset' ||
             name === require.resolve('../index') ||
             // Also add a check for the plugin names we include for bundler support
             plugins.includes(name)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,7 +43,7 @@
     "@types/normalize-path": "^3.0.0"
   },
   "dependencies": {
-    "@linaria/babel": "^3.0.0-beta.0",
+    "@linaria/babel-preset": "^3.0.0-beta.0",
     "glob": "^7.1.3",
     "mkdirp": "^0.5.1",
     "normalize-path": "^3.0.0",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -8,7 +8,7 @@ import normalize from 'normalize-path';
 import mkdirp from 'mkdirp';
 import glob from 'glob';
 import yargs from 'yargs';
-import { transform } from '@linaria/babel';
+import { transform } from '@linaria/babel-preset';
 
 const { argv } = yargs
   .usage('Usage: $0 [options] <files ...>')

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "paths": {},
-    "rootDir": "src/"
-  },
+  "compilerOptions": { "paths": {}, "rootDir": "src/" },
   "references": [{ "path": "../babel" }]
 }

--- a/packages/core/__tests__/detect-core-js.test.js
+++ b/packages/core/__tests__/detect-core-js.test.js
@@ -14,7 +14,7 @@ const waitForProcess = async (process) => {
 
 it('Ensures that package do not include core-js dependency after build', async () => {
   // eslint-disable-next-line import/no-extraneous-dependencies
-  const packageJSON = require('@linaria/babel/package.json');
+  const packageJSON = require('@linaria/babel-preset/package.json');
   const buildScript = packageJSON.scripts['build:lib'];
 
   const proc = cp.exec(buildScript, {

--- a/packages/extractor/__tests__/__snapshots__/extractor.test.ts.snap
+++ b/packages/extractor/__tests__/__snapshots__/extractor.test.ts.snap
@@ -228,7 +228,7 @@ Dependencies: NA
 
 exports[`extractor evaluates expressions with dependencies 1`] = `
 "import { styled } from '@linaria/react';
-import slugify from '@linaria/babel/__fixtures__/slugify';
+import slugify from '@linaria/babel-preset/__fixtures__/slugify';
 export const Title = /*#__PURE__*/styled(\\"h1\\")({
   name: \\"Title\\",
   class: \\"Title_t1t92lw9\\"
@@ -245,14 +245,14 @@ CSS:
   }
 }
 
-Dependencies: @babel/runtime/helpers/interopRequireDefault, @linaria/babel/__fixtures__/slugify
+Dependencies: @babel/runtime/helpers/interopRequireDefault, @linaria/babel-preset/__fixtures__/slugify
 
 `;
 
 exports[`extractor evaluates expressions with expressions depending on shared dependency 1`] = `
 "import { styled } from '@linaria/react';
 
-const slugify = require('@linaria/babel/__fixtures__/slugify').default;
+const slugify = require('@linaria/babel-preset/__fixtures__/slugify').default;
 
 const boo = t => slugify(t) + 'boo';
 
@@ -274,7 +274,7 @@ CSS:
   }
 }
 
-Dependencies: @linaria/babel/__fixtures__/slugify
+Dependencies: @linaria/babel-preset/__fixtures__/slugify
 
 `;
 
@@ -388,7 +388,7 @@ Dependencies: NA
 exports[`extractor evaluates multiple expressions with shared dependency 1`] = `
 "import { styled } from '@linaria/react';
 
-const slugify = require('@linaria/babel/__fixtures__/slugify').default;
+const slugify = require('@linaria/babel-preset/__fixtures__/slugify').default;
 
 const boo = t => slugify(t) + 'boo';
 
@@ -411,7 +411,7 @@ CSS:
   }
 }
 
-Dependencies: @linaria/babel/__fixtures__/slugify
+Dependencies: @linaria/babel-preset/__fixtures__/slugify
 
 `;
 
@@ -876,7 +876,7 @@ Dependencies: NA
 exports[`extractor should process \`css\` calls with complex interpolation inside components 1`] = `
 "import React from 'react';
 import { css } from '@linaria/core';
-import externalDep from '@linaria/babel/__fixtures__/sample-script';
+import externalDep from '@linaria/babel-preset/__fixtures__/sample-script';
 const globalObj = {
   opacity: 0.5
 };
@@ -914,7 +914,7 @@ CSS:
     }
   }
 
-Dependencies: @babel/runtime/helpers/interopRequireDefault, @linaria/babel/__fixtures__/sample-script
+Dependencies: @babel/runtime/helpers/interopRequireDefault, @linaria/babel-preset/__fixtures__/sample-script
 
 `;
 

--- a/packages/extractor/__tests__/extractor.test.ts
+++ b/packages/extractor/__tests__/extractor.test.ts
@@ -1,4 +1,4 @@
-import { run } from '@linaria/babel/__utils__/strategy-tester';
+import { run } from '@linaria/babel-preset/__utils__/strategy-tester';
 
 describe('extractor', () => {
   run(__dirname, require('../src').default);

--- a/packages/extractor/package.json
+++ b/packages/extractor/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@babel/generator": ">=7",
     "@babel/plugin-transform-runtime": ">=7",
-    "@linaria/babel": "^3.0.0-beta.0",
+    "@linaria/babel-preset": "^3.0.0-beta.0",
     "@linaria/preeval": "^3.0.0-beta.0"
   },
   "peerDependencies": {

--- a/packages/extractor/src/index.ts
+++ b/packages/extractor/src/index.ts
@@ -15,8 +15,8 @@ import { parseSync, transformSync } from '@babel/core';
 import type { NodePath } from '@babel/traverse';
 import generator from '@babel/generator';
 
-import type { Evaluator } from '@linaria/babel';
-import { buildOptions } from '@linaria/babel';
+import type { Evaluator } from '@linaria/babel-preset';
+import { buildOptions } from '@linaria/babel-preset';
 import RequirementsResolver from './RequirementsResolver';
 
 function isMemberExpression(

--- a/packages/extractor/tsconfig.json
+++ b/packages/extractor/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "paths": {},
-    "rootDir": "src/"
-  },
+  "compilerOptions": { "paths": {}, "rootDir": "src/" },
   "references": [{ "path": "../babel" }, { "path": "../preeval" }]
 }

--- a/packages/linaria/package.json
+++ b/packages/linaria/package.json
@@ -42,7 +42,7 @@
     "watch": "yarn build --watch"
   },
   "dependencies": {
-    "@linaria/babel": "^3.0.0-beta.0",
+    "@linaria/babel-preset": "^3.0.0-beta.0",
     "@linaria/core": "^3.0.0-beta.0",
     "@linaria/extractor": "^3.0.0-beta.0",
     "@linaria/react": "^3.0.0-beta.0",

--- a/packages/linaria/src/babel.ts
+++ b/packages/linaria/src/babel.ts
@@ -1,4 +1,4 @@
-import babel from '@linaria/babel';
+import babel from '@linaria/babel-preset';
 
 export default babel;
-export * from '@linaria/babel';
+export * from '@linaria/babel-preset';

--- a/packages/preeval/package.json
+++ b/packages/preeval/package.json
@@ -38,7 +38,7 @@
     "watch": "yarn build --watch"
   },
   "dependencies": {
-    "@linaria/babel": "^3.0.0-beta.0"
+    "@linaria/babel-preset": "^3.0.0-beta.0"
   },
   "peerDependencies": {
     "@babel/core": ">=7"

--- a/packages/preeval/src/index.ts
+++ b/packages/preeval/src/index.ts
@@ -4,14 +4,14 @@
  */
 import type { NodePath } from '@babel/traverse';
 import type { Program } from '@babel/types';
-import type { State, StrictOptions } from '@linaria/babel';
+import type { State, StrictOptions } from '@linaria/babel-preset';
 import {
   GenerateClassNames,
   DetectStyledImportName,
   JSXElement,
   ProcessStyled,
   ProcessCSS,
-} from '@linaria/babel';
+} from '@linaria/babel-preset';
 import { Core } from './babel';
 
 function index(babel: Core, options: StrictOptions) {

--- a/packages/preeval/tsconfig.json
+++ b/packages/preeval/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "paths": {},
-    "rootDir": "src/"
-  },
+  "compilerOptions": { "paths": {}, "rootDir": "src/" },
   "references": [{ "path": "../babel" }]
 }

--- a/packages/react/__tests__/detect-core-js.test.js
+++ b/packages/react/__tests__/detect-core-js.test.js
@@ -14,7 +14,7 @@ const waitForProcess = async (process) => {
 
 it('Ensures that package do not include core-js dependency after build', async () => {
   // eslint-disable-next-line import/no-extraneous-dependencies
-  const packageJSON = require('@linaria/babel/package.json');
+  const packageJSON = require('@linaria/babel-preset/package.json');
   const buildScript = packageJSON.scripts['build:lib'];
 
   const proc = cp.exec(buildScript, {

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -43,7 +43,7 @@
     "rollup": "1.20.0||^2.0.0"
   },
   "dependencies": {
-    "@linaria/babel": "^3.0.0-beta.0",
+    "@linaria/babel-preset": "^3.0.0-beta.0",
     "@rollup/pluginutils": "^4.1.0"
   },
   "peerDependencies": {

--- a/packages/rollup/src/index.ts
+++ b/packages/rollup/src/index.ts
@@ -5,8 +5,8 @@
  */
 
 import { createFilter } from '@rollup/pluginutils';
-import { transform, slugify } from '@linaria/babel';
-import type { PluginOptions, Preprocessor } from '@linaria/babel';
+import { transform, slugify } from '@linaria/babel-preset';
+import type { PluginOptions, Preprocessor } from '@linaria/babel-preset';
 
 type RollupPluginOptions = {
   include?: string | string[];

--- a/packages/rollup/tsconfig.json
+++ b/packages/rollup/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "paths": {},
-    "rootDir": "src/"
-  },
+  "compilerOptions": { "paths": {}, "rootDir": "src/" },
   "references": [{ "path": "../babel" }]
 }

--- a/packages/shaker/__tests__/__snapshots__/shaker.test.ts.snap
+++ b/packages/shaker/__tests__/__snapshots__/shaker.test.ts.snap
@@ -228,7 +228,7 @@ Dependencies: NA
 
 exports[`shaker evaluates expressions with dependencies 1`] = `
 "import { styled } from '@linaria/react';
-import slugify from '@linaria/babel/__fixtures__/slugify';
+import slugify from '@linaria/babel-preset/__fixtures__/slugify';
 export const Title = /*#__PURE__*/styled(\\"h1\\")({
   name: \\"Title\\",
   class: \\"Title_t1t92lw9\\"
@@ -245,14 +245,14 @@ CSS:
   }
 }
 
-Dependencies: @babel/runtime/helpers/interopRequireDefault, @linaria/babel/__fixtures__/slugify
+Dependencies: @babel/runtime/helpers/interopRequireDefault, @linaria/babel-preset/__fixtures__/slugify
 
 `;
 
 exports[`shaker evaluates expressions with expressions depending on shared dependency 1`] = `
 "import { styled } from '@linaria/react';
 
-const slugify = require('@linaria/babel/__fixtures__/slugify').default;
+const slugify = require('@linaria/babel-preset/__fixtures__/slugify').default;
 
 const boo = t => slugify(t) + 'boo';
 
@@ -274,7 +274,7 @@ CSS:
   }
 }
 
-Dependencies: @linaria/babel/__fixtures__/slugify
+Dependencies: @linaria/babel-preset/__fixtures__/slugify
 
 `;
 
@@ -388,7 +388,7 @@ Dependencies: NA
 exports[`shaker evaluates multiple expressions with shared dependency 1`] = `
 "import { styled } from '@linaria/react';
 
-const slugify = require('@linaria/babel/__fixtures__/slugify').default;
+const slugify = require('@linaria/babel-preset/__fixtures__/slugify').default;
 
 const boo = t => slugify(t) + 'boo';
 
@@ -411,7 +411,7 @@ CSS:
   }
 }
 
-Dependencies: @linaria/babel/__fixtures__/slugify
+Dependencies: @linaria/babel-preset/__fixtures__/slugify
 
 `;
 
@@ -851,7 +851,7 @@ Dependencies: NA
 
 exports[`shaker should interpolate imported components 1`] = `
 "import { css } from \\"@linaria/core\\";
-import { Title } from \\"@linaria/babel/__fixtures__/complex-component\\";
+import { Title } from \\"@linaria/babel-preset/__fixtures__/complex-component\\";
 export const square = \\"square_s1t92lw9\\";"
 `;
 
@@ -865,13 +865,13 @@ CSS:
   }
 }
 
-Dependencies: @linaria/babel/__fixtures__/complex-component
+Dependencies: @linaria/babel-preset/__fixtures__/complex-component
 
 `;
 
 exports[`shaker should interpolate imported variables 1`] = `
 "import { css } from \\"@linaria/core\\";
-import { whiteColor } from \\"@linaria/babel/__fixtures__/complex-component\\";
+import { whiteColor } from \\"@linaria/babel-preset/__fixtures__/complex-component\\";
 export const square = \\"square_s1t92lw9\\";"
 `;
 
@@ -883,7 +883,7 @@ CSS:
   color: #fff
 }
 
-Dependencies: @linaria/babel/__fixtures__/complex-component
+Dependencies: @linaria/babel-preset/__fixtures__/complex-component
 
 `;
 
@@ -914,7 +914,7 @@ Dependencies: NA
 exports[`shaker should process \`css\` calls with complex interpolation inside components 1`] = `
 "import React from 'react';
 import { css } from '@linaria/core';
-import externalDep from '@linaria/babel/__fixtures__/sample-script';
+import externalDep from '@linaria/babel-preset/__fixtures__/sample-script';
 const globalObj = {
   opacity: 0.5
 };
@@ -952,7 +952,7 @@ CSS:
     }
   }
 
-Dependencies: @babel/runtime/helpers/interopRequireDefault, @linaria/babel/__fixtures__/sample-script
+Dependencies: @babel/runtime/helpers/interopRequireDefault, @linaria/babel-preset/__fixtures__/sample-script
 
 `;
 
@@ -1052,7 +1052,7 @@ Dependencies: NA
 
 exports[`shaker should work with wildcard imports 1`] = `
 "import { css } from \\"@linaria/core\\";
-import * as mod from \\"@linaria/babel/__fixtures__/complex-component\\";
+import * as mod from \\"@linaria/babel-preset/__fixtures__/complex-component\\";
 export const square = \\"square_s1t92lw9\\";"
 `;
 
@@ -1066,7 +1066,7 @@ CSS:
   }
 }
 
-Dependencies: @babel/runtime/helpers/interopRequireWildcard, @linaria/babel/__fixtures__/complex-component
+Dependencies: @babel/runtime/helpers/interopRequireWildcard, @linaria/babel-preset/__fixtures__/complex-component
 
 `;
 

--- a/packages/shaker/__tests__/shaker.test.ts
+++ b/packages/shaker/__tests__/shaker.test.ts
@@ -1,4 +1,4 @@
-import { run } from '@linaria/babel/__utils__/strategy-tester';
+import { run } from '@linaria/babel-preset/__utils__/strategy-tester';
 import dedent from 'dedent';
 
 describe('shaker', () => {
@@ -7,7 +7,7 @@ describe('shaker', () => {
       const { code, metadata } = await transpile(
         dedent`
       import { css } from "@linaria/core";
-      import * as mod from "@linaria/babel/__fixtures__/complex-component";
+      import * as mod from "@linaria/babel-preset/__fixtures__/complex-component";
 
       export const square = css\`
         ${'${mod.Title}'} {
@@ -25,7 +25,7 @@ describe('shaker', () => {
       const { code, metadata } = await transpile(
         dedent`
       import { css } from "@linaria/core";
-      import { Title } from "@linaria/babel/__fixtures__/complex-component";
+      import { Title } from "@linaria/babel-preset/__fixtures__/complex-component";
 
       export const square = css\`
         ${'${Title}'} {
@@ -43,7 +43,7 @@ describe('shaker', () => {
       const { code, metadata } = await transpile(
         dedent`
       import { css } from "@linaria/core";
-      import { whiteColor } from "@linaria/babel/__fixtures__/complex-component";
+      import { whiteColor } from "@linaria/babel-preset/__fixtures__/complex-component";
 
       export const square = css\`
         color: ${'${whiteColor}'}

--- a/packages/shaker/package.json
+++ b/packages/shaker/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@babel/generator": ">=7",
     "@babel/plugin-transform-runtime": ">=7",
-    "@linaria/babel": "^3.0.0-beta.0",
+    "@linaria/babel-preset": "^3.0.0-beta.0",
     "@linaria/logger": "^3.0.0-beta.0",
     "@linaria/preeval": "^3.0.0-beta.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",

--- a/packages/shaker/src/Visitors.ts
+++ b/packages/shaker/src/Visitors.ts
@@ -1,7 +1,7 @@
 import { types as t } from '@babel/core';
 import type { Aliases, Identifier, Node, VisitorKeys } from '@babel/types';
 import { warn } from '@linaria/logger';
-import { peek } from '@linaria/babel';
+import { peek } from '@linaria/babel-preset';
 import GraphBuilderState from './GraphBuilderState';
 import identifierHandlers from './identifierHandlers';
 import type { Visitor, Visitors } from './types';

--- a/packages/shaker/src/graphBuilder.ts
+++ b/packages/shaker/src/graphBuilder.ts
@@ -1,6 +1,6 @@
 import { types as t } from '@babel/core';
 import type { AssignmentExpression, Node, VisitorKeys } from '@babel/types';
-import { isNode, getVisitorKeys } from '@linaria/babel';
+import { isNode, getVisitorKeys } from '@linaria/babel-preset';
 import DepsGraph from './DepsGraph';
 import GraphBuilderState from './GraphBuilderState';
 import { getVisitors } from './Visitors';

--- a/packages/shaker/src/identifierHandlers.ts
+++ b/packages/shaker/src/identifierHandlers.ts
@@ -1,6 +1,6 @@
 import { types as t } from '@babel/core';
 import type { Aliases, Identifier, Node, VisitorKeys } from '@babel/types';
-import { peek } from '@linaria/babel';
+import { peek } from '@linaria/babel-preset';
 import GraphBuilderState from './GraphBuilderState';
 import type { IdentifierHandlerType, NodeType } from './types';
 import { identifierHandlers as core } from './langs/core';

--- a/packages/shaker/src/index.ts
+++ b/packages/shaker/src/index.ts
@@ -2,8 +2,8 @@ import generator from '@babel/generator';
 import { transformSync } from '@babel/core';
 import type { Program } from '@babel/types';
 import { debug } from '@linaria/logger';
-import type { Evaluator, StrictOptions } from '@linaria/babel';
-import { buildOptions } from '@linaria/babel';
+import type { Evaluator, StrictOptions } from '@linaria/babel-preset';
+import { buildOptions } from '@linaria/babel-preset';
 import shake from './shaker';
 
 function prepareForShake(

--- a/packages/shaker/src/langs/core.ts
+++ b/packages/shaker/src/langs/core.ts
@@ -23,7 +23,7 @@ import type {
   WhileStatement,
 } from '@babel/types';
 
-import { peek } from '@linaria/babel';
+import { peek } from '@linaria/babel-preset';
 import type { IdentifierHandlers, Visitors } from '../types';
 import GraphBuilderState from '../GraphBuilderState';
 import ScopeManager from '../scope';

--- a/packages/shaker/src/shaker.ts
+++ b/packages/shaker/src/shaker.ts
@@ -1,7 +1,7 @@
 import type { Node, Program } from '@babel/types';
 import generator from '@babel/generator';
 import { debug } from '@linaria/logger';
-import { isNode, getVisitorKeys } from '@linaria/babel';
+import { isNode, getVisitorKeys } from '@linaria/babel-preset';
 import build from './graphBuilder';
 import dumpNode from './dumpNode';
 

--- a/packages/shaker/tsconfig.json
+++ b/packages/shaker/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "paths": {},
-    "rootDir": "src/"
-  },
+  "compilerOptions": { "paths": {}, "rootDir": "src/" },
   "references": [
     { "path": "../babel" },
     { "path": "../logger" },

--- a/packages/stylelint/package.json
+++ b/packages/stylelint/package.json
@@ -36,7 +36,7 @@
     "watch": "yarn build --watch"
   },
   "dependencies": {
-    "@linaria/babel": "^3.0.0-beta.0",
+    "@linaria/babel-preset": "^3.0.0-beta.0",
     "strip-ansi": "^5.2.0"
   }
 }

--- a/packages/stylelint/src/preprocessor.ts
+++ b/packages/stylelint/src/preprocessor.ts
@@ -1,6 +1,6 @@
 import stripAnsi from 'strip-ansi';
-import { transform } from '@linaria/babel';
-import type { Replacement } from '@linaria/babel';
+import { transform } from '@linaria/babel-preset';
+import type { Replacement } from '@linaria/babel-preset';
 
 type Errors = {
   [key: string]:

--- a/packages/stylelint/tsconfig.json
+++ b/packages/stylelint/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "paths": {},
-    "rootDir": "src/"
-  },
+  "compilerOptions": { "paths": {}, "rootDir": "src/" },
   "references": [{ "path": "../babel" }]
 }

--- a/packages/webpack4-loader/package.json
+++ b/packages/webpack4-loader/package.json
@@ -46,7 +46,7 @@
     "source-map": "^0.6.1"
   },
   "dependencies": {
-    "@linaria/babel": "^3.0.0-beta.0",
+    "@linaria/babel-preset": "^3.0.0-beta.0",
     "@linaria/logger": "^3.0.0-beta.0",
     "cosmiconfig": "^5.1.0",
     "enhanced-resolve": "^4.1.0",

--- a/packages/webpack4-loader/src/index.ts
+++ b/packages/webpack4-loader/src/index.ts
@@ -13,7 +13,7 @@ import enhancedResolve from 'enhanced-resolve';
 import findYarnWorkspaceRoot from 'find-yarn-workspace-root';
 import type { RawSourceMap } from 'source-map';
 import cosmiconfig from 'cosmiconfig';
-import { EvalCache, Module, transform } from '@linaria/babel';
+import { EvalCache, Module, transform } from '@linaria/babel-preset';
 import { debug } from '@linaria/logger';
 
 const workspaceRoot = findYarnWorkspaceRoot();

--- a/packages/webpack4-loader/tsconfig.json
+++ b/packages/webpack4-loader/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "paths": {},
-    "rootDir": "src/"
-  },
+  "compilerOptions": { "paths": {}, "rootDir": "src/" },
   "references": [{ "path": "../babel" }, { "path": "../logger" }]
 }

--- a/packages/webpack5-loader/package.json
+++ b/packages/webpack5-loader/package.json
@@ -47,7 +47,7 @@
     "webpack": "^5.6.0"
   },
   "dependencies": {
-    "@linaria/babel": "3.0.0-beta.0",
+    "@linaria/babel-preset": "3.0.0-beta.0",
     "@linaria/logger": "3.0.0-beta.0",
     "cosmiconfig": "^5.1.0",
     "enhanced-resolve": "^5.3.1",

--- a/packages/webpack5-loader/src/index.ts
+++ b/packages/webpack5-loader/src/index.ts
@@ -13,7 +13,7 @@ import enhancedResolve from 'enhanced-resolve';
 import findYarnWorkspaceRoot from 'find-yarn-workspace-root';
 import type { RawSourceMap } from 'source-map';
 import cosmiconfig from 'cosmiconfig';
-import { EvalCache, Module, transform } from '@linaria/babel';
+import { EvalCache, Module, transform } from '@linaria/babel-preset';
 import { debug } from '@linaria/logger';
 
 const workspaceRoot = findYarnWorkspaceRoot();

--- a/packages/webpack5-loader/tsconfig.json
+++ b/packages/webpack5-loader/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "paths": {},
-    "rootDir": "src/"
-  },
+  "compilerOptions": { "paths": {}, "rootDir": "src/" },
   "references": [{ "path": "../babel" }, { "path": "../logger" }]
 }

--- a/website/babel.config.js
+++ b/website/babel.config.js
@@ -4,7 +4,7 @@ module.exports = {
     server: {
       presets: [
         ['@babel/preset-env', { targets: { node: 8 } }],
-        require.resolve('@linaria/babel'),
+        require.resolve('@linaria/babel-preset'),
       ],
       plugins: [
         [

--- a/website/package.json
+++ b/website/package.json
@@ -35,6 +35,7 @@
     "@babel/cli": "^7.12.1",
     "@babel/core": "^7.12.3",
     "@babel/preset-flow": "^7.0.0",
+    "@linaria/babel-preset": "^3.0.0-beta.0",
     "@linaria/stylelint": "^3.0.0-beta.0",
     "@linaria/webpack4-loader": "^3.0.0-beta.0",
     "babel-loader": "^8.0.5",


### PR DESCRIPTION
## Motivation

Babel forces to use standardized names for plugins and presets.

## Summary

`@linaria/babel` has been renamed `@linaria/babel-preset`, so that Babel will allow to use it without prefix `module:` in a list of presets. (#704)
