### PR TITLE
docs: fixing links to other doc files

### DIFF
--- a/docs/2.0_MIGRATION_GUIDE.md
+++ b/docs/2.0_MIGRATION_GUIDE.md
@@ -12,7 +12,7 @@ We set babel preset that makes all non-browser dependencies compatible with `nod
 
 After that you should be able to solve issues with `core-js` dependency in your project, because it will no longer collide with version used by Linaria.
 
-### The default [evaluation strategy](../HOW_IT_WORKS.md#evaluators) has been changed to `shaker` 
+### The default [evaluation strategy](./HOW_IT_WORKS.md#evaluators) has been changed to `shaker` 
 
 It should not affect existed code since the new strategy is more powerful, but you can always switch to the old one by adding the next `rules` section to your Linaria-config:
 ```js

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -9,7 +9,7 @@ Linaria consists of 2 parts:
 
 The Babel plugin will look for `css` and `styled` tags in your code, extract the CSS out and return it in the file's metadata. It will also generate unique class names based on the hash of the filename.
 
-> To get a deep dive into Linaria babel plugin internals, check [debugging section of Contributing docs](../CONTRIBUTING.md#debugging-and-deep-dive-into-babel-plugin)
+> To get a deep dive into Linaria babel plugin internals, check [debugging section of Contributing docs](./CONTRIBUTING.md#debugging-and-deep-dive-into-babel-plugin)
 
 When using the `styled` tag, dynamic interpolations will be replaced with CSS custom properties. References to constants in the scope will also be inlined. If the same expression is used multiple times, the plugin will create a single CSS custom property for those.
 
@@ -168,7 +168,7 @@ Currently, we have two built-in strategies:
 - `extractor` was the default strategy in `1.x` version. It takes an interpolated expression, finds all the referenced identifiers, gets all its declarations, repeats cycle for all identifiers in found declarations, and then constructs a new tree of statements from all found declarations. It's a pretty simple strategy, but it significantly changes an evaluated code and doesn't work for non-primitive js-constructions.
 - `shaker` was introduced as an option in `1.4` and became the default in `2.0` version. In contrast to `extractor`, `shaker` tries to find all irrelevant code and cuts it out of the file. As a result, interpolated values can be defined without any restrictions.
 
-If an interpolated value or one of its dependencies is imported from another module, that module will be also processed with an evaluator (the implementation of evaluator will be chosen by matching `rules` from [the Linaria config](../CONFIGURATION.md#options)).
+If an interpolated value or one of its dependencies is imported from another module, that module will be also processed with an evaluator (the implementation of evaluator will be chosen by matching `rules` from [the Linaria config](./CONFIGURATION.md#options)).
 
 Sometimes it can be useful to implement your own strategy (it can be just a mocked version of some heavy or browser-only library). You can do it by implementing `Evaluator` function:
 


### PR DESCRIPTION
## Motivation

Links in some doc files were pointing to wrong location with relative path.

## Summary
Tweaked the relative path to correctly point to the doc file