### PR TITLE
fix: loadOptions test regex

### DIFF
--- a/packages/babel/src/utils/loadOptions.ts
+++ b/packages/babel/src/utils/loadOptions.ts
@@ -28,7 +28,7 @@ export default function loadOptions(
       },
       {
         // The old `ignore` option is used as a default value for `ignore` rule.
-        test: ignore ?? /\/node_modules\//,
+        test: ignore ?? /[\\/]node_modules[\\/]/,
         action: 'ignore',
       },
     ],


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->

Fixes #727 

## Summary

Changes test regex in loadOptions to match `node_modules` path on Win machines, not only nix.

## Test plan

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->

1. create sample project with react, linaria and webpack
2. make dummy react component wrapped into react's `memo`
3. wrap abovementioned react component into linaria's `styled`
4. run build in different envs (e.g. linux, macos, windows)
5. build should finish with success
