### PR TITLE
feat(babel): expose CSS extraction from AST logic

### DIFF
--- a/packages/babel/src/index.ts
+++ b/packages/babel/src/index.ts
@@ -15,7 +15,11 @@ export { default as JSXElement } from './evaluators/visitors/JSXElement';
 export { default as ProcessCSS } from './evaluators/visitors/ProcessCSS';
 export { default as ProcessStyled } from './evaluators/visitors/ProcessStyled';
 export { default as Module } from './module';
-export { default as transform } from './transform';
+export {
+  default as transform,
+  extractCssFromAst,
+  shouldTransformCode,
+} from './transform';
 export * from './types';
 export type { PluginOptions } from './utils/loadOptions';
 export { default as isNode } from './utils/isNode';


### PR DESCRIPTION
Hi all! 👋  Thanks in advance for reviewing my PR! 👀 

## Motivation

My company uses the [Metro module bundler](https://facebook.github.io/metro/) for building our JS bundles. As part of this, we specify our **own [custom babel transformer](https://facebook.github.io/metro/docs/configuration#babeltransformerpath)** for mapping TypeScript source files into their transformed JS equivalent. Our custom transformer calls babel's `transformFromAstSync()` under the hood to do this.

One of the things we'd like to do in our transformer is extract the Linaria CSS from the source file being transformed and, therefore, because we've already created the AST all we need is the **post processing CSS extraction logic**.

## Summary

Moved the logic for extracting CSS from the AST into the `extractCssFromAst()` function and export it from the`@linaria/babel-preset` package.

## Test plan

- [ ] `yarn link` @linaria/babel-preset to our project and ensure it compiles

## Follow up

We're currently using Linaria `v2.0.2` and so I'd also like to back port and have the change released... I'm assuming I can do this by releasing a PR against the `2.0.x` branch?