### PR TITLE
fix: Import custom identifier called css with error "Cannot find module 'linaria'" #739

### DIFF
--- a/packages/babel/src/utils/hasImport.ts
+++ b/packages/babel/src/utils/hasImport.ts
@@ -8,13 +8,13 @@ const linariaLibs = new Set([
   'linaria/react',
 ]);
 
-const safeResolve = (name) => {
+const safeResolve = (name: string) => {
   try {
     return require.resolve(name);
   } catch (err) {
     return null;
   }
-}
+};
 
 // Verify if the binding is imported from the specified source
 export default function hasImport(

--- a/packages/babel/src/utils/hasImport.ts
+++ b/packages/babel/src/utils/hasImport.ts
@@ -8,6 +8,14 @@ const linariaLibs = new Set([
   'linaria/react',
 ]);
 
+const safeResolve = (name) => {
+  try {
+    return require.resolve(name);
+  } catch (err) {
+    return null;
+  }
+}
+
 // Verify if the binding is imported from the specified source
 export default function hasImport(
   t: any,
@@ -44,7 +52,7 @@ export default function hasImport(
         // Otherwise try to resolve both and check if they are the same file
         resolveFromFile(value) ===
           (linariaLibs.has(source)
-            ? require.resolve(source)
+            ? safeResolve(source)
             : resolveFromFile(source))
     );
 


### PR DESCRIPTION

## Motivation

https://github.com/callstack/linaria/issues/739

## Summary

When import `css` from some module like './utils',  webpack will throw an error "Cannot find module 'linaria'"

```js
import { css } from './utils';

...

```

Because the package 'linaria' is deprecated, At [here](https://github.com/callstack/linaria/blob/master/packages/babel/src/utils/hasImport.ts#L47) try the resolve this. And then require.resolve will throw an exception.

## Test plan

use this case https://codesandbox.io/s/linaria-demo-forked-rbivr?file=/src/index.js
