### PR TITLE
fix(core): remove unnecessary spread operators from css and cx (#746)

### DIFF
--- a/packages/core/__tests__/cx.test.ts
+++ b/packages/core/__tests__/cx.test.ts
@@ -1,0 +1,7 @@
+import { cx } from '../src';
+
+it('should filter falsy values', () => {
+  expect(cx('1', 'test', false, '2', 0, '', null, undefined, '3')).toBe(
+    '1 test 2 3'
+  );
+});

--- a/packages/core/src/css.ts
+++ b/packages/core/src/css.ts
@@ -1,11 +1,15 @@
 import type { CSSProperties } from './CSSProperties';
 import type { StyledMeta } from './StyledMeta';
 
-export default function css(
-  _strings: TemplateStringsArray,
-  ..._exprs: Array<string | number | CSSProperties | StyledMeta>
-): string {
+type CSS = (
+  strings: TemplateStringsArray,
+  ...exprs: Array<string | number | CSSProperties | StyledMeta>
+) => string;
+
+const css: CSS = () => {
   throw new Error(
     'Using the "css" tag in runtime is not supported. Make sure you have set up the Babel plugin correctly.'
   );
-}
+};
+
+export default css;

--- a/packages/core/src/cx.ts
+++ b/packages/core/src/cx.ts
@@ -1,5 +1,9 @@
 export type ClassName = string | false | void | null | 0;
 
-export default function cx(...classNames: ClassName[]): string {
-  return classNames.filter(Boolean).join(' ');
-}
+type CX = (...classNames: ClassName[]) => string;
+
+const cx: CX = function cx() {
+  return Array.prototype.slice.call(arguments).filter(Boolean).join(' ');
+};
+
+export default cx;


### PR DESCRIPTION
## Motivation

Fix for https://github.com/callstack/linaria/issues/746

## Summary

Spread operators aren't really necessary in `core`, so I've separated type-definition and implementation and made the implementation fully es5 compatible.

## Test plan

A new tiny test was added.