### PR TITLE
fix(core,react): make IE 11 compatible (fixes #746)

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -14,13 +14,7 @@
  */
 
 const commonJSTargets = {
-  browsers: [
-    'last 2 versions',
-    'not ie 11',
-    'not ie_mob 11',
-    'not op_mini all',
-    'not dead',
-  ],
+  browsers: ['last 2 versions', 'not op_mini all', 'not dead'],
   node: '10',
 };
 
@@ -72,6 +66,13 @@ module.exports = {
                 loose: true,
                 // our styled component should not need to use any polyfill. We do not include core-js in dependencies. However, we leave this to detect if future changes would not introduce any need for polyfill
                 useBuiltIns: 'usage',
+                // Even core-js doesn't remember IE11
+                exclude: [
+                  /es\.array\.(?:filter|for-each|index-of|join|reduce|slice)/,
+                  'es.function.name',
+                  'es.object.keys',
+                  'web.dom-collections.for-each',
+                ],
                 corejs: 3,
                 // this is used to test if we do not introduced core-js polyfill
                 debug: process.env.DEBUG_CORE_JS === 'true',


### PR DESCRIPTION
## Motivation

Linaria can partially work even in IE (except prop-based interpolation), but we don't transpile `core` and `styled` to es3, so people with old browsers get completely broken page. This PR fixes that issue. https://github.com/callstack/linaria/issues/746

## Summary

- dropped `not ie 11` from the targets;
- replaced unsupported functions;
- overridden polyfills config for core-js.
