### PR TITLE
chore: fix vscode auto import incorrect path

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,7 @@
   "sideEffects": false,
   "main": "lib/index.js",
   "module": "esm/index.js",
-  "types": "types",
+  "types": "types/index.d.ts",
   "files": [
     "types/",
     "lib/",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -8,7 +8,7 @@
   "sideEffects": false,
   "main": "lib/index.js",
   "module": "esm/index.js",
-  "types": "types",
+  "types": "types/index.d.ts",
   "files": [
     "types/",
     "lib/",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->
In vs code ide, if I auto import the `css` method, I will get the code: `import { css } from "@linaria/core/types";`.

It maybe a bug of vs code, but I don't think they will fix it recently. This pr could avoid this issue.

### before

![image](https://user-images.githubusercontent.com/5526525/115011445-36d9b680-9ee1-11eb-9136-72a7876950e4.png)


### after

![image](https://user-images.githubusercontent.com/5526525/115011328-1ad61500-9ee1-11eb-8ab0-8387b6340e5a.png)


## Summary

<!--
Explain how your implementation works and your thoughts behind the solution.
It will help maintainers to review your PR.
You can skip it if PR is trivial.
-->

## Test plan

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->

Do as the screenshot above.
