### PR TITLE
fix(cli): cannot find module '../lib/cli' (#753)

### DIFF
--- a/packages/cli/bin/linaria.js
+++ b/packages/cli/bin/linaria.js
@@ -2,4 +2,4 @@
 
 /* eslint-disable import/no-unresolved */
 
-module.exports = require('../lib/cli');
+module.exports = require('../lib/linaria');


### PR DESCRIPTION
## Motivation

This PR fixes a regression in @linaria/cli

## Summary

See #753 
