### PR TITLE
fix(webpack): hot reload fails after compile error (fixes #762)

### DIFF
--- a/packages/webpack4-loader/src/index.ts
+++ b/packages/webpack4-loader/src/index.ts
@@ -82,8 +82,11 @@ export default function webpack4Loader(
 
   try {
     // Use webpack's resolution when evaluating modules
-    Module._resolveFilename = (id, { filename }) =>
-      resolveSync(path.dirname(filename), id);
+    Module._resolveFilename = (id, { filename }) => {
+      const result = resolveSync(path.dirname(filename), id);
+      this.addDependency(result);
+      return result;
+    };
 
     result = transform(content, {
       filename: path.relative(process.cwd(), this.resourcePath),

--- a/packages/webpack5-loader/src/index.ts
+++ b/packages/webpack5-loader/src/index.ts
@@ -87,6 +87,7 @@ export default function webpack5Loader(
         throw new Error('No result');
       }
 
+      this.addDependency(result);
       return result;
     };
 


### PR DESCRIPTION
## Motivation

In case of an error, webpack loaders don't mark some files as a dependency and that causes problems with HMR. (#762)

## Summary

This PR adds an explicit call of `addDependency` for required files.
