### PR TITLE
feat(interop): interop between Linaria and traditional CSS-in-JS libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ Take a look on [Contributing](CONTRIBUTING.md) docs to check how you can run Lin
 
   Here, there should be no side-effects in the `colors.js` file, or any file it imports. We recommend to move helpers and shared configuration to files without any side-effects.
 
+## Interoperability with other CSS-in-JS libraries
+
+Linaria can work together with other CSS-in-JS libraries out-of-the-box. However, if you want to use styled components from Linaria as selectors in `styled-components`/`emotion`, you need to use [@linaria/interop](/packages/interop/README.md)    
+
 ## Editor Plugins
 
 ### VSCode

--- a/packages/interop/README.md
+++ b/packages/interop/README.md
@@ -1,0 +1,45 @@
+<p align="center">
+  <img alt="Linaria" src="https://raw.githubusercontent.com/callstack/linaria/HEAD/website/assets/linaria-logo@2x.png" width="496">
+</p>
+
+<p align="center">
+Zero-runtime CSS in JS library.
+</p>
+
+---
+
+# `@linaria/interop`
+
+This plugin allows to interpolate Linaria components inside styled-components and Emotion:
+```javascript
+import styled from 'styled-components';
+import { Title } from './Title.styled'; // Linaria component
+
+const Article = () => { /* … */ };
+
+export default styled(Article)`
+  & > ${Title} {
+    color: green;
+  }
+`;
+
+```
+
+## Quick start
+
+Install the plugin first:
+
+```
+npm install --save-dev @linaria/interop
+```
+
+Then add `@linaria/interop` to your babel configuration *before* `styled-components`:
+
+```JSON
+{
+  "plugins": [
+    ["@linaria/interop", { "library": "styled-components" }],
+    "styled-components"
+  ]
+}
+```

--- a/packages/interop/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/interop/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`styled-components css 1`] = `
+"import { css } from \\"styled-components\\";
+import Title from \\"./Title\\";
+export default css\`
+  & > \${(i => i && i.__linaria ? '.' + i.__linaria.className : i)(Title)} {
+    color: red;
+  }
+\`;"
+`;
+
+exports[`styled-components keeps linaria 1`] = `
+"import styled from \\"linaria/react\\";
+import Title from \\"./Title\\";
+export default styled.h1\`
+  & > \${Title} {
+    color: red;
+  }
+\`;"
+`;
+
+exports[`styled-components member expression as selector 1`] = `
+"import styled from \\"styled-components\\";
+import Title from \\"./Title\\";
+export default styled.h1\`
+  & > \${(i => i && i.__linaria ? '.' + i.__linaria.className : i)(Title.Small)} {
+    color: red;
+  }
+\`;"
+`;
+
+exports[`styled-components styled(Cmp) 1`] = `
+"import styled from \\"styled-components\\";
+import Cmp from \\"./Cmp\\";
+import Title from \\"./Title\\";
+export default styled(Cmp)\`
+  & > \${(i => i && i.__linaria ? '.' + i.__linaria.className : i)(Title)} {
+    color: red;
+  }
+\`;"
+`;
+
+exports[`styled-components styled(Cmp).attrs({}) 1`] = `
+"import styled from \\"styled-components\\";
+import Cmp from \\"./Cmp\\";
+import Title from \\"./Title\\";
+export default styled(Cmp).attrs(() => ({}))\`
+  & > \${(i => i && i.__linaria ? '.' + i.__linaria.className : i)(Title)} {
+    color: red;
+  }
+\`;"
+`;
+
+exports[`styled-components styled.h1 1`] = `
+"import styled from \\"styled-components\\";
+import Title from \\"./Title\\";
+export default styled.h1\`
+  & > \${(i => i && i.__linaria ? '.' + i.__linaria.className : i)(Title)} {
+    color: red;
+  }
+\`;"
+`;
+
+exports[`styled-components styled.h1.attrs({}) 1`] = `
+"import styled from \\"styled-components\\";
+import Title from \\"./Title\\";
+export default styled.h1.attrs(() => ({}))\`
+  & > \${(i => i && i.__linaria ? '.' + i.__linaria.className : i)(Title)} {
+    color: red;
+  }
+\`;"
+`;

--- a/packages/interop/__tests__/index.test.js
+++ b/packages/interop/__tests__/index.test.js
@@ -1,0 +1,117 @@
+const babel = require('@babel/core');
+const dedent = require('dedent');
+const plugin = require('../');
+
+const getCode = (src) => {
+  const { code } = babel.transform(dedent(src), { plugins: [plugin] });
+  return code;
+};
+
+describe('styled-components', function () {
+  it('keeps linaria', () => {
+    const code = getCode(`
+    import styled from "linaria/react";
+    import Title from "./Title";
+
+    export default styled.h1\`
+      & > ${'${Title}'} {
+        color: red;
+      }
+    \`;
+  `);
+
+    expect(code).toMatchSnapshot();
+  });
+
+  it('css', () => {
+    const code = getCode(`
+    import { css } from "styled-components";
+    import Title from "./Title";
+
+    export default css\`
+      & > ${'${Title}'} {
+        color: red;
+      }
+    \`;
+  `);
+
+    expect(code).toMatchSnapshot();
+  });
+
+  it('styled.h1', () => {
+    const code = getCode(`
+    import styled from "styled-components";
+    import Title from "./Title";
+
+    export default styled.h1\`
+      & > ${'${Title}'} {
+        color: red;
+      }
+    \`;
+  `);
+
+    expect(code).toMatchSnapshot();
+  });
+
+  it('member expression as selector', () => {
+    const code = getCode(`
+    import styled from "styled-components";
+    import Title from "./Title";
+
+    export default styled.h1\`
+      & > ${'${Title.Small}'} {
+        color: red;
+      }
+    \`;
+  `);
+
+    expect(code).toMatchSnapshot();
+  });
+
+  it('styled(Cmp)', () => {
+    const code = getCode(`
+    import styled from "styled-components";
+    import Cmp from "./Cmp";
+    import Title from "./Title";
+
+    export default styled(Cmp)\`
+      & > ${'${Title}'} {
+        color: red;
+      }
+    \`;
+  `);
+
+    expect(code).toMatchSnapshot();
+  });
+
+  it('styled(Cmp).attrs({})', () => {
+    const code = getCode(`
+    import styled from "styled-components";
+    import Cmp from "./Cmp";
+    import Title from "./Title";
+
+    export default styled(Cmp).attrs(() => ({}))\`
+      & > ${'${Title}'} {
+        color: red;
+      }
+    \`;
+  `);
+
+    expect(code).toMatchSnapshot();
+  });
+
+  it('styled.h1.attrs({})', () => {
+    const code = getCode(`
+    import styled from "styled-components";
+    import Title from "./Title";
+
+    export default styled.h1.attrs(() => ({}))\`
+      & > ${'${Title}'} {
+        color: red;
+      }
+    \`;
+  `);
+
+    expect(code).toMatchSnapshot();
+  });
+});

--- a/packages/interop/index.js
+++ b/packages/interop/index.js
@@ -1,0 +1,54 @@
+module.exports = function ({ types: t }, config = {}) {
+  const library = config.library || 'styled-components';
+  const isLibrary =
+    library instanceof RegExp ? (s) => library.test(s) : (s) => s === library;
+  const fixer = {
+    'MemberExpression|Identifier': (path) => {
+      if (!t.isTemplateLiteral(path.parent) || path.listKey !== 'expressions') {
+        return;
+      }
+
+      const original = path.node;
+      path.replaceWithSourceString(
+        `(i => i && i.__linaria ? '.' + i.__linaria.className : i)('placeholder')`
+      );
+      path.get('arguments.0').replaceWith(original);
+    },
+  };
+
+  return {
+    visitor: {
+      TaggedTemplateExpression(path) {
+        const tag = path.get('tag');
+        let identifier = null;
+        if (t.isIdentifier(tag)) {
+          identifier = tag;
+        } else if (t.isMemberExpression(tag)) {
+          identifier = tag.get('object');
+        } else if (t.isCallExpression(tag)) {
+          identifier = tag.get('callee');
+        }
+
+        if (t.isMemberExpression(identifier)) {
+          // it's something like styled().attrs()
+          if (t.isCallExpression(identifier.node.object)) {
+            identifier = identifier.get('object.callee');
+          } else if (t.isMemberExpression(identifier.node.object)) {
+            identifier = identifier.get('object.object');
+          }
+        }
+
+        const scope = identifier.scope;
+        const binding = scope.getBinding(identifier.node.name);
+        if (!t.isImportDeclaration(binding.path.parent)) {
+          return;
+        }
+
+        const importSource = binding.path.parent.source.value;
+        if (isLibrary(importSource)) {
+          path.get('quasi').traverse(fixer);
+        }
+      },
+    },
+  };
+};

--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@linaria/babel-plugin-interop",
+  "version": "3.0.0-beta.5",
+  "main": "index.js",
+  "repository": "https://github.com/callstack/linaria/tree/master/packages/interop",
+  "homepage": "https://github.com/callstack/linaria/tree/master/packages/interop#readme",
+  "author": {
+    "name": "Anton Evzhakov",
+    "email": "anton@evz.name"
+  },
+  "scripts": {
+    "test": "jest --config ../../jest.config.js --rootDir ."
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "@babel/core": ">=7",
+    "dedent": "^0.7.0"
+  }
+}


### PR DESCRIPTION
## Motivation

Linaria can be used together with traditional CSS-in-JS libraries, but styled components cannot be used as selectors in `styled-components`/`emotion` styles. This PR introduces a plugin that allows such an interoperability
