### PR TITLE
fix(esbuild): import esbuild correctly

### DIFF
--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -8,7 +8,7 @@ import path from 'path';
 import fs from 'fs';
 import type { PluginOptions, Preprocessor } from '@linaria/babel-preset';
 import { slugify, transform } from '@linaria/babel-preset';
-import esbuild, { Plugin, TransformOptions, Loader } from 'esbuild';
+import { transformSync, Plugin, TransformOptions, Loader } from 'esbuild';
 
 type EsbuildPluginOptions = {
   sourceMap?: boolean;
@@ -55,7 +55,7 @@ export default function linaria({
           };
         }
 
-        const { code } = esbuild.transformSync(rawCode, {
+        const { code } = transformSync(rawCode, {
           ...esbuildOptions,
           loader,
         });


### PR DESCRIPTION
The previous way of importing esbuild would lead the error:
 > node_modules/@linaria/esbuild/lib/index.js:74:29: error: [plugin: linaria] Cannot read property 'transformSync' of undefined
    74         } = _esbuild.default.transformSync(rawCode, { ...esbuildOptions,

<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

When using linaria with esbuild as described here: https://github.com/callstack/linaria/blob/master/docs/BUNDLERS_INTEGRATION.md#esbuild one would get a failing build due to the import not working as expected. Error message:
``` > node_modules/@linaria/esbuild/lib/index.js:74:29: error: [plugin: linaria] Cannot read property 'transformSync' of undefined
    74 │         } = _esbuild.default.transformSync(rawCode, { ...esbuildOptions,
       ╵                              ^
    at ./node_modules/@linaria/esbuild/lib/index.js:74:30
    at callback (./node_modules/esbuild/lib/main.js:869:34)
    at handleRequest (./node_modules/esbuild/lib/main.js:652:36)
    at handleIncomingPacket (./node_modules/esbuild/lib/main.js:699:7)
    at Socket.readFromStdout (./node_modules/esbuild/lib/main.js:576:7)
    at Socket.emit (node:events:394:28)
    at addChunk (node:internal/streams/readable:312:12)
    at readableAddChunk (node:internal/streams/readable:287:9)
    at Socket.Readable.push (node:internal/streams/readable:226:10)
    at Pipe.onStreamRead (node:internal/stream_base_commons:190:23)```

## Summary

esbuild does export `transformSync` just fine and hence it can be imported like the other interfaces.

## Test plan

To test this, you'll need a simple esbuild project. And add the build config (to build.js):
```
const { build } = require("esbuild");
const linaria = require("@linaria/esbuild");

const prod = process.env.NODE_ENV === "production";

build({
  entryPoints: ["./src/index.tsx"],
  outdir: "dist",
  minify: true,
  bundle: true,
  plugins: [
    linaria.default({
      sourceMap: prod,
    }),
  ],
}).catch(() => process.exit(1));
```
Now the build should work and not fail with the previously mentioned issue.
