### PR TITLE
fix(esbuild): workaround to for esbuild compile options

### DIFF
--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -55,6 +55,16 @@ export default function linaria({
           };
         }
 
+        if (typeof esbuildOptions === 'undefined') {
+          esbuildOptions = {};
+          if ('jsxFactory' in build.initialOptions) {
+            esbuildOptions.jsxFactory = build.initialOptions.jsxFactory;
+          }
+          if ('jsxFragment' in build.initialOptions) {
+            esbuildOptions.jsxFragment = build.initialOptions.jsxFragment;
+          }
+        }
+
         const { code } = transformSync(rawCode, {
           ...esbuildOptions,
           loader,


### PR DESCRIPTION
## Motivation

When using esbuild with preact the jsxFactory and jsxFragment parameter are used to use h() rather than React.createElement(). This change ensures that the parameters are passed to the transform function.

## Summary

This workaround checks if jsxFactory or jsxFragment are part of the original build options and if so copies them to to the transform options.

NOTE 1: Usually esbuild would just pick up on tsconfig.json - this workaround won't work there. The pararmeters must be provided explicitly.

NOTE 2: The plugin should probably be rewritten on a more fundamental
level as it interefers heavily with the esbuild build process.

## Test plan

Setup an esbuild sample project with preact and linaria, then use this build script and check that there is no "React.createElement" in the bundle:
```
const { build } = require("esbuild");
const linaria = require("@linaria/esbuild");

const prod = process.env.NODE_ENV === "production";

build({
  entryPoints: ["./src/index.tsx"],
  outdir: "dist",
  jsxFactory: "h",
  jsxFragment: "Fragment",
  minify: true,
  bundle: true,
  plugins: [
    linaria.default({
      sourceMap: prod,
    }),
  ],
}).catch(() => process.exit(1));
```
