### PR TITLE
fix: webpack resolve options

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -86,8 +86,7 @@ module.exports = {
   By default, the loader will resolve modules using the `alias` and `modules`
   settings from your Webpack configuration. If you need additional custom
   configuration for resolving modules, use this property to add or customize the
-  [enhanced-resolve
-  options](https://www.npmjs.com/package/enhanced-resolve#user-content-resolver-options).
+  [enhanced-resolve options](https://www.npmjs.com/package/enhanced-resolve#user-content-resolver-options).
 
 ## `@linaria/babel-preset`
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -80,6 +80,14 @@ module.exports = {
 - `babelOptions: Object`
 
   If you need to specify custom babel configuration, you can pass them here. These babel options will be used by Linaria when parsing and evaluating modules.
+  
+- `resolveOptions: Object`
+
+  By default, the loader will resolve modules using the `alias` and `modules`
+  settings from your Webpack configuration. If you need additional custom
+  configuration for resolving modules, use this property to add or customize the
+  [enhanced-resolve
+  options](https://www.npmjs.com/package/enhanced-resolve#user-content-resolver-options).
 
 ## `@linaria/babel-preset`
 

--- a/packages/webpack4-loader/src/index.ts
+++ b/packages/webpack4-loader/src/index.ts
@@ -34,11 +34,17 @@ export default function webpack4Loader(
 
   EvalCache.clearForFile(this.resourcePath);
 
+  const resolveOptionsDefaults = {
+    conditionNames: ['require'],
+    extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
+  };
+
   const {
     sourceMap = undefined,
     cacheDirectory = '.linaria-cache',
     preprocessor = undefined,
     extension = '.linaria.css',
+    resolveOptions = {},
     ...rest
   } = loaderUtils.getOptions(this) || {};
 
@@ -57,23 +63,21 @@ export default function webpack4Loader(
     )
   );
 
-  const resolveOptions = {
-    extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
-  };
-
   const resolveSync = enhancedResolve.create.sync(
     // this._compilation is a deprecated API
     // However there seems to be no other way to access webpack's resolver
     // There is this.resolve, but it's asynchronous
     // Another option is to read the webpack.config.js, but it won't work for programmatic usage
     // This API is used by many loaders/plugins, so hope we're safe for a while
-    this._compilation?.options.resolve
-      ? {
-          ...resolveOptions,
-          alias: this._compilation.options.resolve.alias,
-          modules: this._compilation.options.resolve.modules,
-        }
-      : resolveOptions
+    {
+      ...resolveOptionsDefaults,
+      ...((this._compilation?.options.resolve && {
+        alias: this._compilation.options.resolve.alias,
+        modules: this._compilation.options.resolve.modules,
+      }) ||
+        {}),
+      ...resolveOptions,
+    }
   );
 
   let result;

--- a/packages/webpack5-loader/src/index.ts
+++ b/packages/webpack5-loader/src/index.ts
@@ -32,11 +32,17 @@ export default function webpack5Loader(
 
   EvalCache.clearForFile(this.resourcePath);
 
+  const resolveOptionsDefaults = {
+    conditionNames: ['require'],
+    extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
+  };
+
   const {
     sourceMap = undefined,
     cacheDirectory = '.linaria-cache',
     preprocessor = undefined,
     extension = '.linaria.css',
+    resolveOptions = {},
     ...rest
   } = this.getOptions() || {};
 
@@ -55,23 +61,21 @@ export default function webpack5Loader(
     )
   );
 
-  const resolveOptions = {
-    extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
-  };
-
   const resolveSync = enhancedResolve.create.sync(
     // this._compilation is a deprecated API
     // However there seems to be no other way to access webpack's resolver
     // There is this.resolve, but it's asynchronous
     // Another option is to read the webpack.config.js, but it won't work for programmatic usage
     // This API is used by many loaders/plugins, so hope we're safe for a while
-    this._compilation?.options.resolve
-      ? {
-          ...resolveOptions,
-          alias: this._compilation.options.resolve.alias,
-          modules: this._compilation.options.resolve.modules,
-        }
-      : resolveOptions
+    {
+      ...resolveOptionsDefaults,
+      ...((this._compilation?.options.resolve && {
+        alias: this._compilation.options.resolve.alias,
+        modules: this._compilation.options.resolve.modules,
+      }) ||
+        {}),
+      ...resolveOptions,
+    }
   );
 
   let result;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

We have some packages that export both ESM and CommonJS modules using [conditional package exports](https://webpack.js.org/guides/package-exports/#conditions) using the `import` and `require` conditions, such as [in this example](https://github.com/rmazzeo-godaddy/linaria-conditionnames-missing/blob/main/simple-dependency/package.json#L12-L21). These work fine in our Webpack 5 apps, however if we try to use these imports in Linaria blocks with the Linaria Webpack loader, it blows up with the error:
```
Package path ./sizes is not exported from package
```

<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->

## Summary

What's missing is that the Linaria webpack loaders do not pass down the appropriate `conditionNames` to the enhanced resolver. This PR adds the `require` condition name by default, and also introduces the ability to customing the loader `resolveOptions`.

<!--
Explain how your implementation works and your thoughts behind the solution.
It will help maintainers to review your PR.
You can skip it if PR is trivial.
-->

## Test plan

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->

@rmazzeo-godaddy put together [this repo](https://github.com/rmazzeo-godaddy/linaria-conditionnames-missing) that reproduces the problem.

```shell
git clone git@github.com:rmazzeo-godaddy/linaria-conditionnames-missing.git
cd linaria-conditionnames-missing
npm ci
npm run start
```