### PR TITLE
fix(shaker): fix undefined imports in some cases (#333, #761)

### DIFF
--- a/packages/babel/__tests__/evaluators/__snapshots__/shaker.test.ts.snap
+++ b/packages/babel/__tests__/evaluators/__snapshots__/shaker.test.ts.snap
@@ -109,6 +109,7 @@ Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 exports.redColor = 'red';
+exports['yellowColor'] = 'yellow';
 Object.defineProperty(exports, \\"greenColor\\", {
   enumerable: true,
   get: function get() {

--- a/packages/babel/__tests__/evaluators/shaker.test.ts
+++ b/packages/babel/__tests__/evaluators/shaker.test.ts
@@ -123,12 +123,14 @@ it('shakes exports', () => {
 });
 
 it('shakes es5 exports', () => {
-  const [shaken] = _shake(undefined, ['redColor', 'greenColor'])`
+  const [shaken] = _shake(undefined, ['redColor', 'greenColor', 'yellowColor'])`
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
     });
     exports.redColor = 'red';
+    exports['yellowColor'] = 'yellow';
+    exports['pinkColor'] = 'pink';
     Object.defineProperty(exports, "blueColor", {
       enumerable: true,
       get: function get() {

--- a/packages/shaker/src/graphBuilder.ts
+++ b/packages/shaker/src/graphBuilder.ts
@@ -114,7 +114,8 @@ class GraphBuilder extends GraphBuilderState {
     ) {
       if (
         t.isMemberExpression(node.left) &&
-        t.isIdentifier(node.left.property)
+        (t.isIdentifier(node.left.property) ||
+          t.isStringLiteral(node.left.property))
       ) {
         if (
           t.isIdentifier(node.left.object) &&
@@ -145,7 +146,12 @@ class GraphBuilder extends GraphBuilderState {
             this.graph.addExport('default', node);
           }
         } else {
-          this.graph.addExport(node.left.property.name, node);
+          // it can be either `exports.name` or `exports["name"]`
+          const nameNode = node.left.property;
+          this.graph.addExport(
+            t.isStringLiteral(nameNode) ? nameNode.value : nameNode.name,
+            node
+          );
         }
       }
     }


### PR DESCRIPTION
## Motivation

Shaker didn't process exports when they were defined with string literals (`exports["foo"] = 42` instead of `exports.foo = 42`).

## Summary

Just a small fix that will resolve #333 and hopefully #761

## Test plan

One test was extended.