### PR TITLE
fix(esbuild): add missing resolveDir to support webfont bundling

### DIFF
--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -40,6 +40,7 @@ export default function linaria({
         return {
           contents: cssLookup.get(args.path),
           loader: 'css',
+          resolveDir: path.basename(args.path),
         };
       });
 


### PR DESCRIPTION
## Motivation

When attempting to bundle a font before, esbuild would complain:
```
> linaria:App_hash.linaria.css:1:46: error: Could not resolve "./font.ttf" (the plugin "linaria" didn't set a resolve directory)
    1 ? @font-face{font-family:"font";src:url("./font.ttf");}...
```

## Summary

With this fix the `resolveDir` is set to the basedir of the file loading the font (or other external asset) and thus relative paths should work just fine.

## Test plan

Note: When testing this, configure the esbuild build to include the appropriate loader, e.g.:
```
    loader: { ".ttf": "dataurl" },
```
