### PR TITLE
fix(shaker): named exports are removed (#800)

### DIFF
--- a/packages/babel/__tests__/evaluators/__snapshots__/preeval.test.ts.snap
+++ b/packages/babel/__tests__/evaluators/__snapshots__/preeval.test.ts.snap
@@ -7,6 +7,28 @@ const Component =
 custom.div\`\`;"
 `;
 
+exports[`hoists exports 1`] = `
+"\\"use strict\\";
+
+var _foo = require(\\"./foo\\");
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+Object.defineProperty(exports, \\"foo\\", {
+  enumerable: true,
+  get: function get() {
+    return _foo.foo;
+  }
+});
+Object.defineProperty(exports, \\"bar\\", {
+  enumerable: true,
+  get: function get() {
+    return _foo.bar;
+  }
+});"
+`;
+
 exports[`preserves classNames 1`] = `
 "import { styled } from '@linaria/react';
 const Component =

--- a/packages/babel/__tests__/evaluators/__snapshots__/shaker.test.ts.snap
+++ b/packages/babel/__tests__/evaluators/__snapshots__/shaker.test.ts.snap
@@ -121,12 +121,11 @@ Object.defineProperty(exports, \\"greenColor\\", {
 exports[`shakes exports 1`] = `
 "\\"use strict\\";
 
+var _ = require(\\"\\\\u2026\\");
+
 Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
-
-var _ = require(\\"\\\\u2026\\");
-
 var a = _.whiteColor;
 exports.__linariaPreval = [a];"
 `;

--- a/packages/babel/__tests__/evaluators/preeval.test.ts
+++ b/packages/babel/__tests__/evaluators/preeval.test.ts
@@ -91,3 +91,31 @@ it('replaces constant', async () => {
 
   expect(code).toMatchSnapshot();
 });
+
+it('hoists exports', async () => {
+  const { code } = await transpile(
+    dedent`
+      "use strict";
+
+      Object.defineProperty(exports, "__esModule", {
+        value: true
+      });
+      Object.defineProperty(exports, "foo", {
+        enumerable: true,
+        get: function get() {
+          return _foo.foo;
+        }
+      });
+      Object.defineProperty(exports, "bar", {
+        enumerable: true,
+        get: function get() {
+          return _foo.bar;
+        }
+      });
+
+      var _foo = require("./foo");
+    `
+  );
+
+  expect(code).toMatchSnapshot();
+});

--- a/packages/preeval/src/index.ts
+++ b/packages/preeval/src/index.ts
@@ -3,7 +3,7 @@
  * It works the same as main `babel/extract` preset, but do not evaluate lazy dependencies.
  */
 import type { NodePath } from '@babel/traverse';
-import type { Program } from '@babel/types';
+import type { Program, Statement, VariableDeclaration } from '@babel/types';
 import type { State, StrictOptions } from '@linaria/babel-preset';
 import {
   GenerateClassNames,
@@ -13,6 +13,30 @@ import {
   ProcessCSS,
 } from '@linaria/babel-preset';
 import { Core } from './babel';
+
+const isHoistableExport = (
+  node: NodePath<Statement>
+): node is NodePath<Statement> & NodePath<VariableDeclaration> => {
+  // Only `var` can be hoisted
+  if (!node.isVariableDeclaration({ kind: 'var' })) return false;
+
+  const declarations = node.get('declarations');
+
+  // Our target has only one declaration
+  if (!Array.isArray(declarations) || declarations.length !== 1) return false;
+
+  const init = declarations[0].get('init');
+  // It should be initialized with CallExpression…
+  if (!init || Array.isArray(init) || !init.isCallExpression()) return false;
+
+  const callee = init.get('callee');
+  // … which callee should be `required` …
+  if (Array.isArray(callee) || !callee.isIdentifier({ name: 'require' }))
+    return false;
+
+  // … which should be a global identifier
+  return !callee.scope.hasReference('require');
+};
 
 function index(babel: Core, options: StrictOptions) {
   return {
@@ -34,6 +58,21 @@ function index(babel: Core, options: StrictOptions) {
               GenerateClassNames(babel, p, state, options),
             JSXElement,
           });
+        },
+        exit(path: NodePath<Program>) {
+          /* A really dirty hack that solves https://github.com/callstack/linaria/issues/800
+           * Sometimes babel inserts `require` after usages of required modules.
+           * It makes the shaker sad. As a temporary solution, we hoist requires.
+           * This hack should be deleted after transition `shaker` to @babel/traverse
+           */
+          path
+            .get('body')
+            .filter(isHoistableExport)
+            .forEach((p) => {
+              const node = p.node;
+              p.remove();
+              path.unshiftContainer('body', node);
+            });
         },
       },
       CallExpression: ProcessStyled,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

See https://github.com/callstack/linaria/issues/800

## Summary

In some cases, Babel generates code that depends on hoisted variables. Since `shaker` uses simplified tree traversing, it doesn't properly process those cases and isn't able to evaluate the dependencies of a shaking file.

The best solution here would be migration to `@babel/traverse`. However, it will take a while.
So that, this PR implements the worst solution :) I've added a dirty hack to `preeval`, that checks that generated code has those "wrong" variables and hoists them.

## Test plan

One test was added, one test was fixed.