### PR TITLE
fix(shaker): keep exports if there are dependent code (fixes #804)

### DIFF
--- a/packages/babel/__tests__/evaluators/__snapshots__/shaker.test.ts.snap
+++ b/packages/babel/__tests__/evaluators/__snapshots__/shaker.test.ts.snap
@@ -65,6 +65,18 @@ color.green = '#0f0';
 exports.__linariaPreval = [color];"
 `;
 
+exports[`keeps reused exports 1`] = `
+"\\"use strict\\";
+
+var bar = function bar() {
+  return 'hello world';
+};
+
+exports.bar = bar;
+var foo = exports.bar();
+exports.__linariaPreval = [foo];"
+`;
+
 exports[`removes all 1`] = `
 "\\"use strict\\";
 

--- a/packages/babel/__tests__/evaluators/shaker.test.ts
+++ b/packages/babel/__tests__/evaluators/shaker.test.ts
@@ -227,3 +227,17 @@ it('shakes for-in statements', () => {
 
   expect(shaken).toMatchSnapshot();
 });
+
+it('keeps reused exports', () => {
+  const [shaken] = _shake()`
+    const bar = function() {
+      return 'hello world';
+    };
+    exports.bar = bar;
+
+    const foo = exports.bar();
+    exports.__linariaPreval = [foo];
+  `;
+
+  expect(shaken).toMatchSnapshot();
+});

--- a/packages/shaker/package.json
+++ b/packages/shaker/package.json
@@ -50,7 +50,8 @@
     "@linaria/babel-preset": "^3.0.0-beta.7",
     "@linaria/logger": "^3.0.0-beta.3",
     "@linaria/preeval": "^3.0.0-beta.8",
-    "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
+    "ts-invariant": "^0.9.0"
   },
   "peerDependencies": {
     "@babel/core": ">=7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13720,6 +13720,13 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
+ts-invariant@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.9.0.tgz#4c60e9159a31742ab0103f13d7f63314fb5409c9"
+  integrity sha512-+JqhKqywk+ue5JjAC6eTWe57mOIxYXypMUkBDStkAzvnlfkDJ1KGyeMuNRMwOt6GXzHSC1UT9JecowpZDmgXqA==
+  dependencies:
+    tslib "^2.1.0"
+
 tsconfig-paths@^3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"
@@ -13734,6 +13741,11 @@ tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
+  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
 tslint@5.14.0:
   version "5.14.0"


### PR DESCRIPTION
## Motivation

See #804 

## Summary

This PR adds a workaround that processes `exports.somethings` expressions as regular variables in a global scope.

## Test plan

One new test was added.