### PR TITLE
fix(shaker): support for "export * from …" (fixes #808)

### DIFF
--- a/packages/shaker/__fixtures__/bar.js
+++ b/packages/shaker/__fixtures__/bar.js
@@ -1,0 +1,2 @@
+export const bar1 = 'bar1';
+export const bar2 = 'bar2';

--- a/packages/shaker/__fixtures__/foo.js
+++ b/packages/shaker/__fixtures__/foo.js
@@ -1,0 +1,2 @@
+export const foo1 = "foo1";
+export const foo2 = "foo2";

--- a/packages/shaker/__fixtures__/reexports.js
+++ b/packages/shaker/__fixtures__/reexports.js
@@ -1,0 +1,2 @@
+export * from './foo';
+export * from './bar';

--- a/packages/shaker/__tests__/__snapshots__/shaker.test.ts.snap
+++ b/packages/shaker/__tests__/__snapshots__/shaker.test.ts.snap
@@ -1103,6 +1103,24 @@ Dependencies: @babel/runtime/helpers/typeof, @linaria/babel-preset/__fixtures__/
 
 `;
 
+exports[`shaker should work with wildcard reexports 1`] = `
+"import { css } from \\"@linaria/core\\";
+import { foo1 } from \\"../__fixtures__/reexports\\";
+export const square = \\"square_s1t92lw9\\";"
+`;
+
+exports[`shaker should work with wildcard reexports 2`] = `
+
+CSS:
+
+.square_s1t92lw9 {
+  color: foo1;
+}
+
+Dependencies: ../__fixtures__/reexports
+
+`;
+
 exports[`shaker simplifies react components 1`] = `
 "import React from 'react';
 import { styled } from '@linaria/react';

--- a/packages/shaker/__tests__/shaker.test.ts
+++ b/packages/shaker/__tests__/shaker.test.ts
@@ -21,6 +21,22 @@ describe('shaker', () => {
       expect(metadata).toMatchSnapshot();
     });
 
+    it('should work with wildcard reexports', async () => {
+      const { code, metadata } = await transpile(
+        dedent`
+      import { css } from "@linaria/core";
+      import { foo1 } from "../__fixtures__/reexports";
+
+      export const square = css\`
+        color: ${'${foo1}'};
+      \`;
+    `
+      );
+
+      expect(code).toMatchSnapshot();
+      expect(metadata).toMatchSnapshot();
+    });
+
     it('should interpolate imported components', async () => {
       const { code, metadata } = await transpile(
         dedent`

--- a/packages/shaker/src/graphBuilder.ts
+++ b/packages/shaker/src/graphBuilder.ts
@@ -107,6 +107,10 @@ class GraphBuilder extends GraphBuilderState {
     parentKey: VisitorKeys[TParent['type']] | null,
     listIdx: number | null = null
   ): VisitorAction {
+    if (parent) {
+      this.graph.addParent(node, parent);
+    }
+
     if (
       this.isExportsAssigment(node) &&
       !this.isExportsAssigment(node.right) &&


### PR DESCRIPTION
## Motivation

See #808 
 
## Summary

In case of re-export, files don't explicitly contain identifiers that should be kept and `shaker` wasn't able to link exported variables with imported files. This PR fixes that.

## Test plan

A new test was added.