### PR TITLE
fix(styled): remove unnecessary core-js polyfills  (fixes #799)

### DIFF
--- a/packages/core/__tests__/detect-core-js.test.js
+++ b/packages/core/__tests__/detect-core-js.test.js
@@ -26,7 +26,9 @@ it('Ensures that package do not include core-js dependency after build', async (
   });
   const result = await waitForProcess(proc);
   // run `DEBUG_CORE_JS=true yarn build:lib` to debug issues with introduced core-js dependency
-  expect(result).not.toContain('Added following core-js polyfill');
+  expect(result).not.toContain(
+    'The corejs3 polyfill added the following polyfills'
+  );
   expect(result).toContain(
     'Based on your code and targets, the corejs3 polyfill did not add any polyfill'
   );

--- a/packages/react/__tests__/detect-core-js.test.js
+++ b/packages/react/__tests__/detect-core-js.test.js
@@ -26,7 +26,9 @@ it('Ensures that package do not include core-js dependency after build', async (
   });
   const result = await waitForProcess(proc);
   // run `DEBUG_CORE_JS=true yarn build:lib` to debug issues with introduced core-js dependency
-  expect(result).not.toContain('Added following core-js polyfill');
+  expect(result).not.toContain(
+    'The corejs3 polyfill added the following polyfills'
+  );
   expect(result).toContain(
     'Based on your code and targets, the corejs3 polyfill did not add any polyfill'
   );

--- a/packages/react/src/styled.ts
+++ b/packages/react/src/styled.ts
@@ -4,7 +4,7 @@
  * - injects classNames for the returned component
  * - injects CSS variables used to define dynamic styles based on props
  */
-import * as React from 'react';
+import React from 'react';
 import validAttr from '@emotion/is-prop-valid';
 import { cx } from '@linaria/core';
 import type { CSSProperties, StyledMeta } from '@linaria/core';


### PR DESCRIPTION
## Motivation

`@linaria/styled` imports a few unnecessary polyfills.

## Summary

It appeared, that our `detect-core-js` tests were broken and didn't detect a leak of core-js polyfills. The leak itself was caused by wildcard import from `react`.

## Test plan

Boths `detect-core-js` were fixed.