### PR TITLE
feat: make @linaria/shaker optional

### DIFF
--- a/packages/babel/src/utils/loadOptions.ts
+++ b/packages/babel/src/utils/loadOptions.ts
@@ -10,7 +10,7 @@ const explorer = cosmiconfig('linaria');
 export default function loadOptions(
   overrides: Partial<PluginOptions> = {}
 ): Partial<StrictOptions> {
-  const { configFile, ignore, ...rest } = overrides;
+  const { configFile, ignore, rules, ...rest } = overrides;
 
   const result =
     configFile !== undefined
@@ -20,7 +20,7 @@ export default function loadOptions(
   return {
     displayName: false,
     evaluate: true,
-    rules: [
+    rules: rules ?? [
       {
         // FIXME: if `rule` is not specified in a config, `@linaria/shaker` should be added as a dependency
         // eslint-disable-next-line import/no-extraneous-dependencies


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->

I want to use Linaria without evaluating the interpolated values. So I don't need to install `@linaria/shaker` but `@linaria/babel-preset` requires the package if no evaluator rules are active.

The default evaluator rules will be skipped when any rules option is set. It makes `@linaria/shaker` optional.

Related #813.

## Test plan

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->

A rollup example. This should work without `@linaria/shaker` installed.

```js
import linaria from '@linaria/rollup';

export default {
  plugins: [
    linaria({
      rules: [],
    }),
  ],
};
```