### PR TITLE
fix: Faster method of building dependencies array

### DIFF
--- a/packages/shaker/src/DepsGraph.ts
+++ b/packages/shaker/src/DepsGraph.ts
@@ -130,10 +130,11 @@ export default class DepsGraph {
 
   getDependencies(nodes: t.Node[]) {
     this.processQueue();
-    return nodes.reduce(
-      (acc, node) => acc.concat(Array.from(this.dependencies.get(node) || [])),
-      [] as t.Node[]
+    const reduced: t.Node[] = [];
+    nodes.forEach((n) =>
+      reduced.push(...Array.from(this.dependencies.get(n) || []))
     );
+    return reduced;
   }
 
   getLeaf(name: string): t.Node | undefined {


### PR DESCRIPTION

## Motivation

Fixes https://github.com/callstack/linaria/issues/797

## Summary

I'm pretty surprised that this has any impact, I don't have a good rationale for why but it appears to be dramatically faster to update the array in place.

Using the demo repo linked in the above issue without this change:

```
$ webpack
asset app.js 961 KiB [compared for emit] (name: app) 1 related asset
asset styles.css 8.35 KiB [compared for emit] (name: app) 1 related asset
Entrypoint app 969 KiB (1.11 MiB) = styles.css 8.35 KiB app.js 961 KiB 2 auxiliary assets
orphan modules 390 bytes [orphan] 3 modules
runtime modules 670 bytes 3 modules
modules by path ./node_modules/ 947 KiB
  modules by path ./node_modules/scheduler/ 32.4 KiB 4 modules
  modules by path ./node_modules/react/ 59.4 KiB 2 modules
  modules by path ./node_modules/react-dom/ 840 KiB 2 modules
  modules by path ./node_modules/@linaria/ 4.34 KiB 2 modules
  modules by path ./node_modules/@emotion/ 4.41 KiB 2 modules
  modules by path ./node_modules/prop-types/ 4 KiB 2 modules
  ./node_modules/object-assign/index.js 2.06 KiB [built] [code generated]
modules by path ./.linaria-cache/src/*.css 50 bytes (javascript) 8.31 KiB (css/mini-extract)
  ./.linaria-cache/src/App.linaria.css 50 bytes [built] [code generated]
  css ./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[1].use[1]!./.linaria-cache/src/App.linaria.css 8.31 KiB [built] [code generated]
./src/App.js 4.68 KiB [built] [code generated]
webpack 5.42.0 compiled successfully in 23904 ms
```

And with this change:
```
$ webpack
asset app.js 961 KiB [emitted] (name: app) 1 related asset
asset styles.css 8.35 KiB [compared for emit] (name: app) 1 related asset
Entrypoint app 969 KiB (1.11 MiB) = styles.css 8.35 KiB app.js 961 KiB 2 auxiliary assets
orphan modules 390 bytes [orphan] 3 modules
runtime modules 670 bytes 3 modules
modules by path ./node_modules/ 947 KiB
  modules by path ./node_modules/scheduler/ 32.4 KiB 4 modules
  modules by path ./node_modules/react/ 59.4 KiB 2 modules
  modules by path ./node_modules/react-dom/ 840 KiB 2 modules
  modules by path ./node_modules/@linaria/ 4.34 KiB 2 modules
  modules by path ./node_modules/@emotion/ 4.41 KiB 2 modules
  modules by path ./node_modules/prop-types/ 4 KiB 2 modules
  ./node_modules/object-assign/index.js 2.06 KiB [built] [code generated]
modules by path ./.linaria-cache/src/*.css 50 bytes (javascript) 8.31 KiB (css/mini-extract)
  ./.linaria-cache/src/App.linaria.css 50 bytes [built] [code generated]
  css ./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[1].use[1]!./.linaria-cache/src/App.linaria.css 8.31 KiB [built] [code generated]
./src/App.js 4.68 KiB [built] [code generated]
webpack 5.42.0 compiled successfully in 1874 ms
```
