### PR TITLE
feat: Add {file, name, dir, ext} to `classNameSlug` resolution

### DIFF
--- a/packages/babel/__tests__/__snapshots__/babel.test.ts.snap
+++ b/packages/babel/__tests__/__snapshots__/babel.test.ts.snap
@@ -97,7 +97,7 @@ exports[`handles fn passed in as classNameSlug 1`] = `
 "import { styled } from '@linaria/react';
 export const Title = /*#__PURE__*/styled('h1')({
   name: \\"Title\\",
-  class: \\"t17gu1mi_42_Title\\"
+  class: \\"t17gu1mi_Title_t17gu1mi_Title__tests___app_index_js_index__js_app\\"
 });"
 `;
 
@@ -105,7 +105,7 @@ exports[`handles fn passed in as classNameSlug 2`] = `
 
 CSS:
 
-.t17gu1mi_42_Title {
+.t17gu1mi_Title_t17gu1mi_Title__tests___app_index_js_index__js_app {
   font-size: 14px;
 }
 
@@ -389,6 +389,26 @@ Dependencies: NA
 
 `;
 
+exports[`removes fake replacement patterns in string classNameSlug 1`] = `
+"import { styled } from '@linaria/react';
+export const Title = /*#__PURE__*/styled('h1')({
+  name: \\"Title\\",
+  class: \\"__\\"
+});"
+`;
+
+exports[`removes fake replacement patterns in string classNameSlug 2`] = `
+
+CSS:
+
+.__ {
+  font-size: 14px;
+}
+
+Dependencies: NA
+
+`;
+
 exports[`replaces unknown expressions with CSS custom properties 1`] = `
 "import { styled } from '@linaria/react';
 export const Title = /*#__PURE__*/styled(\\"h1\\")({
@@ -552,7 +572,7 @@ exports[`uses string passed in as classNameSlug 1`] = `
 "import { styled } from '@linaria/react';
 export const Title = /*#__PURE__*/styled('h1')({
   name: \\"Title\\",
-  class: \\"testSlug\\"
+  class: \\"t17gu1mi_Title__tests___app_index_js_index__js_app\\"
 });"
 `;
 
@@ -560,7 +580,7 @@ exports[`uses string passed in as classNameSlug 2`] = `
 
 CSS:
 
-.testSlug {
+.t17gu1mi_Title__tests___app_index_js_index__js_app {
   font-size: 14px;
 }
 

--- a/packages/babel/__tests__/babel.test.ts
+++ b/packages/babel/__tests__/babel.test.ts
@@ -43,7 +43,29 @@ it('uses string passed in as classNameSlug', async () => {
       font-size: 14px;
     \`;
 `,
-    { classNameSlug: 'testSlug' }
+    {
+      classNameSlug: ['hash', 'title', 'file', 'name', 'ext', 'dir']
+        .map((s) => `[${s}]`)
+        .join('_'),
+    }
+  );
+
+  expect(code).toMatchSnapshot();
+  expect(metadata).toMatchSnapshot();
+});
+
+it('removes fake replacement patterns in string classNameSlug', async () => {
+  const { code, metadata } = await transpile(
+    dedent`
+    import { styled } from '@linaria/react';
+
+    export const Title = styled('h1')\`
+      font-size: 14px;
+    \`;
+`,
+    {
+      classNameSlug: `[not]_[actual]_[replacements]`,
+    }
   );
 
   expect(code).toMatchSnapshot();
@@ -60,8 +82,17 @@ it('handles fn passed in as classNameSlug', async () => {
     \`;
 `,
     {
-      classNameSlug: (hash, title) => {
-        return `${hash}_${7 * 6}_${title}`;
+      classNameSlug: (hash, title, vars) => {
+        return [
+          hash,
+          title,
+          vars.hash,
+          vars.title,
+          vars.file,
+          vars.name,
+          vars.ext,
+          vars.dir,
+        ].join('_');
       },
     }
   );

--- a/packages/babel/src/types.ts
+++ b/packages/babel/src/types.ts
@@ -113,7 +113,20 @@ export type EvalRule = {
   action: Evaluator | 'ignore' | string;
 };
 
-type ClassNameFn = (hash: string, title: string) => string;
+export type ClassNameSlugVars = {
+  hash: string;
+  title: string;
+  file: string;
+  ext: string;
+  name: string;
+  dir: string;
+};
+
+type ClassNameFn = (
+  hash: string,
+  title: string,
+  args: ClassNameSlugVars
+) => string;
 
 export type StrictOptions = {
   classNameSlug?: string | ClassNameFn;

--- a/packages/babel/src/utils/isSlugVar.ts
+++ b/packages/babel/src/utils/isSlugVar.ts
@@ -1,0 +1,8 @@
+import { ClassNameSlugVars } from '../types';
+
+const isSlugVar = (
+  key: string,
+  slugVars: ClassNameSlugVars
+): key is keyof ClassNameSlugVars => key in slugVars;
+
+export default isSlugVar;


### PR DESCRIPTION
Fixes #650
Fixes #571

## Motivation

If you want to know where a particular class is coming from, you need more than a hash or even the original title of the class. How many `.inner` or `.title` classes have you seen in a large codebase, right?

## Summary

This PR adds four new vars to `classNameSlug` resolution. It also adds the original two `hash` and `title` to the object, with the idea that a future breaking change might sandwich the function parameters down to just this one.

While just `file` would have been sufficient for function style, I added `dir, name, ext` for ease of use with string-style. Here's what you would expect in each:

```ts
{
  hash: 'qdegrke',
  title: 'displayName',
  file: 'this/is/your/module/Component/SubComp.tsx',
  name: 'SubComp',
  ext: 'tsx',
  dir: 'Component',
}
```

## Test plan

Added tests.
