### PR TITLE
fix(shaker): improve dependency resolution for wildcard exports

### DIFF
--- a/packages/babel/__fixtures__/reexports/constants.ts
+++ b/packages/babel/__fixtures__/reexports/constants.ts
@@ -1,0 +1,2 @@
+export const foo = 'foo';
+export const bar = 'bar';

--- a/packages/babel/__fixtures__/reexports/foo.ts
+++ b/packages/babel/__fixtures__/reexports/foo.ts
@@ -1,0 +1,3 @@
+import * as fooStyles from './constants';
+
+export { fooStyles };

--- a/packages/babel/__fixtures__/reexports/index.ts
+++ b/packages/babel/__fixtures__/reexports/index.ts
@@ -1,0 +1,1 @@
+export * from './foo';

--- a/packages/babel/src/module.ts
+++ b/packages/babel/src/module.ts
@@ -242,7 +242,7 @@ class Module {
           } else {
             // For JS/TS files, evaluate the module
             // The module will be transpiled using provided transform
-            m.evaluate(code, only.includes('*') ? null : only);
+            m.evaluate(code, only.includes('*') ? ['*'] : only);
           }
         } else {
           // For non JS/JSON requires, just export the id

--- a/packages/shaker/__tests__/__snapshots__/shaker.test.ts.snap
+++ b/packages/shaker/__tests__/__snapshots__/shaker.test.ts.snap
@@ -144,6 +144,28 @@ Dependencies: @babel/runtime/helpers/interopRequireDefault, @babel/runtime/helpe
 
 `;
 
+exports[`shaker evaluates chain of reexports 1`] = `
+"import { styled } from '@linaria/react';
+import { fooStyles } from \\"@linaria/babel-preset/__fixtures__/reexports\\";
+const value = fooStyles.foo;
+export const H1 = /*#__PURE__*/styled(\\"h1\\")({
+  name: \\"H1\\",
+  class: \\"H1_h1t92lw9\\"
+});"
+`;
+
+exports[`shaker evaluates chain of reexports 2`] = `
+
+CSS:
+
+.H1_h1t92lw9 {
+  color: foo;
+}
+
+Dependencies: @linaria/babel-preset/__fixtures__/reexports
+
+`;
+
 exports[`shaker evaluates complex styles with functions and nested selectors 1`] = `
 "import { css } from '@linaria/core';
 export const bareIconClass = \\"bareIconClass_b1t92lw9\\";

--- a/packages/shaker/__tests__/shaker.test.ts
+++ b/packages/shaker/__tests__/shaker.test.ts
@@ -96,5 +96,23 @@ describe('shaker', () => {
       expect(code).toMatchSnapshot();
       expect(metadata).toMatchSnapshot();
     });
+
+    it('evaluates chain of reexports', async () => {
+      const { code, metadata } = await transpile(
+        dedent`
+      import { styled } from '@linaria/react';
+      import { fooStyles } from "@linaria/babel-preset/__fixtures__/reexports";
+
+      const value = fooStyles.foo;
+
+      export const H1 = styled.h1\`
+        color: ${'${value}'};
+      \`
+      `
+      );
+
+      expect(code).toMatchSnapshot();
+      expect(metadata).toMatchSnapshot();
+    });
   });
 });

--- a/packages/shaker/src/shaker.ts
+++ b/packages/shaker/src/shaker.ts
@@ -50,6 +50,8 @@ function shakeNode<TNode extends Node>(node: TNode, alive: Set<Node>): Node {
   return Object.keys(changes).length ? { ...node, ...changes } : node;
 }
 
+const isDefined = <T>(i: T | undefined): i is T => i !== undefined;
+
 /*
  * Gets AST and a list of nodes for evaluation
  * Removes unrelated “dead” code.
@@ -73,6 +75,10 @@ export default function shake(
   const reexports: string[] = [];
   let deps = (exports ?? [])
     .map((token) => {
+      if (token === '*') {
+        return depsGraph.getLeaves(null).filter(isDefined);
+      }
+
       const node = depsGraph.getLeaf(token);
       if (node) return [node];
       // We have some unknown token. Do we have `export * from …` in that file?


### PR DESCRIPTION
## Motivation

Fixes #816

## Summary

Shaker correctly detected wildcard imports but mistakenly marked everything in the imported file as unnecessary.

## Test plan

A new test was added.