### PR TITLE
Fixes for `--exactOptionalPropertyTypes` TS flag

### DIFF
--- a/packages/react/src/styled.ts
+++ b/packages/react/src/styled.ts
@@ -63,13 +63,15 @@ interface IProps {
 // If styled wraps custom component, that component should have className property
 function styled<TConstructor extends React.FunctionComponent<any>>(
   tag: TConstructor extends React.FunctionComponent<infer T>
-    ? T extends { className?: string }
+    ? T extends { className?: string | undefined }
       ? TConstructor
       : never
     : never
 ): ComponentStyledTag<TConstructor>;
 function styled<T>(
-  tag: T extends { className?: string } ? React.ComponentType<T> : never
+  tag: T extends { className?: string | undefined }
+    ? React.ComponentType<T>
+    : never
 ): ComponentStyledTag<T>;
 function styled<TName extends keyof JSX.IntrinsicElements>(
   tag: TName
@@ -197,7 +199,7 @@ type ComponentStyledTag<T> = <
 >(
   strings: TemplateStringsArray,
   // Expressions can contain functions only if wrapped component has style property
-  ...exprs: TrgProps extends { style?: React.CSSProperties }
+  ...exprs: TrgProps extends { style?: React.CSSProperties | undefined }
     ? Array<
         | StaticPlaceholder
         | ((props: NoInfer<OwnProps & TrgProps>) => string | number)


### PR DESCRIPTION
TypeScript 4.4 introduced [new `--exactOptionalPropertyTypes` flag](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-4.html#exact-optional-property-types---exactoptionalpropertytypes). With this flag enabled typescript compiler strictly distinguish between `?` and `undefined` type. Currently [`@types/react:17.0`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/c134157852d95b32a5feeb675e13489b76fbeda0/types/react/index.d.ts#L1831-L1842) package has `className?: string | undefined` and `style?: CSSProperties | undefined` specified for html attributes, but linaria types are only marked as `?` but `undefined`. This patch fixes this incompatibility
