### PR TITLE
fix(core): return type alias instead of string from `css` and `cx`

### DIFF
--- a/packages/core/src/css.ts
+++ b/packages/core/src/css.ts
@@ -1,10 +1,12 @@
 import type { CSSProperties } from './CSSProperties';
 import type { StyledMeta } from './StyledMeta';
 
+export type LinariaClassName = string & { __linariaClassName: true };
+
 type CSS = (
   strings: TemplateStringsArray,
   ...exprs: Array<string | number | CSSProperties | StyledMeta>
-) => string;
+) => LinariaClassName;
 
 const css: CSS = () => {
   throw new Error(

--- a/packages/core/src/cx.ts
+++ b/packages/core/src/cx.ts
@@ -1,9 +1,18 @@
-export type ClassName = string | false | void | null | 0;
+import { LinariaClassName } from './css';
 
-type CX = (...classNames: ClassName[]) => string;
+export type ClassName<T = string> = T | false | void | null | 0 | '';
 
-const cx: CX = function cx() {
-  return Array.prototype.slice.call(arguments).filter(Boolean).join(' ');
+interface ICX {
+  (...classNames: ClassName<LinariaClassName>[]): LinariaClassName;
+  (...classNames: ClassName[]): string;
+}
+
+const cx: ICX = function cx() {
+  const result = Array.prototype.slice
+    .call(arguments)
+    .filter(Boolean)
+    .join(' ');
+  return result as LinariaClassName;
 };
 
 export default cx;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,3 +2,4 @@ export { default as css } from './css';
 export { default as cx } from './cx';
 export type { CSSProperties } from './CSSProperties';
 export type { StyledMeta } from './StyledMeta';
+export type { LinariaClassName } from './css';


### PR DESCRIPTION
## Motivation

Strictly typed `css` significantly simplified the creation of `@linaria/eslint` plugin which can check that there are no constant class names in user code.
```
const fooString = "foo";
const fooClass = css``;

<div className="foo" /> <!-- not ok -->
<div className={fooString} /> <!-- not ok -->
<div className={fooClass} /> <!-- ok -->
<div className={cx(condition && fooClass)} /> <!-- ok -->
<div className={cx(condition && "foo")} /> <!-- not ok -->
<div className={cx(condition && fooString)} /> <!-- not ok -->
```


## Summary

`css` returns `LinariaClassName` instead of `string`.
`cx` returns `LinariaClassName` if every argument is `LinariaClassName`, otherwise it return `string`.
