### PR TITLE
fix(react): unions in prop types are not resolved

### DIFF
--- a/src/react/styled.ts
+++ b/src/react/styled.ts
@@ -55,13 +55,13 @@ const warnIfInvalid = (value: any, componentName: string) => {
 // If styled wraps custom component, that component should have className property
 function styled<TConstructor extends React.FunctionComponent<any>>(
   tag: TConstructor extends React.FunctionComponent<infer T>
-    ? T extends { className?: string }
+    ? [T] extends [{ className?: string }]
       ? TConstructor
       : never
     : never
 ): ComponentStyledTag<TConstructor>;
 function styled<T>(
-  tag: T extends { className?: string } ? React.ComponentType<T> : never
+  tag: [T] extends [{ className?: string }] ? React.ComponentType<T> : never
 ): ComponentStyledTag<T>;
 function styled<TName extends keyof JSX.IntrinsicElements>(
   tag: TName
@@ -155,7 +155,7 @@ function styled(tag: any): any {
 }
 
 type StyledComponent<T> = StyledMeta &
-  (T extends React.FunctionComponent<any>
+  ([T] extends [React.FunctionComponent<any>]
     ? T
     : React.FunctionComponent<T & { as?: React.ElementType }>);
 
@@ -177,7 +177,7 @@ type HtmlStyledTag<TName extends keyof JSX.IntrinsicElements> = <
 
 type ComponentStyledTag<T> = <
   OwnProps = {},
-  TrgProps = T extends React.FunctionComponent<infer TProps> ? TProps : T
+  TrgProps = [T] extends [React.FunctionComponent<infer TProps>] ? TProps : T
 >(
   strings: TemplateStringsArray,
   // Expressions can contain functions only if wrapped component has style property
@@ -188,7 +188,7 @@ type ComponentStyledTag<T> = <
       >
     : StaticPlaceholder[]
 ) => keyof OwnProps extends never
-  ? T extends React.FunctionComponent<any>
+  ? [T] extends [React.FunctionComponent<any>]
     ? StyledMeta & T
     : StyledComponent<TrgProps>
   : StyledComponent<OwnProps & TrgProps>;


### PR DESCRIPTION
## Motivation

Suppose I have:

```tsx
type GridProps =
  | { container?: false }
  | { container: true; spacing: number }
declare const Grid: React.FC<GridProps & { className?: string }>

// ❌ should not compile
const testGrid = <Grid container={false} spacing={8} />

/**
Type '{ container: false; spacing: number; }' is not assignable to type 'IntrinsicAttributes & PropsWithChildren<GridProps & { className?: string | undefined; }>'.
     Property 'spacing' does not exist on type 'IntrinsicAttributes & { container?: false | undefined; } & { className?: string | undefined; } & { children?: ReactNode; }'.
*/

// ✅ compiles
const testGrid = <Grid container={true} spacing={8} />
```

The idea is to have an extra guard where you can only pass `spacing` as a prop when `container` is `true`. But unfortunately the current typing doesn't handle this case very well yet: passing this component to linaria's `styled` doesn't even compile.

```ts
const LinariaGrid = styled(Grid)``
```

and yields this rather long error message:
```
No overload matches this call.
     Overload 1 of 3, '(tag: (FunctionComponent<{ container?: false | undefined; } & { className?: string | undefined; }> & FC<GridProps & { className?: string | undefined; }>) | (FunctionComponent<...> & FC<...>)): ComponentStyledTag<...>', gave the following error.
       Argument of type 'FC<GridProps & { className?: string | undefined; }>' is not assignable to parameter of type '(FunctionComponent<{ container?: false | undefined; } & { className?: string | undefined; }> & FC<GridProps & { className?: string | undefined; }>) | (FunctionComponent<...> & FC<...>)'.
         Type 'FunctionComponent<GridProps & { className?: string | undefined; }>' is not assignable to type 'FunctionComponent<{ container?: false | undefined; } & { className?: string | undefined; }> & FC<GridProps & { className?: string | undefined; }>'.
           Type 'FunctionComponent<GridProps & { className?: string | undefined; }>' is not assignable to type 'FunctionComponent<{ container?: false | undefined; } & { className?: string | undefined; }>'.
             Types of property 'propTypes' are incompatible.
               Type 'WeakValidationMap<GridProps & { className?: string | undefined; }> | undefined' is not assignable to type 'WeakValidationMap<{ container?: false | undefined; } & { className?: string | undefined; }> | undefined'.
                 Type 'WeakValidationMap<{ container: true; spacing: number; } & { className?: string | undefined; }>' is not assignable to type 'WeakValidationMap<{ container?: false | undefined; } & { className?: string | undefined; }>'.
                   Types of property 'container' are incompatible.
                     Type 'Validator<true> | undefined' is not assignable to type 'Validator<false | null | undefined> | undefined'.
                       Type 'Validator<true>' is not assignable to type 'Validator<false | null | undefined>'.
                         Type 'true' is not assignable to type 'false | null | undefined'.
     Overload 2 of 3, '(tag: ComponentType<{ container?: false | undefined; } & { className?: string | undefined; }> | ComponentType<{ container: true; spacing: number; } & { className?: string | undefined; }>): ComponentStyledTag<...>', gave the following error.
       Argument of type 'FC<GridProps & { className?: string | undefined; }>' is not assignable to parameter of type 'ComponentType<{ container?: false | undefined; } & { className?: string | undefined; }> | ComponentType<{ container: true; spacing: number; } & { className?: string | undefined; }>'.
         Type 'FunctionComponent<GridProps & { className?: string | undefined; }>' is not assignable to type 'FunctionComponent<{ container?: false | undefined; } & { className?: string | undefined; }>'.
           Types of property 'propTypes' are incompatible.
             Type 'WeakValidationMap<GridProps & { className?: string | undefined; }> | undefined' is not assignable to type 'WeakValidationMap<{ container?: false | undefined; } & { className?: string | undefined; }> | undefined'.
               Type 'WeakValidationMap<{ container: true; spacing: number; } & { className?: string | undefined; }>' is not assignable to type 'WeakValidationMap<{ container?: false | undefined; } & { className?: string | undefined; }>'.
                 Types of property 'container' are incompatible.
                   Type 'Validator<true> | undefined' is not assignable to type 'Validator<false | null | undefined> | undefined'.
                     Type 'Validator<true>' is not assignable to type 'Validator<false | null | undefined>'.
                       Type 'true' is not assignable to type 'false | null | undefined'.
     Overload 3 of 3, '(tag: keyof IntrinsicElements): HtmlStyledTag<keyof IntrinsicElements>', gave the following error.
       Argument of type 'FC<GridProps & { className?: string | undefined; }>' is not assignable to parameter of type 'keyof IntrinsicElements'.
         Type 'FunctionComponent<GridProps & { className?: string | undefined; }>' is not assignable to type '"view"'.
```

This is because the union type is distributed when acted on a conditional type, as described [here](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types).

## Summary

The fix is quite simple: we add an extra bracket to every position in which the "prop" type variable is mentioned e.g `[T] extends React.ComponentType<any> ? ... : ...`  to make the type non-distributive.
