### PR TITLE
Remove "hmr" option from Webpack docs

### DIFF
--- a/docs/BUNDLERS_INTEGRATION.md
+++ b/docs/BUNDLERS_INTEGRATION.md
@@ -54,9 +54,6 @@ Now add the following snippet in under `module.rules`:
   use: [
     {
       loader: MiniCssExtractPlugin.loader,
-      options: {
-        hmr: process.env.NODE_ENV !== 'production',
-      },
     },
     {
       loader: 'css-loader',
@@ -141,9 +138,6 @@ module.exports = {
         use: [
           {
             loader: MiniCssExtractPlugin.loader,
-            options: {
-              hmr: process.env.NODE_ENV !== 'production',
-            },
           },
           {
             loader: 'css-loader',


### PR DESCRIPTION
After upgrading Webpack, I was getting this error:

```
ValidationError: Invalid options object. Mini CSS Extract Plugin Loader has been initialized using an options object that does not match the API schema.
 - options has an unknown property 'hmr'. These properties are valid:
   object { publicPath?, emit?, esModule?, layer? }
```

Seems like this option isn't supported any more.

<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->

## Summary

<!--
Explain how your implementation works and your thoughts behind the solution.
It will help maintainers to review your PR.
You can skip it if PR is trivial.
-->

## Test plan

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->
