### PR TITLE
fix: cli trying to transform directories

### DIFF
--- a/packages/cli/src/linaria.ts
+++ b/packages/cli/src/linaria.ts
@@ -86,6 +86,10 @@ function processFiles(files: string[], options: Options) {
   );
 
   resolvedFiles.forEach((filename) => {
+    if (fs.lstatSync(filename).isDirectory()) {
+      return;
+    }
+
     const outputFilename = resolveOutputFilename(
       filename,
       options.outDir,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

Running `linaria` CLI with a glob wildcard produced an error if the directory contains nested folders.

```
 /build
    /components
      /SomeComponent.js
    /index.js
 /src
    /components
      /SomeComponent.tsx
    /index.ts


```

```sh
yarn linaria -o build -r src -i build ./src/**/*
```

## Summary

Simply check if the file is a `directory` before we run any transformations.

## Test plan

It works with nested directories - scenario presented above. There is no unit testing set up for `@linaria/cli` so I skipped adding test cases for this.
