### PR TITLE
Refactor/rest op

### DIFF
--- a/packages/react/__tests__/styled.test.js
+++ b/packages/react/__tests__/styled.test.js
@@ -1,3 +1,5 @@
+import { restOp } from '../src/styled';
+
 const React = require('react');
 const renderer = require('react-test-renderer');
 const styled = require('../src').styled;
@@ -253,4 +255,25 @@ it('throws when using as tag for template literal', () => {
         color: blue;
       `
   ).toThrow('Using the "styled" tag in runtime is not supported');
+});
+
+it('can get rest keys from object', () => {
+  const obj = { one: 1, two: 2, three: 3 };
+  const rest = restOp(obj, ['two']);
+  // eslint-disable-next-line no-unused-vars
+  const { two, ...expectedRest } = obj;
+  expect(rest).toEqual(expectedRest);
+});
+it('can get rest keys from complex object', () => {
+  const obj = {
+    string: 'hello',
+    bool: false,
+    object: { hello: 'world' },
+    arr: [1, 2, 3],
+    num: 47,
+  };
+  const rest = restOp(obj, ['bool', 'object', 'arr']);
+  // eslint-disable-next-line no-unused-vars
+  const { bool, object, arr, ...expectedRest } = obj;
+  expect(rest).toEqual(expectedRest);
 });

--- a/packages/react/src/styled.ts
+++ b/packages/react/src/styled.ts
@@ -16,8 +16,8 @@ type Options = {
   class: string;
   vars?: {
     [key: string]: [
-        string | number | ((props: unknown) => string | number),
-        string | void
+      string | number | ((props: unknown) => string | number),
+      string | void
     ];
   };
 };
@@ -33,7 +33,7 @@ export const restOp: CustomOmit = (obj, keys) => {
   const res = {} as { [K in keyof typeof obj]: typeof obj[K] };
   let key: keyof typeof obj;
   for (key in obj) {
-    if (!keys.includes(key)) {
+    if (keys.indexOf(key) === -1) {
       res[key] = obj[key];
     }
   }
@@ -161,10 +161,10 @@ function styled(tag: any): any {
       ? React.forwardRef(render)
       : // React.forwardRef won't available on older React versions and in Preact
         // Fallback to a innerRef prop in that case
-      (props: any) => {
-        const rest = restOp(props, ['innerRef']);
-        return render(rest, props.innerRef);
-      };
+        (props: any) => {
+          const rest = restOp(props, ['innerRef']);
+          return render(rest, props.innerRef);
+        };
 
     (Result as any).displayName = options.name;
 
@@ -187,28 +187,28 @@ type StaticPlaceholder = string | number | CSSProperties | StyledMeta;
 
 type HtmlStyledTag<TName extends keyof JSX.IntrinsicElements> = <
   TAdditionalProps = {}
-  >(
+>(
   strings: TemplateStringsArray,
   ...exprs: Array<
     | StaticPlaceholder
     | ((
-    // Without Omit here TS tries to infer TAdditionalProps
-    // from a component passed for interpolation
-    props: JSX.IntrinsicElements[TName] & Omit<TAdditionalProps, never>
-  ) => string | number)
-    >
+        // Without Omit here TS tries to infer TAdditionalProps
+        // from a component passed for interpolation
+        props: JSX.IntrinsicElements[TName] & Omit<TAdditionalProps, never>
+      ) => string | number)
+  >
 ) => StyledComponent<JSX.IntrinsicElements[TName] & TAdditionalProps>;
 
 type ComponentStyledTag<T> = <
   OwnProps = {},
   TrgProps = T extends React.FunctionComponent<infer TProps> ? TProps : T
-  >(
+>(
   strings: TemplateStringsArray,
   // Expressions can contain functions only if wrapped component has style property
   ...exprs: TrgProps extends { style?: React.CSSProperties | undefined }
     ? Array<
-      | StaticPlaceholder
-      | ((props: NoInfer<OwnProps & TrgProps>) => string | number)
+        | StaticPlaceholder
+        | ((props: NoInfer<OwnProps & TrgProps>) => string | number)
       >
     : StaticPlaceholder[]
 ) => keyof OwnProps extends never
@@ -225,8 +225,8 @@ export type Styled = typeof styled & StyledJSXIntrinsics;
 
 export default (process.env.NODE_ENV !== 'production'
   ? new Proxy(styled, {
-    get(o, prop: keyof JSX.IntrinsicElements) {
-      return o(prop);
-    },
-  })
+      get(o, prop: keyof JSX.IntrinsicElements) {
+        return o(prop);
+      },
+    })
   : styled) as Styled;


### PR DESCRIPTION
## Motivation

1. Better performance. No needs to do 2 interactions over arr (filter, reduce)
2. Add typings for restOp (using Omit version https://stackoverflow.com/a/53968837/12853087)
3. Add tests for restOp

## Summary

Improved performance, by reducing interactions (ON)
Add typing for restOp (see [TS playground](https://www.typescriptlang.org/play?ssl=24&ssc=1&pln=25&pc=1#code/JYOwLgpgTgZghgYwgAgMIFcDOYD2BbAeT2DGQG8AoZa5AHgBVkIAPSEAE02RwCMArCAjAAaZAGkmrCBy4BtAHSKAFAGsIATxwxk9AJSyAugYB8VGkt58AXDtFr1mG2N03KNd8lliATMlDIAUWYEABt0dghaey1bcVkQdDweaBMDG3ovbwMzagBfCnyKBBwQbG5iMBsMbHwiEmQAXmQLfjsNTF1G43Ic5GLS0igIUiayXOQ4LjcPai8-EGRo7TB1AAcIGMs05pX1zf59MWz3XIBuXpDhxY0bJeRdje1Lc-cYHChm+3nuA56Z6mA2iUAEJVO15KBQuEIJgwepdAi-v93EMwLJ7AZGj8+OiNAYXv98ideqj0FAFqjzmcKEUSmVLFiyCUIDYAIyiMAAdxwNm8HIAFkMWcgAMyFfplOBY-AkFp8USyADkzMVokVXJwioMugocHkYEFEAguv13JNzIoQA))

Added test for it

## Test plan
```javascript
it('can get rest keys from object', () => {
  const obj = { one: 1, two: 2, three: 3 };
  const rest = restOp(obj, ['two']);
  // eslint-disable-next-line no-unused-vars
  const { two, ...expectedRest } = obj;
  expect(rest).toEqual(expectedRest);
});
```
added works well, but pre-commit hooks failed

```javascript
 FAIL  __tests__/detect-core-js.test.js
  ● Ensures that package do not include core-js dependency after build

    expect(received).not.toContain(expected) // indexOf

    Expected substring: not "The corejs3 polyfill added the following polyfills"
    Received string:        "@babel/preset-env: `DEBUG` option
    
    Using targets:
    {
      \"android\": \"90\",
...
```

As I see some tests failed, If you know how to fix them, let me know, please. Since I did not touch that files or tests.
