### PR TITLE
fix(shaker): exports/object issue with TS (fixes #861)

### DIFF
--- a/packages/babel/src/extract.ts
+++ b/packages/babel/src/extract.ts
@@ -185,7 +185,7 @@ export default function extract(
               lazyValues = evaluation.value.__linariaPreval || [];
               debug('lazy-deps:values', evaluation.value.__linariaPreval);
             } catch (e) {
-              error('lazy-deps:evaluate', code);
+              error('lazy-deps:evaluate:error', code);
               throw new Error(
                 'An unexpected runtime error occurred during dependencies evaluation: \n' +
                   e.stack +

--- a/packages/shaker/src/GraphBuilderState.ts
+++ b/packages/shaker/src/GraphBuilderState.ts
@@ -1,6 +1,7 @@
 import type { Node, VisitorKeys } from '@babel/types';
 import ScopeManager from './scope';
 import DepsGraph from './DepsGraph';
+import { VisitorAction } from './types';
 
 export type OnVisitCallback = (n: Node) => void;
 
@@ -41,5 +42,5 @@ export default abstract class GraphBuilderState {
     parent: TParent | null,
     parentKey: VisitorKeys[TParent['type']] | null,
     listIdx?: number | null
-  ): void;
+  ): VisitorAction;
 }

--- a/packages/shaker/src/langs/core.ts
+++ b/packages/shaker/src/langs/core.ts
@@ -477,7 +477,16 @@ export const visitors: Visitors = {
    * `obj.b = 2` will be cut and we will get just `{ a: 1 }`.
    */
   MemberExpression(this: GraphBuilderState, node: MemberExpression) {
-    this.baseVisit(node);
+    if (this.visit(node.object, node, 'object') !== 'ignore') {
+      this.graph.addEdge(node, node.object);
+    }
+
+    this.context.push('expression');
+    if (this.visit(node.property, node, 'property') !== 'ignore') {
+      this.graph.addEdge(node, node.property);
+    }
+    this.context.pop();
+
     this.graph.addEdge(node.object, node);
 
     if (


### PR DESCRIPTION
## Motivation

See #861

## Summary

If an exported identifier was used as an object's index in a left part of an assignment operator, that identifier was mistakenly interpreted as a declaration instead of reference.