### PR TITLE
fix(stylelint): fix indentation errors (fixes #693)

### DIFF
--- a/packages/stylelint/src/index.ts
+++ b/packages/stylelint/src/index.ts
@@ -7,6 +7,5 @@ export default {
     'value-no-vendor-prefix': true,
     'no-empty-source': null,
     'no-extra-semicolons': null,
-    'no-missing-end-of-source-newline': null,
   },
 };


### PR DESCRIPTION
## Motivation

Existed implementation of the stylelint processor generates empty lines that cause false-positive `no-empty-first-line` warnings.

## Summary

This PR reimplements warnings positions adjustment in order to generate more clean CSS without redundant empty lines.
