### PR TITLE
fix(webpack): fix usage of webpackResolveOptions conditionally

### DIFF
--- a/packages/webpack4-loader/src/index.ts
+++ b/packages/webpack4-loader/src/index.ts
@@ -59,7 +59,7 @@ export default function webpack4Loader(
 
   // Resolved configuration contains empty list of extensions as a default value
   // https://github.com/callstack/linaria/issues/855
-  if (webpackResolveOptions && webpackResolveOptions.extensions?.length === 0) {
+  if (webpackResolveOptions?.extensions?.length === 0) {
     delete webpackResolveOptions.extensions;
   }
 

--- a/packages/webpack4-loader/src/index.ts
+++ b/packages/webpack4-loader/src/index.ts
@@ -59,7 +59,7 @@ export default function webpack4Loader(
 
   // Resolved configuration contains empty list of extensions as a default value
   // https://github.com/callstack/linaria/issues/855
-  if (webpackResolveOptions.extensions?.length === 0) {
+  if (webpackResolveOptions && webpackResolveOptions.extensions?.length === 0) {
     delete webpackResolveOptions.extensions;
   }
 

--- a/packages/webpack5-loader/src/index.ts
+++ b/packages/webpack5-loader/src/index.ts
@@ -47,7 +47,7 @@ export default function webpack5Loader(
 
   // Resolved configuration contains empty list of extensions as a default value
   // https://github.com/callstack/linaria/issues/855
-  if (webpackResolveOptions.extensions?.length === 0) {
+  if (webpackResolveOptions?.extensions?.length === 0) {
     delete webpackResolveOptions.extensions;
   }
 


### PR DESCRIPTION
## Motivation

There's no existing issue for this as far as I know.

Fixes an issue like this:

```
INFO ==>  ModuleBuildError: Module build failed (from ./node_modules/thread-loader/dist/cjs.js):
--
INFO ==>  Thread Loader (Worker 6)
INFO ==>  Cannot read property 'extensions' of undefined
```

## Summary

There are some contexts in which the `webpackResolveOptions` might be undefined – eg issues like https://github.com/TypeStrong/ts-loader/issues/1206 .

In general the loader handles `this._compilation` not being there, but in practice, breaks because of this line. You can see on line 86 that this is meant to handle the case where `webpackResolveOptions` is undefined, but it was just missed there (if only we could do it in typescript! But I imagine that's more trouble than it's worth for a webpack loader)

You can compare this with `linaria@^2.0.0` to see how it differs in the `@linaria/webpack4-loader`

## Test plan

Tested locally by patching the module with this change