### PR TITLE
fix(webpack): add cacheProvider to support customized cache

### DIFF
--- a/docs/BUNDLERS_INTEGRATION.md
+++ b/docs/BUNDLERS_INTEGRATION.md
@@ -1,6 +1,7 @@
 # Bundlers Integration
 
 ## Jump To
+
 - [webpack](#webpack)
 - [Rollup](#Rollup)
 - [Svelte](#Svelte)
@@ -11,7 +12,7 @@ If you use Babel in your project, make sure to have a [config file for Babel](ht
 
 ## Bundlers
 
-Please note, that `@babel/core` is a peer dependency of all loaders. Do not forget to add it to `devDependencies` list in your project. 
+Please note, that `@babel/core` is a peer dependency of all loaders. Do not forget to add it to `devDependencies` list in your project.
 
 ### webpack
 
@@ -182,15 +183,16 @@ The loader accepts the following options:
 
   Setting this option to `true` will include source maps for the generated CSS so that you can see where source of the class name in devtools. We recommend to enable this only in development mode because the sourcemap is inlined into the CSS files.
 
-- `cacheDirectory: string` (default: `'.linaria-cache'`):
+- `cacheProvider: undefined | string | ICache` (default: `undefined`):
+  By default Linaria use a memory cache to store temporary CSS files. But if you are using this loader with [thread-loader](https://www.npmjs.com/package/thread-loader) you should use some consistent cache to prevent [some unexpected issues](https://github.com/callstack/linaria/issues/881). This options support a `ICache` instance or a path to NodeJS module which export a `ICache` instance as `module.exports`
+  > ```
+  > interface ICache {
+  >   get: (key: string) => Promise<string>;
+  >   set: (key: string, value: string) => Promise<void>
+  > }
+  > ```
 
-  Path to the directory where the loader will output the intermediate CSS files. You can pass a relative or absolute directory path. Make sure the directory is inside the working directory for things to work properly. **You should add this directory to `.gitignore` so you don't accidentally commit them.**
-  
-- `extension: string` (default: `'.linaria.css'`):
-
-  An extension of the intermediate CSS files.
-
-- `preprocessor: 'none' | 'stylis' | Function` (default: `'stylis'`)
+* `preprocessor: 'none' | 'stylis' | Function` (default: `'stylis'`)
 
   You can override the pre-processor if you want to override how the loader processes the CSS.
 
@@ -256,16 +258,15 @@ export default {
 };
 ```
 
-
-If you are using [@rollup/plugin-babel](https://github.com/rollup/plugins/tree/master/packages/babel) as well, ensure the linaria plugin is declared earlier in the `plugins` array than your babel plugin. 
+If you are using [@rollup/plugin-babel](https://github.com/rollup/plugins/tree/master/packages/babel) as well, ensure the linaria plugin is declared earlier in the `plugins` array than your babel plugin.
 
 ```js
 import linaria from 'linaria/rollup';
 import css from 'rollup-plugin-css-only';
-import babel from "@rollup/plugin-babel";
+import babel from '@rollup/plugin-babel';
 
 export default {
-   /* rest of your config */
+  /* rest of your config */
   plugins: [
     linaria({
       sourceMap: process.env.NODE_ENV !== 'production',
@@ -273,8 +274,10 @@ export default {
     css({
       output: 'styles.css',
     }),
-    babel({/**/}),
-     /* rest of your plugins */
+    babel({
+      /**/
+    }),
+    /* rest of your plugins */
   ],
 };
 ```
@@ -282,6 +285,7 @@ export default {
 ### Svelte
 
 #### Contents
+
 - [Svelte with Rollup](#Rollup-1)
 - [Svelte with Webpack](#Webpack-1)
 
@@ -362,4 +366,3 @@ module.exports = {
   },
 };
 ```
-

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,45 @@
+export interface ICache {
+  get: (key: string) => Promise<string>;
+  set: (key: string, value: string) => Promise<void>;
+}
+
+// memory cache, which is the default cache implementation in Linaria
+
+class MemoryCache implements ICache {
+  private cache: Map<string, string> = new Map();
+
+  public get(key: string): Promise<string> {
+    return Promise.resolve(this.cache.get(key) ?? '');
+  }
+
+  public set(key: string, value: string): Promise<void> {
+    this.cache.set(key, value);
+    return Promise.resolve();
+  }
+}
+
+export const memoryCache = new MemoryCache();
+
+/**
+ * return cache instance from `options.cacheProvider`
+ * @param cacheProvider string | ICache | undefined
+ * @returns ICache instance
+ */
+export const getCacheInstance = async (
+  cacheProvider: string | ICache | undefined
+): Promise<ICache> => {
+  if (!cacheProvider) {
+    return memoryCache;
+  }
+  if (typeof cacheProvider === 'string') {
+    return require(cacheProvider);
+  }
+  if (
+    typeof cacheProvider === 'object' &&
+    'get' in cacheProvider &&
+    'set' in cacheProvider
+  ) {
+    return cacheProvider;
+  }
+  throw new Error(`Invalid cache provider: ${cacheProvider}`);
+};

--- a/src/outputCssLoader.ts
+++ b/src/outputCssLoader.ts
@@ -1,9 +1,13 @@
-const cssLookup = new Map<string, string>();
+import loaderUtils from 'loader-utils';
+import { getCacheInstance } from './cache';
 
-export const addFile = (id: string, content: string) => {
-  cssLookup.set(id, content);
-};
+type LoaderContext = Parameters<typeof loaderUtils.getOptions>[0];
 
-export default function outputCssLoader(this: { resourcePath: string }) {
-  return cssLookup.get(this.resourcePath) ?? '';
+export default function outputCssLoader(this: LoaderContext) {
+  this.async();
+  const { cacheProvider } = loaderUtils.getOptions(this) || {};
+  getCacheInstance(cacheProvider)
+    .then((cacheInstance) => cacheInstance.get(this.resourcePath))
+    .then((result) => this.callback(null, result))
+    .catch((err: Error) => this.callback(err));
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

This PR try to fix https://github.com/callstack/linaria/issues/881 . This PR is mainly inspired from https://github.com/callstack/linaria/commit/a281440271cb29d4d2e2b0cb3b2fee26f1e4bc69

<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->

## Summary

This PR add a new option `cacheProvider` for Linaria loader.

- `cacheProvider: undefined | string | ICache` (default: `undefined`):
  By default Linaria use a memory cache to store temporary CSS files. But if you are using this loader with [thread-loader](https://www.npmjs.com/package/thread-loader) you should use some consistent cache to prevent [some unexpected issues](https://github.com/callstack/linaria/issues/881). This options support a `ICache` instance or a path to NodeJS module which export a `ICache` instance as `module.exports`
  > ```
  > interface ICache {
  >   get: (key: string) => Promise<string>;
  >   set: (key: string, value: string) => Promise<void>
  > }
  > ```

<!--
Explain how your implementation works and your thoughts behind the solution.
It will help maintainers to review your PR.
You can skip it if PR is trivial.
-->

## Test plan

I run `yarn build` in this repo and copied `libs` folder to my Linaria project's `node_modules/linaria` folder.
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->
