### PR TITLE
fix(react): refactored types for styled function (fixes #872)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react": ">=16",
     "release-it": "^14.2.1",
     "release-it-lerna-changelog": "^3.1.0",
-    "typescript": "^3.9.7"
+    "typescript": "^4.2.3"
   },
   "resolutions": {
     "@typescript-eslint/experimental-utils": "^4.28.0",

--- a/packages/babel/src/extract.ts
+++ b/packages/babel/src/extract.ts
@@ -184,14 +184,18 @@ export default function extract(
               state.dependencies.push(...evaluation.dependencies);
               lazyValues = evaluation.value.__linariaPreval || [];
               debug('lazy-deps:values', evaluation.value.__linariaPreval);
-            } catch (e) {
+            } catch (e: unknown) {
               error('lazy-deps:evaluate:error', code);
-              throw new Error(
-                'An unexpected runtime error occurred during dependencies evaluation: \n' +
-                  e.stack +
-                  '\n\nIt may happen when your code or third party module is invalid or uses identifiers not available in Node environment, eg. window. \n' +
-                  'Note that line numbers in above stack trace will most likely not match, because Linaria needed to transform your code a bit.\n'
-              );
+              if (e instanceof Error) {
+                throw new Error(
+                  'An unexpected runtime error occurred during dependencies evaluation: \n' +
+                    e.stack +
+                    '\n\nIt may happen when your code or third party module is invalid or uses identifiers not available in Node environment, eg. window. \n' +
+                    'Note that line numbers in above stack trace will most likely not match, because Linaria needed to transform your code a bit.\n'
+                );
+              } else {
+                throw e;
+              }
             }
           }
 

--- a/packages/babel/src/index.ts
+++ b/packages/babel/src/index.ts
@@ -26,6 +26,7 @@ export * from './types';
 export type { PluginOptions } from './utils/loadOptions';
 export { default as isNode } from './utils/isNode';
 export { default as getVisitorKeys } from './utils/getVisitorKeys';
+export type { VisitorKeys } from './utils/getVisitorKeys';
 export { default as peek } from './utils/peek';
 export { default as CollectDependencies } from './visitors/CollectDependencies';
 export { default as DetectStyledImportName } from './visitors/DetectStyledImportName';

--- a/packages/babel/src/types.ts
+++ b/packages/babel/src/types.ts
@@ -1,4 +1,4 @@
-import type { Node, Expression, TaggedTemplateExpression } from '@babel/types';
+import type { Expression, TaggedTemplateExpression } from '@babel/types';
 import type { TransformOptions } from '@babel/core';
 import type { NodePath } from '@babel/traverse';
 import type { StyledMeta } from '@linaria/core';
@@ -181,21 +181,3 @@ export type Options = {
 
 export type PreprocessorFn = (selector: string, cssText: string) => string;
 export type Preprocessor = 'none' | 'stylis' | PreprocessorFn | void;
-
-type AllNodes = { [T in Node['type']]: Extract<Node, { type: T }> };
-
-declare module '@babel/types' {
-  type VisitorKeys = {
-    [T in keyof AllNodes]: Extract<
-      keyof AllNodes[T],
-      {
-        [Key in keyof AllNodes[T]]: AllNodes[T][Key] extends
-          | Node
-          | Node[]
-          | null
-          ? Key
-          : never;
-      }[keyof AllNodes[T]]
-    >;
-  };
-}

--- a/packages/babel/src/utils/getVisitorKeys.ts
+++ b/packages/babel/src/utils/getVisitorKeys.ts
@@ -1,10 +1,15 @@
 import { types as t } from '@babel/core';
-import type { Node, VisitorKeys } from '@babel/types';
+import type { Node } from '@babel/types';
 
-type Keys<T extends Node> = (VisitorKeys[T['type']] & keyof T)[];
+export type VisitorKeys<T extends Node> = {
+  [K in keyof T]: Exclude<T[K], undefined> extends Node | Node[] | null
+    ? K
+    : never;
+}[keyof T] &
+  string;
 
 export default function getVisitorKeys<TNode extends Node>(
   node: TNode
-): Keys<TNode> {
-  return t.VISITOR_KEYS[node.type] as Keys<TNode>;
+): VisitorKeys<TNode>[] {
+  return t.VISITOR_KEYS[node.type] as VisitorKeys<TNode>[];
 }

--- a/packages/react/__dtslint__/styled.ts
+++ b/packages/react/__dtslint__/styled.ts
@@ -133,3 +133,40 @@ styled.a`
   // $ExpectType Validator<string> | undefined
   NewWrapper.propTypes!.prop2;
 })();
+
+((/* Issue #844 */) => {
+  type GridProps = { container?: false } | { container: true; spacing: number };
+
+  const Grid: React.FC<GridProps & { className?: string }> = () => null;
+
+  // Type 'false' is not assignable to type 'true'
+  // $ExpectError
+  React.createElement(Grid, { container: false, spacing: 8 });
+
+  React.createElement(Grid, { container: true, spacing: 8 });
+
+  styled(Grid)``;
+})();
+
+((/* Issue #872 */) => {
+  interface BaseProps {
+    className?: string;
+    style?: React.CSSProperties;
+  }
+
+  interface ComponentProps extends BaseProps {
+    title: string;
+  }
+
+  const Flow = <TProps extends BaseProps>(Cmp: React.FC<TProps>) =>
+    styled(Cmp)`
+      display: flow;
+    `;
+
+  const Component: React.FC<ComponentProps> = (props) =>
+    React.createElement('div', props);
+
+  const Implementation = Flow(Component);
+
+  (() => React.createElement(Implementation, { title: 'Title' }))();
+})();

--- a/packages/shaker/src/GraphBuilderState.ts
+++ b/packages/shaker/src/GraphBuilderState.ts
@@ -1,4 +1,5 @@
-import type { Node, VisitorKeys } from '@babel/types';
+import type { Node } from '@babel/types';
+import type { VisitorKeys } from '@linaria/babel-preset';
 import ScopeManager from './scope';
 import DepsGraph from './DepsGraph';
 import { VisitorAction } from './types';
@@ -40,7 +41,7 @@ export default abstract class GraphBuilderState {
   abstract visit<TNode extends Node, TParent extends Node>(
     node: TNode,
     parent: TParent | null,
-    parentKey: VisitorKeys[TParent['type']] | null,
+    parentKey: VisitorKeys<TParent> | null,
     listIdx?: number | null
   ): VisitorAction;
 }

--- a/packages/shaker/src/Visitors.ts
+++ b/packages/shaker/src/Visitors.ts
@@ -1,7 +1,8 @@
 import { types as t } from '@babel/core';
-import type { Identifier, Node, VisitorKeys } from '@babel/types';
+import type { Identifier, Node } from '@babel/types';
 import { warn } from '@linaria/logger';
 import { peek } from '@linaria/babel-preset';
+import type { VisitorKeys } from '@linaria/babel-preset';
 import GraphBuilderState from './GraphBuilderState';
 import identifierHandlers from './identifierHandlers';
 import type { Visitor, Visitors } from './types';
@@ -13,7 +14,7 @@ const visitors: Visitors = {
     this: GraphBuilderState,
     node: Identifier,
     parent: TParent | null,
-    parentKey: VisitorKeys[TParent['type']] | null,
+    parentKey: VisitorKeys<TParent> | null,
     listIdx: number | null = null
   ) {
     if (!parent || !parentKey) {

--- a/packages/shaker/src/identifierHandlers.ts
+++ b/packages/shaker/src/identifierHandlers.ts
@@ -1,6 +1,7 @@
 import { types as t } from '@babel/core';
-import type { Aliases, Identifier, Node, VisitorKeys } from '@babel/types';
+import type { Aliases, Identifier, Node } from '@babel/types';
 import { peek } from '@linaria/babel-preset';
+import type { VisitorKeys } from '@linaria/babel-preset';
 import GraphBuilderState from './GraphBuilderState';
 import type { IdentifierHandlerType, NodeType } from './types';
 import { identifierHandlers as core } from './langs/core';
@@ -10,7 +11,7 @@ type HandlerFn = <TParent extends Node = Node>(
   builder: GraphBuilderState,
   node: Identifier,
   parent: TParent,
-  parentKey: VisitorKeys[TParent['type']],
+  parentKey: VisitorKeys<TParent>,
   listIdx: number | null
 ) => void;
 

--- a/packages/shaker/src/types.ts
+++ b/packages/shaker/src/types.ts
@@ -1,4 +1,5 @@
-import type { Aliases, Node, VisitorKeys } from '@babel/types';
+import type { Aliases, Node } from '@babel/types';
+import type { VisitorKeys } from '@linaria/babel-preset';
 
 export type NodeOfType<T> = Extract<Node, { type: T }>;
 
@@ -9,7 +10,7 @@ export type VisitorAction = 'ignore' | void;
 export type Visitor<TNode extends Node> = <TParent extends Node>(
   node: TNode,
   parent: TParent | null,
-  parentKey: VisitorKeys[TParent['type']] | null,
+  parentKey: VisitorKeys<TParent> | null,
   listIdx: number | null
 ) => VisitorAction;
 

--- a/packages/stylelint/src/preprocessor.ts
+++ b/packages/stylelint/src/preprocessor.ts
@@ -63,10 +63,10 @@ function preprocessor() {
         cache[filename] = undefined;
         errors[filename] = undefined;
         offsets[filename] = [];
-      } catch (e) {
+      } catch (e: unknown) {
         cache[filename] = undefined;
         offsets[filename] = undefined;
-        errors[filename] = e;
+        errors[filename] = e as Error;
 
         // Ignore parse errors here
         // We handle it separately

--- a/yarn.lock
+++ b/yarn.lock
@@ -4498,10 +4498,10 @@ camelcase@^6.2.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
-caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219:
-  version "1.0.30001237"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001237.tgz#4b7783661515b8e7151fc6376cfd97f0e427b9e5"
-  integrity sha512-pDHgRndit6p1NR2GhzMbQ6CkRrp4VKuSsqbcLeOQppYPKOYkKT/6ZvZDvKJUqcmtyWIAHuZq3SVS2vc1egCZzw==
+caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001286:
+  version "1.0.30001286"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001286.tgz#3e9debad420419618cfdf52dc9b6572b28a8fff6"
+  integrity sha512-zaEMRH6xg8ESMi2eQ3R4eZ5qw/hJiVsO/HlLwniIwErij0JDr9P+8V4dtx1l+kLq6j3yy8l8W4fst1lBnat5wQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -13887,10 +13887,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.9.7:
-  version "3.9.10"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
-  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
+typescript@^4.2.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.3.tgz#afaa858e68c7103317d89eb90c5d8906268d353c"
+  integrity sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==
 
 uglify-js@^3.1.4:
   version "3.13.9"


### PR DESCRIPTION
## Motivation

See #872

## Summary

Types for `styled` were completely refactored. Now it supports dynamic calls (#872) and shows better errors if a target component has no `className` or `style` properties.

Thank you @Beraliv for helping!

## Test plan

`yarn test:dts`