### PR TITLE
fix(webpack): fix error when cacheProvider is undefined

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -109,7 +109,7 @@ export default function loader(
       .then((cacheInstance) => cacheInstance.set(this.resourcePath, cssText))
       .then(() => {
         const request = `${outputFilename}!=!${outputCssLoader}?cacheProvider=${encodeURIComponent(
-          cacheProvider
+          cacheProvider ?? ''
         )}!${this.resourcePath}`;
         const stringifiedRequest = loaderUtils.stringifyRequest(this, request);
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

While cherry picking `cacheProvider` to Linaria v3 I found a same bug in https://github.com/callstack/linaria/pull/884
<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->

## Summary

If `cacheProvider` is not set ( `undefined` ), the query param `cacheProvider=${encodeURIComponent(cacheProvider)}`  became a string `'undefined'` and result in a runtime error `Cannot find module 'undefined'`.

<!--
Explain how your implementation works and your thoughts behind the solution.
It will help maintainers to review your PR.
You can skip it if PR is trivial.
-->

## Test plan

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->
I'v test `cacheProvider: undefined` in https://github.com/callstack/linaria/pull/889
