### PR TITLE
fix(shaker): fix some edge cases related to specific export patterns

### DIFF
--- a/packages/babel/__utils__/strategy-tester.ts
+++ b/packages/babel/__utils__/strategy-tester.ts
@@ -306,7 +306,7 @@ export function run(
     const { code, metadata } = await transpile(
       dedent`
       import { styled } from '@linaria/react';
-
+      let external = 0;
       export const Title = styled.h1\`
         color: ${'${(external, () => "blue")}'};
       \`;
@@ -321,7 +321,7 @@ export function run(
     const { code, metadata } = await transpile(
       dedent`
       import { styled } from '@linaria/react';
-
+      let external = 0;
       const color = (external, () => 'blue');
 
       export const Title = styled.h1\`

--- a/packages/shaker/__fixtures__/assignToExport.js
+++ b/packages/shaker/__fixtures__/assignToExport.js
@@ -1,0 +1,1 @@
+var Padding = (exports.Padding = 4);

--- a/packages/shaker/__fixtures__/computedKeys.js
+++ b/packages/shaker/__fixtures__/computedKeys.js
@@ -1,0 +1,5 @@
+const computedKeyName = 'red';
+export const object = {
+  [computedKeyName]: 'red',
+  blue: 'blue',
+};

--- a/packages/shaker/__fixtures__/objectExport.js
+++ b/packages/shaker/__fixtures__/objectExport.js
@@ -1,0 +1,3 @@
+module.exports = {
+  margin: 5,
+};

--- a/packages/shaker/__tests__/__snapshots__/shaker.test.ts.snap
+++ b/packages/shaker/__tests__/__snapshots__/shaker.test.ts.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`shaker assigning to exports 1`] = `
+"import { css } from \\"@linaria/core\\";
+import { Padding } from \\"../__fixtures__/assignToExport\\";
+export const square = \\"square_s1t92lw9\\";"
+`;
+
+exports[`shaker assigning to exports 2`] = `
+
+CSS:
+
+.square_s1t92lw9 {
+  div {
+    padding: 4px;
+  }
+}
+
+Dependencies: ../__fixtures__/assignToExport
+
+`;
+
 exports[`shaker derives display name from filename 1`] = `
 "import { styled } from '@linaria/react';
 export default /*#__PURE__*/styled(\\"h1\\")({
@@ -226,6 +246,7 @@ Dependencies: NA
 
 exports[`shaker evaluates dependencies with sequence expression 1`] = `
 "import { styled } from '@linaria/react';
+let external = 0;
 const color = (external, () => 'blue');
 export const Title = /*#__PURE__*/styled(\\"h1\\")({
   name: \\"Title\\",
@@ -381,6 +402,7 @@ Dependencies: @linaria/babel-preset/__fixtures__/enums
 
 exports[`shaker evaluates interpolations with sequence expression 1`] = `
 "import { styled } from '@linaria/react';
+let external = 0;
 export const Title = /*#__PURE__*/styled(\\"h1\\")({
   name: \\"Title\\",
   class: \\"Title_t1t92lw9\\",
@@ -481,6 +503,66 @@ CSS:
 }
 
 Dependencies: NA
+
+`;
+
+exports[`shaker exporting objects 1`] = `
+"import { css } from \\"@linaria/core\\";
+import object from \\"../__fixtures__/objectExport\\";
+export const square = \\"square_s1t92lw9\\";"
+`;
+
+exports[`shaker exporting objects 2`] = `
+
+CSS:
+
+.square_s1t92lw9 {
+  div {
+    margin: 5px;
+  }
+}
+
+Dependencies: @babel/runtime/helpers/interopRequireDefault, ../__fixtures__/objectExport
+
+`;
+
+exports[`shaker exporting objects with computed keys 1`] = `
+"import { css } from \\"@linaria/core\\";
+import { object } from \\"../__fixtures__/computedKeys\\";
+export const square = \\"square_s1t92lw9\\";"
+`;
+
+exports[`shaker exporting objects with computed keys 2`] = `
+
+CSS:
+
+.square_s1t92lw9 {
+  div {
+    color: blue;
+  }
+}
+
+Dependencies: ../__fixtures__/computedKeys
+
+`;
+
+exports[`shaker exporting sequence expressions 1`] = `
+"import { css } from \\"@linaria/core\\";
+import number from \\"../__fixtures__/sequenceExport\\";
+export const square = \\"square_s1t92lw9\\";"
+`;
+
+exports[`shaker exporting sequence expressions 2`] = `
+
+CSS:
+
+.square_s1t92lw9 {
+  div {
+    height: 5px;
+  }
+}
+
+Dependencies: @babel/runtime/helpers/interopRequireDefault, ../__fixtures__/sequenceExport
 
 `;
 

--- a/packages/shaker/__tests__/shaker.test.ts
+++ b/packages/shaker/__tests__/shaker.test.ts
@@ -23,6 +23,78 @@ describe('shaker', () => {
       expect(metadata).toMatchSnapshot();
     });
 
+    it('assigning to exports', async () => {
+      const { code, metadata } = await transpile(
+        dedent`
+      import { css } from "@linaria/core";
+      import { Padding } from "../__fixtures__/assignToExport";
+
+      export const square = css\`
+        div {
+          padding: ${'${Padding}'}px;
+        }
+      \`;
+    `
+      );
+
+      expect(code).toMatchSnapshot();
+      expect(metadata).toMatchSnapshot();
+    });
+
+    it('exporting objects', async () => {
+      const { code, metadata } = await transpile(
+        dedent`
+      import { css } from "@linaria/core";
+      import object from "../__fixtures__/objectExport";
+
+      export const square = css\`
+        div {
+          margin: ${'${object.margin}'}px;
+        }
+      \`;
+    `
+      );
+
+      expect(code).toMatchSnapshot();
+      expect(metadata).toMatchSnapshot();
+    });
+
+    it('exporting objects with computed keys', async () => {
+      const { code, metadata } = await transpile(
+        dedent`
+      import { css } from "@linaria/core";
+      import { object } from "../__fixtures__/computedKeys";
+
+      export const square = css\`
+        div {
+          color: ${'${object.blue}'};
+        }
+      \`;
+    `
+      );
+
+      expect(code).toMatchSnapshot();
+      expect(metadata).toMatchSnapshot();
+    });
+
+    it('exporting sequence expressions', async () => {
+      const { code, metadata } = await transpile(
+        dedent`
+      import { css } from "@linaria/core";
+      import number from "../__fixtures__/sequenceExport";
+
+      export const square = css\`
+        div {
+          height: ${'${number}'}px;
+        }
+      \`;
+    `
+      );
+
+      expect(code).toMatchSnapshot();
+      expect(metadata).toMatchSnapshot();
+    });
+
     it('should work with wildcard reexports', async () => {
       const { code, metadata } = await transpile(
         dedent`

--- a/packages/shaker/src/langs/core.ts
+++ b/packages/shaker/src/langs/core.ts
@@ -736,17 +736,19 @@ export const visitors: Visitors = {
   /*
    * SequenceExpression
    * It is a special case of expression in which the value of the whole
-   * expression depends only on the last subexpression in the list.
-   * The rest of the subexpressions can be omitted if they don't have dependent nodes.
+   * evaluates to the last subexpression in the list.
+   * In theory, some could be emitted, but we set all the subexpressions
+   * to have dependencies since there could be references in the list.
    *
    * Example:
    * const a = (1, 2, b = 3, 4, b + 2); // `a` will be equal 5
    */
   SequenceExpression(this: GraphBuilderState, node: SequenceExpression) {
-    // Sequence value depends on only last expression in the list
     this.baseVisit(node, true);
     if (node.expressions.length > 0) {
-      this.graph.addEdge(node, node.expressions[node.expressions.length - 1]);
+      for (let expression of node.expressions) {
+        this.graph.addEdge(node, expression);
+      }
     }
   },
 };


### PR DESCRIPTION
I've tried adopting the shaker method (over extraction) and ran into some edge cases – I've added tests that explain what those edge cases look like.

## Motivation
There are three cases that weren't shaken correctly by the shaker algorithm:
1. Assigning to an export (eg. `var x = module.exports = {...}`)
2. Exporting objects (with computed keys)
3. Exporting objects directly (eg. `module.exports = {...}`) and using this object as a default import elsewhere

## Summary
This fixes it by changing the shaker algorithm to support these cases.

I think so long as we can get these new tests to pass, I'd be happy to take suggestions on exactly how we can implement the fixes. In particular, the biggest change is to support assigning to an export, for example:

```
var x = module.exports = {...}
```

The issue there is that the variable declaration `var x = ...` is marked as not-alive, and so the whole expression is shaken. This fixes it by checking variable declarations, but we could also change the `shake` part of the code to check for alive children. I think that that may have broader implications though.

Very impressed with the shaker algorithm overall, thanks for writing it!

## Test plan
Tested with snapshot tests. I believe for CI to pass, https://github.com/callstack/linaria/pull/950