### PR TITLE
fix(esbuild): add add missing loader and resolveDir

### DIFF
--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -79,6 +79,8 @@ export default function linaria({
         if (!result.cssText) {
           return {
             contents: code,
+            loader,
+            resolveDir: path.basename(args.path),
           };
         }
 
@@ -99,6 +101,8 @@ export default function linaria({
           import ${JSON.stringify(cssFilename)};
           ${result.code}
           `,
+          loader,
+          resolveDir: path.basename(args.path),
         };
       });
     },


### PR DESCRIPTION
## Motivation

Resolve #954

## Summary

Add loader and resolveDir to the return value of build.onLoad. Without them, errors will occur when combined with other external esbuild plugins.