### PR TITLE
Remove console.log from stylelint preprocessor

### DIFF
--- a/packages/stylelint/src/preprocessor.ts
+++ b/packages/stylelint/src/preprocessor.ts
@@ -108,8 +108,6 @@ function preprocessor() {
       cache[filename] = replacements;
       offsets[filename] = offsets[filename]?.reverse();
 
-      console.log(cssText);
-
       return cssText + '\n';
     },
     result(result: LintResult, filename: string) {


### PR DESCRIPTION
I noticed that our stylelint runs are logging all of our styles. I've
traced this down to this console.log call.

From what I can tell, it looks like this was added by mistake in
https://github.com/callstack/linaria/pull/876

<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->

I want to remove noise from my CI logs

## Summary

<!--
Explain how your implementation works and your thoughts behind the solution.
It will help maintainers to review your PR.
You can skip it if PR is trivial.
-->
See above

## Test plan

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->
N/A