### PR TITLE
fix(react): support UpperCamelCase custom elements #968

### DIFF
--- a/packages/react/__tests__/__snapshots__/styled.test.js.snap
+++ b/packages/react/__tests__/__snapshots__/styled.test.js.snap
@@ -22,13 +22,22 @@ exports[`does not filter attributes for components 1`] = `
 </div>
 `;
 
-exports[`does not filter attributes for custom elements 1`] = `
+exports[`does not filter attributes for kebab cased custom elements 1`] = `
 <my-element
   className="abcdefg"
   unknownAttribute="voila"
 >
   This is a test
 </my-element>
+`;
+
+exports[`does not filter attributes for upper camel cased custom elements 1`] = `
+<View
+  className="abcdefg"
+  hoverClass="voila"
+>
+  This is a test
+</View>
 `;
 
 exports[`filters unknown html attributes for HTML tag 1`] = `

--- a/packages/react/__tests__/styled.test.js
+++ b/packages/react/__tests__/styled.test.js
@@ -1,4 +1,4 @@
-import { restOp } from '../src/styled';
+import { omit } from '../src/styled';
 
 const React = require('react');
 const renderer = require('react-test-renderer');
@@ -184,7 +184,7 @@ it('filters unknown html attributes for HTML tag', () => {
   expect(tree.toJSON()).toMatchSnapshot();
 });
 
-it('does not filter attributes for custom elements', () => {
+it('does not filter attributes for kebab cased custom elements', () => {
   const Test = styled('my-element')({
     name: 'TestComponent',
     class: 'abcdefg',
@@ -193,6 +193,17 @@ it('does not filter attributes for custom elements', () => {
   const tree = renderer.create(
     <Test unknownAttribute="voila">This is a test</Test>
   );
+
+  expect(tree.toJSON()).toMatchSnapshot();
+});
+
+it('does not filter attributes for upper camel cased custom elements', () => {
+  const Test = styled('View')({
+    name: 'TestComponent',
+    class: 'abcdefg',
+  });
+
+  const tree = renderer.create(<Test hoverClass="voila">This is a test</Test>);
 
   expect(tree.toJSON()).toMatchSnapshot();
 });
@@ -259,7 +270,7 @@ it('throws when using as tag for template literal', () => {
 
 it('can get rest keys from object', () => {
   const obj = { one: 1, two: 2, three: 3 };
-  const rest = restOp(obj, ['two']);
+  const rest = omit(obj, ['two']);
   // eslint-disable-next-line no-unused-vars
   const { two, ...expectedRest } = obj;
   expect(rest).toEqual(expectedRest);
@@ -272,7 +283,7 @@ it('can get rest keys from complex object', () => {
     arr: [1, 2, 3],
     num: 47,
   };
-  const rest = restOp(obj, ['bool', 'object', 'arr']);
+  const rest = omit(obj, ['bool', 'object', 'arr']);
   // eslint-disable-next-line no-unused-vars
   const { bool, object, arr, ...expectedRest } = obj;
   expect(rest).toEqual(expectedRest);


### PR DESCRIPTION
## Motivation

See #968

## Summary

This PR fixes props filtration in order to support custom components with UpperCameCase names.

## Test plan

New tests were added.