### PR TITLE
fix: error when css calls reference css calls inside components

### DIFF
--- a/packages/babel/__utils__/strategy-tester.ts
+++ b/packages/babel/__utils__/strategy-tester.ts
@@ -890,6 +890,38 @@ export function run(
     expect(metadata).toMatchSnapshot();
   });
 
+  it('should process `css` calls referencing other `css` calls inside components', async () => {
+    const { code, metadata } = await transpile(
+      dedent`
+      import React from 'react'
+      import {css} from '@linaria/core'
+
+      export function Component() {
+        const outer = css\`
+          color: red;
+        \`;
+
+        const inner = css\`
+          color: green;
+          .${'${outer}'}:hover & {
+            color: blue;
+          }
+        \`;
+
+        return React.createElement("div", { className: outer },
+          "outer",
+          React.createElement("div", { className: inner },
+            "inner"
+          )
+        );
+      }
+      `
+    );
+
+    expect(code).toMatchSnapshot();
+    expect(metadata).toMatchSnapshot();
+  });
+
   it('should process `styled` calls with complex interpolation inside components', async () => {
     const { code, metadata } = await transpile(
       dedent`

--- a/packages/extractor/__tests__/__snapshots__/extractor.test.ts.snap
+++ b/packages/extractor/__tests__/__snapshots__/extractor.test.ts.snap
@@ -882,6 +882,38 @@ Dependencies: NA
 
 `;
 
+exports[`extractor should process \`css\` calls referencing other \`css\` calls inside components 1`] = `
+"import React from 'react';
+import { css } from '@linaria/core';
+export function Component() {
+  const outer = \\"outer_o1t92lw9\\";
+  const inner = \\"inner_i1xjmq2i\\";
+  return React.createElement(\\"div\\", {
+    className: outer
+  }, \\"outer\\", React.createElement(\\"div\\", {
+    className: inner
+  }, \\"inner\\"));
+}"
+`;
+
+exports[`extractor should process \`css\` calls referencing other \`css\` calls inside components 2`] = `
+
+CSS:
+
+.outer_o1t92lw9 {
+    color: red;
+  }
+.inner_i1xjmq2i {
+    color: green;
+    .outer_o1t92lw9:hover & {
+      color: blue;
+    }
+  }
+
+Dependencies: NA
+
+`;
+
 exports[`extractor should process \`css\` calls with complex interpolation inside components 1`] = `
 "import React from 'react';
 import { css } from '@linaria/core';

--- a/packages/shaker/__tests__/__snapshots__/shaker.test.ts.snap
+++ b/packages/shaker/__tests__/__snapshots__/shaker.test.ts.snap
@@ -1048,6 +1048,38 @@ Dependencies: NA
 
 `;
 
+exports[`shaker should process \`css\` calls referencing other \`css\` calls inside components 1`] = `
+"import React from 'react';
+import { css } from '@linaria/core';
+export function Component() {
+  const outer = \\"outer_o1t92lw9\\";
+  const inner = \\"inner_i1xjmq2i\\";
+  return React.createElement(\\"div\\", {
+    className: outer
+  }, \\"outer\\", React.createElement(\\"div\\", {
+    className: inner
+  }, \\"inner\\"));
+}"
+`;
+
+exports[`shaker should process \`css\` calls referencing other \`css\` calls inside components 2`] = `
+
+CSS:
+
+.outer_o1t92lw9 {
+    color: red;
+  }
+.inner_i1xjmq2i {
+    color: green;
+    .outer_o1t92lw9:hover & {
+      color: blue;
+    }
+  }
+
+Dependencies: NA
+
+`;
+
 exports[`shaker should process \`css\` calls with complex interpolation inside components 1`] = `
 "import React from 'react';
 import { css } from '@linaria/core';


### PR DESCRIPTION
## Motivation

fix: https://github.com/callstack/linaria/issues/957

## Summary

The issue was caused by the referenced template getting hoisted, converting the path already added to `state.queue` into an identifier referencing the hoisted variable. The code processing the queue expected all paths to be tagged template literals and crashed when trying to access `path.get('quasi').get('expressions')`.

Avoiding hoisting templates when referenced in other templates seem to have solved the problem.