### PR TITLE
fix(atomic): fix duplication of the same css properties in the same file

### DIFF
--- a/packages/babel/__tests__/__snapshots__/babel.test.ts.snap
+++ b/packages/babel/__tests__/__snapshots__/babel.test.ts.snap
@@ -129,6 +129,25 @@ Dependencies: NA
 
 `;
 
+exports[`compiles atomic css with unique atoms based on key value pairs 1`] = `
+"/* @flow */
+import { css } from '@linaria/atomic';
+const x = \\"atm_e2_12xxubj\\";
+const y = \\"atm_e2_tnzek8\\";
+console.log(x, y);"
+`;
+
+exports[`compiles atomic css with unique atoms based on key value pairs 2`] = `
+
+CSS:
+
+.atm_e2_12xxubj{height:100px;}
+.atm_e2_tnzek8{height:99px;}
+
+Dependencies: NA
+
+`;
+
 exports[`does not include styles if not referenced anywhere 1`] = `
 "import { css } from '@linaria/core';
 import { styled } from '@linaria/react';

--- a/packages/babel/__tests__/babel.test.ts
+++ b/packages/babel/__tests__/babel.test.ts
@@ -700,6 +700,29 @@ it('compiles atomic css with keyframes', async () => {
   expect(metadata).toMatchSnapshot();
 });
 
+it('compiles atomic css with unique atoms based on key value pairs', async () => {
+  const { code, metadata } = await transpile(
+    dedent`
+    /* @flow */
+
+    import { css } from '@linaria/atomic';
+
+    const x = css\`
+      height: 100px;
+    \`;
+
+    const y = css\`
+      height: 99px
+    \`;
+
+    console.log(x, y);
+      `
+  );
+
+  expect(code).toMatchSnapshot();
+  expect(metadata).toMatchSnapshot();
+});
+
 it('can re-export lib apis using a custom resolver', async () => {
   const { code, metadata } = await transpile(
     dedent`

--- a/packages/babel/src/evaluators/templateProcessor.ts
+++ b/packages/babel/src/evaluators/templateProcessor.ts
@@ -307,7 +307,7 @@ export default function getTemplateProcessor(
       }
       const atomicRules = atomize(cssText);
       atomicRules.forEach((rule) => {
-        state.rules[rule.property] = {
+        state.rules[rule.cssText] = {
           cssText: rule.cssText,
           start: path.parent?.loc?.start ?? null,
           className: className!,


### PR DESCRIPTION
## Motivation

This fixes a bug I discovered where the same property is getting overriden by other css in the same file. Test case provided for the scenario that's failing


## Summary

Relatively simple fix – this just uses the CSS text itself as a key in the metadata to ensure that it's unique per rule + declaration, between declarations too.

## Test plan

Fixed with a snapshot test
