### PR TITLE
fix(react): styled API prop interpolation #981

### DIFF
--- a/packages/babel/src/evaluators/templateProcessor.ts
+++ b/packages/babel/src/evaluators/templateProcessor.ts
@@ -192,7 +192,7 @@ export default function getTemplateProcessor(options: StrictOptions) {
         try {
           const { ex: expression } = expressionValue;
           cssText += tagProcessor.addInterpolation(
-            expression instanceof NodePath ? expression.node : expression,
+            'node' in expression ? expression.node : expression,
             expressionValue.source
           );
         } catch (e) {


### PR DESCRIPTION
## Motivation

See #981 

## Summary

Do not use `instanceof` in an environment with uncontrolled dependencies.
