### PR TITLE
feat(cli): new flag --transform

### DIFF
--- a/.changeset/slow-flowers-rest.md
+++ b/.changeset/slow-flowers-rest.md
@@ -1,0 +1,5 @@
+---
+'@linaria/cli': patch
+---
+
+CLI now supports full inline transformations instead of just extracting styles. With the new flag --transform, Linaria CLI replaces template tags with their runtime representations.


### PR DESCRIPTION
## Motivation

Previously, CLI could only extract styles from source files, but template tags were kept untouched. 

## Summary

This PR introduces two new options:
- `--transform` or `-t` that say Linaria, that we want not only extract styles but also replace all template tags with their runtime representations;
- `--modules [name]` or `-m [name]` that specify what type of import will be used: `require(…)` or `import …`.

With this PR and #976, it became possible to use pure tsc compiler and @linaria/cli as postprocessing for building libs.