### PR TITLE
fix(babel): aliases for processors and fixed resolver

### DIFF
--- a/.changeset/fair-cars-attack.md
+++ b/.changeset/fair-cars-attack.md
@@ -1,0 +1,6 @@
+---
+'@linaria/babel-preset': patch
+'@linaria/testkit': patch
+---
+
+Fix for the case when `styled` wraps an imported component.

--- a/.changeset/wicked-mugs-smash.md
+++ b/.changeset/wicked-mugs-smash.md
@@ -1,0 +1,9 @@
+---
+'@linaria/atomic': patch
+'@linaria/babel-preset': patch
+'@linaria/core': patch
+'@linaria/react': patch
+'@linaria/testkit': patch
+---
+
+Aliases for environments without the support of `exports` in package.json.

--- a/packages/atomic/processors/css.js
+++ b/packages/atomic/processors/css.js
@@ -1,0 +1,5 @@
+Object.defineProperty(exports, '__esModule', {
+  value: true,
+});
+
+exports.default = require('../lib/processors/css').default;

--- a/packages/atomic/processors/styled.js
+++ b/packages/atomic/processors/styled.js
@@ -1,0 +1,5 @@
+Object.defineProperty(exports, '__esModule', {
+  value: true,
+});
+
+exports.default = require('../lib/processors/styled').default;

--- a/packages/babel/src/evaluators/templateProcessor.ts
+++ b/packages/babel/src/evaluators/templateProcessor.ts
@@ -3,7 +3,6 @@
  * It uses CSS code from template literals and evaluated values of lazy dependencies stored in ValueCache.
  */
 
-import { NodePath } from '@babel/traverse';
 import type { TemplateElement } from '@babel/types';
 
 import type { StyledMeta } from '@linaria/core';

--- a/packages/core/processors/BaseProcessor.js
+++ b/packages/core/processors/BaseProcessor.js
@@ -1,0 +1,5 @@
+Object.defineProperty(exports, '__esModule', {
+  value: true,
+});
+
+exports.default = require('../lib/processors/BaseProcessor').default;

--- a/packages/core/processors/css.js
+++ b/packages/core/processors/css.js
@@ -1,0 +1,5 @@
+Object.defineProperty(exports, '__esModule', {
+  value: true,
+});
+
+exports.default = require('../lib/processors/css').default;

--- a/packages/react/processors/styled.js
+++ b/packages/react/processors/styled.js
@@ -1,0 +1,5 @@
+Object.defineProperty(exports, '__esModule', {
+  value: true,
+});
+
+exports.default = require('../lib/processors/styled').default;

--- a/packages/testkit/src/utils/getTagProcessor.test.ts
+++ b/packages/testkit/src/utils/getTagProcessor.test.ts
@@ -49,6 +49,19 @@ describe('getTagProcessor', () => {
     expect(tagSource(result)).toBe('renamedStyled(Cmp)');
   });
 
+  it('imported component', () => {
+    const result = run(
+      dedent`
+      import Layout from "../__fixtures__/components-library";
+      import { styled } from "@linaria/react";
+
+      export const StyledLayout = styled(Layout)\`\`;
+    `
+    );
+
+    expect(tagSource(result)).toBe('styled(Layout)');
+  });
+
   it('renamedStyled(Cmp)``', () => {
     const result = run(
       dedent`


### PR DESCRIPTION
## Motivation

Some environment doesn't support `exports` in `package.json`.

## Summary

Aliases from roots of packages to lib folders should solve that problem.