### PR TITLE
fix(cli): pass source-root option to babel

### DIFF
--- a/.changeset/twelve-dolphins-sin.md
+++ b/.changeset/twelve-dolphins-sin.md
@@ -1,0 +1,6 @@
+---
+'@linaria/babel-preset': patch
+'@linaria/cli': patch
+---
+
+Pass source-root option from CLI to babel-preset

--- a/packages/babel/src/transform.ts
+++ b/packages/babel/src/transform.ts
@@ -187,6 +187,7 @@ export default function transform(code: string, options: Options): Result {
     sourceMaps: true,
     sourceFileName: options.filename,
     inputSourceMap: options.inputSourceMap,
+    root: options.root,
   })!;
 
   return extractCssFromAst(babelFileResult, code, options);

--- a/packages/babel/src/types.ts
+++ b/packages/babel/src/types.ts
@@ -157,10 +157,11 @@ export type LinariaMetadata = {
 
 export type Options = {
   filename: string;
-  preprocessor?: Preprocessor;
-  outputFilename?: string;
   inputSourceMap?: RawSourceMap;
+  outputFilename?: string;
   pluginOptions?: Partial<PluginOptions>;
+  preprocessor?: Preprocessor;
+  root?: string;
 };
 
 export type PreprocessorFn = (selector: string, cssText: string) => string;

--- a/packages/cli/src/linaria.ts
+++ b/packages/cli/src/linaria.ts
@@ -141,6 +141,7 @@ function processFiles(files: (number | string)[], options: Options) {
         pluginOptions: {
           configFile: options.configFile,
         },
+        root: options.sourceRoot,
       }
     );
 


### PR DESCRIPTION
## Motivation

CLI didn't pass `source-root` to the babel plugin.