### PR TITLE
fix(cli): write files only when all transformations are finished

### DIFF
--- a/.changeset/smart-rivers-exist.md
+++ b/.changeset/smart-rivers-exist.md
@@ -1,0 +1,5 @@
+---
+'@linaria/cli': patch
+---
+
+CLI should write files only when all transforms are finished successfully.

--- a/packages/cli/src/linaria.ts
+++ b/packages/cli/src/linaria.ts
@@ -153,6 +153,8 @@ async function processFiles(files: (number | string)[], options: Options) {
     }
   };
 
+  const modifiedFiles: { name: string; content: string }[] = [];
+
   // eslint-disable-next-line no-restricted-syntax
   for (const filename of resolvedFiles) {
     if (fs.lstatSync(filename).isDirectory()) {
@@ -229,16 +231,20 @@ async function processFiles(files: (number | string)[], options: Options) {
           : fs.readFileSync(normalizedInputFilename, 'utf-8');
 
         if (!inputContent.trim().endsWith(statement)) {
-          fs.writeFileSync(
-            normalizedInputFilename,
-            `${inputContent}\n${statement}\n`
-          );
+          modifiedFiles.push({
+            name: normalizedInputFilename,
+            content: `${inputContent}\n${statement}\n`,
+          });
         }
       }
 
       count += 1;
     }
   }
+
+  modifiedFiles.forEach(({ name, content }) => {
+    fs.writeFileSync(name, content);
+  });
 
   console.log(`Successfully extracted ${count} CSS files.`);
 


### PR DESCRIPTION
## Motivation

CLI should not write changes if some files cannot be transformed.