### PR TITLE
fix(babel, react, shaker): tag in runtime is not supported (fixes #1021)

### DIFF
--- a/.changeset/three-emus-turn.md
+++ b/.changeset/three-emus-turn.md
@@ -1,0 +1,7 @@
+---
+'@linaria/babel-preset': patch
+'@linaria/react': patch
+'@linaria/shaker': patch
+---
+
+Fix 'Using the tag in runtime is not supported' in some enviroments (fixes #1021)

--- a/packages/babel/src/index.ts
+++ b/packages/babel/src/index.ts
@@ -30,7 +30,7 @@ export { default as peek } from './utils/peek';
 export { default as processTemplateExpression } from './utils/processTemplateExpression';
 
 function isEnabled(caller?: TransformCaller & { evaluate?: true }) {
-  return caller?.name !== 'linaria' || !caller.evaluate;
+  return caller?.name !== 'linaria' || caller.evaluate === true;
 }
 
 export default function linaria(babel: ConfigAPI, options: PluginOptions) {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,2 +1,4 @@
 export { default as styled } from './styled';
+export type { StyledJSXIntrinsics, Styled } from './styled';
 export type { CSSProperties } from '@linaria/core';
+export type { StyledMeta } from '@linaria/tags';

--- a/packages/react/src/processors/styled.ts
+++ b/packages/react/src/processors/styled.ts
@@ -48,13 +48,13 @@ export default class StyledProcessor extends TaggedTemplateProcessor {
   constructor(params: Params, ...args: TailProcessorParams) {
     validateParams(
       params,
-      ['tag', ['call', 'member'], 'template'],
+      ['tag', ['call', 'member'], ['template', 'call']],
       'Invalid usage of `styled` tag'
     );
 
     const [tag, tagOp, template] = params;
 
-    super([tag, template], ...args);
+    super([tag, template[0] === 'call' ? ['template', []] : template], ...args);
 
     let component: WrappedNode | undefined;
     if (tagOp[0] === 'call' && tagOp.length === 2) {

--- a/packages/react/src/styled.ts
+++ b/packages/react/src/styled.ts
@@ -246,7 +246,7 @@ type ComponentStyledTagWithInterpolation<TTrgProps, TOrigCmp> = <OwnProps = {}>(
   ? StyledMeta & TOrigCmp
   : StyledComponent<OwnProps & TTrgProps>;
 
-type StyledJSXIntrinsics = {
+export type StyledJSXIntrinsics = {
   readonly [P in keyof JSX.IntrinsicElements]: HtmlStyledTag<P>;
 };
 

--- a/packages/shaker/src/index.ts
+++ b/packages/shaker/src/index.ts
@@ -19,6 +19,9 @@ const getShakerConfig = (only: string[] | null): TransformOptions => {
 
   const config = {
     ast: true,
+    caller: {
+      name: 'linaria',
+    },
     envName: 'linaria',
     targets: {
       node: 'current',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,7 +410,7 @@ importers:
       '@babel/types': 7.18.9
       '@types/babel__core': 7.1.19
       '@types/node': 17.0.39
-      '@types/react': 18.0.10
+      '@types/react': 18.0.15
       react: 16.14.0
       react-test-renderer: 16.14.0_react@16.14.0
 
@@ -3554,8 +3554,8 @@ packages:
     resolution: {integrity: sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==}
     dev: true
 
-  /@types/react/18.0.10:
-    resolution: {integrity: sha512-dIugadZuIPrRzvIEevIu7A1smqOAjkSMv8qOfwPt9Ve6i6JT/FQcCHyk2qIAxwsQNKZt5/oGR0T4z9h2dXRAkg==}
+  /@types/react/18.0.15:
+    resolution: {integrity: sha512-iz3BtLuIYH1uWdsv6wXYdhozhqj20oD4/Hk2DNXIn1kFsmp9x8d9QB6FnPhfkbhd2PgEONt9Q1x/ebkwjfFLow==}
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
@@ -10936,14 +10936,14 @@ packages:
       safe-buffer: 5.2.1
 
   /strip-ansi/3.0.1:
-    resolution: {integrity: sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=}
+    resolution: {integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==}
     engines: {node: '>=0.10.0'}
     dependencies:
       ansi-regex: 2.1.1
     dev: true
 
   /strip-ansi/4.0.0:
-    resolution: {integrity: sha1-qEeQIusaw2iocTibY1JixQXuNo8=}
+    resolution: {integrity: sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==}
     engines: {node: '>=4'}
     dependencies:
       ansi-regex: 3.0.1
@@ -12323,7 +12323,7 @@ packages:
     engines: {node: '>=10'}
 
   /yallist/2.1.2:
-    resolution: {integrity: sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=}
+    resolution: {integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==}
     dev: true
 
   /yallist/4.0.0:


### PR DESCRIPTION
## Motivation

There are a few problems: the wrong condition in babel-preset, missed caller in Shaker, and the problem with processing already processed `styled`. All of them caused errors in different environments, such as jest and Vite dev-mode.