### PR TITLE
feat(babel): react hooks aren't needed for evaluation

### DIFF
--- a/.changeset/real-terms-brush.md
+++ b/.changeset/real-terms-brush.md
@@ -1,0 +1,5 @@
+---
+'@linaria/babel-preset': patch
+---
+
+React hooks aren't needed for evaluation so we can replace them as we already do with react components (fixes compatability with [ariakit](https://github.com/ariakit/ariakit) and some other libraries).


### PR DESCRIPTION
## Motivation

The size of evaluated code can be reduced by shaking out all functions that use react hooks.

## Summary

This PR modifies the preeval stage to detect and delete not only `createElement` calls but all react functions that can be used only inside components.
