### PR TITLE
fix(preeval): do not remove global var in string template

### DIFF
--- a/packages/utils/src/scopeHelpers.ts
+++ b/packages/utils/src/scopeHelpers.ts
@@ -127,6 +127,16 @@ export function findParentForDelete(path: NodePath): NodePath | null {
     return findParentForDelete(parent);
   }
 
+  if (parent.isTemplateLiteral()) {
+    mutate(path, (p) => {
+      p.replaceWith({
+        type: 'StringLiteral',
+        value: '',
+      });
+    });
+    return null;
+  }
+
   if (parent.isAssignmentExpression()) {
     return findParentForDelete(parent);
   }


### PR DESCRIPTION
## Motivation
Should fix #1039 

## Summary
it's safe to not remove the global var inside `TemplateString`, I replace it with empty string