### PR TITLE
fix: update SWC helpers path in module evaluation

### DIFF
--- a/.changeset/wild-eyes-joke.md
+++ b/.changeset/wild-eyes-joke.md
@@ -1,0 +1,5 @@
+---
+'@linaria/babel-preset': patch
+---
+
+fix: update SWC helpers path in module evaluation

--- a/packages/babel/src/module.ts
+++ b/packages/babel/src/module.ts
@@ -76,12 +76,14 @@ const createCustomDebug =
   };
 
 const cookModuleId = (rawId: string) => {
-  // It's a dirty hack for avoiding conflicts with babel-preset-react-app
-  // https://github.com/callstack/linaria/issues/745
-  // FIXME @Anber: I'll try to figure out a better solution. Probably, using Terser as a shaker's core can solve problems with interfered plugins.
-  return rawId.replace(
-    '/@babel/runtime/helpers/esm/',
-    '/@babel/runtime/helpers/'
+  return (
+    rawId
+      // It's a dirty hack for avoiding conflicts with babel-preset-react-app
+      // https://github.com/callstack/linaria/issues/745
+      // FIXME @Anber: I'll try to figure out a better solution. Probably, using Terser as a shaker's core can solve problems with interfered plugins.
+      .replace('/@babel/runtime/helpers/esm/', '/@babel/runtime/helpers/')
+      // The same hack for SWC helpers
+      .replace(/(@swc\/helpers\/)src(\/.+)\.mjs/, '$1lib$2.js')
   );
 };
 


### PR DESCRIPTION
## Summary

We use module evaluation from Linaria v3 in Griffel. It's expected to have Linaria or Griffel loader after main transformer i.e.:

```js
module.exports = {
  module: {
    rules: [
      {
        test: /\.(ts|tsx)$/,
        exclude: /node_modules/,
        use: [{ loader: "@griffel/webpack-loader" }, { use: "babel-loader" }]
      }
    ]
  }
};
```

The problem comes with Next.js and SWC used there. SWC emits helpers in the same way as Babel:

```ts
import _objectSpread from "@swc/helpers/src/_object_spread.mjs";

var a = _objectSpread({}, {
    foo: true
});
```

The problem is in an import that points to ESM module while it should point to CJS to successfully evaluate code.

ESM helpers follow this pattern: `node_modules/@swc/helpers/src/_array_with_holes.mjs`
CJS helpers follow this pattern: `node_modules/@swc/helpers/lib/_array_without_holes.js`

This PR adds another `.replace()` to `cookModuleId()` to handle this.

## Test plan

N/A
I wanted to add an additional test, but haven't found it. I tested changes manually in a test project.
