### PR TITLE
docs: added -m and -t options for CLI

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -34,4 +34,6 @@ where `source-root` is directory with source JS files and `insert-css-requires` 
 * `-i, --insert-css-requires <dir>` - Directory containing JS files to insert require statements for the CSS files (__works only if `-r, --source-root` is provided__)
 * `-c, --config-file <filepath>` - Path to the configuration file. If a relative path is given, it'll be resolved relative to the current working directory.
 * `-x, --ignore "<pattern>"` - Pattern of files to ignore. Be sure to wrap with quotes.
+* `-m, --modules <type>` - Specifies a type of used imports.
+* `-t, --transform <boolean>` - Replace template tags with evaluated values.
  


### PR DESCRIPTION
## Motivation

CLI has two handy arguments that are missed in the documentation: `-t` and `-m`
