### PR TITLE
fix(babel, react): do not process already transformed literals (fixes #1037)

### DIFF
--- a/.changeset/hot-eagles-impress.md
+++ b/.changeset/hot-eagles-impress.md
@@ -1,0 +1,9 @@
+---
+'@linaria/babel-preset': minor
+'@linaria/react': minor
+'@linaria/tags': minor
+'@linaria/webpack4-loader': minor
+'@linaria/webpack5-loader': minor
+---
+
+Sometimes Linaria can meet already processed code. In such a case, it shall ignore runtime versions of `styled` tags. (fixes #1037)

--- a/packages/babel/src/transform.ts
+++ b/packages/babel/src/transform.ts
@@ -176,7 +176,7 @@ export default async function transform(
   eventEmitter?.({ type: 'transform:stage-1:start', filename });
 
   const entryPoint = Promise.resolve({
-    name: options.filename,
+    name: filename,
     code: originalCode,
     only: ['__linariaPreval'],
   });

--- a/packages/babel/src/utils/getTagProcessor.ts
+++ b/packages/babel/src/utils/getTagProcessor.ts
@@ -476,6 +476,11 @@ export default function getTagProcessor(
         cache.set(path.node, null);
       }
     } catch (e) {
+      if (e === BaseProcessor.SKIP) {
+        cache.set(path.node, null);
+        return null;
+      }
+
       if (e instanceof Error) {
         throw buildCodeFrameError(path, e.message);
       }

--- a/packages/react/src/processors/styled.ts
+++ b/packages/react/src/processors/styled.ts
@@ -54,7 +54,13 @@ export default class StyledProcessor extends TaggedTemplateProcessor {
 
     const [tag, tagOp, template] = params;
 
-    super([tag, template[0] === 'call' ? ['template', []] : template], ...args);
+    if (template[0] === 'call') {
+      // It is already transformed styled-literal. Skip it.
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
+      throw TaggedTemplateProcessor.SKIP;
+    }
+
+    super([tag, template], ...args);
 
     let component: WrappedNode | undefined;
     if (tagOp[0] === 'call' && tagOp.length === 2) {

--- a/packages/tags/src/BaseProcessor.ts
+++ b/packages/tags/src/BaseProcessor.ts
@@ -30,6 +30,8 @@ export type TailProcessorParams = ProcessorParams extends [Params, ...infer T]
   : never;
 
 export default abstract class BaseProcessor {
+  public static SKIP = Symbol('skip');
+
   public readonly artifacts: Artifact[] = [];
 
   public readonly className: string;

--- a/packages/webpack4-loader/src/index.ts
+++ b/packages/webpack4-loader/src/index.ts
@@ -70,7 +70,7 @@ export default function webpack4Loader(
   transform(
     content.toString(),
     {
-      filename: path.relative(process.cwd(), this.resourcePath),
+      filename: this.resourcePath,
       inputSourceMap: inputSourceMap ?? undefined,
       pluginOptions: rest,
       preprocessor,

--- a/packages/webpack5-loader/src/index.ts
+++ b/packages/webpack5-loader/src/index.ts
@@ -83,7 +83,7 @@ const webpack5Loader: Loader = function webpack5LoaderPlugin(
   transform(
     content.toString(),
     {
-      filename: path.relative(process.cwd(), this.resourcePath),
+      filename: this.resourcePath,
       inputSourceMap: convertSourceMap(inputSourceMap, this.resourcePath),
       pluginOptions: rest,
       preprocessor,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2728,22 +2728,22 @@ packages:
       find-up: 4.1.0
     dev: true
 
-  /@definitelytyped/header-parser/0.0.121:
-    resolution: {integrity: sha512-78HY1J+QiwZPXFZQWb9gPQPxAMNg6/1e4gl7gL/8dmd17vVWLi3AGrLJoG8Pn1p8d7MF2rlPw/2AE6+r1IHNHA==}
+  /@definitelytyped/header-parser/0.0.124:
+    resolution: {integrity: sha512-0MfRuxWJV8TXLgI/4PVsiXG4SS9WOrQ3abjZcAcQY0KC+M4Ny+GSZ1Ypbh76kTcFjYWqxL0Xw7ANQFk0OjuDaA==}
     dependencies:
-      '@definitelytyped/typescript-versions': 0.0.121
+      '@definitelytyped/typescript-versions': 0.0.124
       '@types/parsimmon': 1.10.6
       parsimmon: 1.18.1
     dev: true
 
-  /@definitelytyped/typescript-versions/0.0.121:
-    resolution: {integrity: sha512-mTfkR7MrGo08lzOPZx3ZgIER9PoalRZok3hmrsLDxTUhS5lrgdgXBOpAyDMtnJUAO6AxrIx126XGlkN+1rvKcA==}
+  /@definitelytyped/typescript-versions/0.0.124:
+    resolution: {integrity: sha512-95OsAortdPqZJrjopgrFKa/Fo2jrCsJNFMR05KRw3H6Q/Z0bWNJK5kJvB63eRVQhtz5M7OiG4xSwN/KDxf3eyw==}
     dev: true
 
-  /@definitelytyped/utils/0.0.121:
-    resolution: {integrity: sha512-H2g09ZJcmCk0BAy86M/UcMP4pq0UGaKBGpjPjPe5btKgZDB6A1Tn1/TKd46cQ6grhFdsxJFE5cb8XWGTKkpA8w==}
+  /@definitelytyped/utils/0.0.124:
+    resolution: {integrity: sha512-CnnbUBpxIrMAAxsLT9+rRp7nF/MHpMqf/+mfbY30LaTELrJHmH5FQqnxQSkHZkoUkHESvpxtl9xg4yYezCQ5qw==}
     dependencies:
-      '@definitelytyped/typescript-versions': 0.0.121
+      '@definitelytyped/typescript-versions': 0.0.124
       '@qiwi/npm-registry-client': 8.9.1
       '@types/node': 14.18.20
       charm: 1.0.2
@@ -5572,7 +5572,7 @@ packages:
     peerDependencies:
       typescript: '*'
     dependencies:
-      '@definitelytyped/header-parser': 0.0.121
+      '@definitelytyped/header-parser': 0.0.124
       command-exists: 1.2.9
       rimraf: 3.0.2
       semver: 6.3.0
@@ -5588,9 +5588,9 @@ packages:
     peerDependencies:
       typescript: '>= 3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.7.0-dev || >= 3.8.0-dev || >= 3.9.0-dev || >= 4.0.0-dev'
     dependencies:
-      '@definitelytyped/header-parser': 0.0.121
-      '@definitelytyped/typescript-versions': 0.0.121
-      '@definitelytyped/utils': 0.0.121
+      '@definitelytyped/header-parser': 0.0.124
+      '@definitelytyped/typescript-versions': 0.0.124
+      '@definitelytyped/utils': 0.0.124
       dts-critic: 3.3.11_typescript@4.7.4
       fs-extra: 6.0.1
       json-stable-stringify: 1.0.1


### PR DESCRIPTION
## Motivation

See #1037

## Summary

This PR introduces a way to skip a tag if it doesn't match the required conditions (e.g. `styled` is used as a call instead of a template tag).