### PR TITLE
fix(babel): improve jsx-runtime detection

### DIFF
--- a/.changeset/unlucky-goats-tie.md
+++ b/.changeset/unlucky-goats-tie.md
@@ -1,0 +1,8 @@
+---
+'@linaria/babel-preset': patch
+'@linaria/shaker': patch
+'@linaria/testkit': patch
+'@linaria/utils': patch
+---
+
+Better detection for jsx-runtime. Reduces the amount of evaluated code and improves speed and stability.

--- a/packages/babel/src/utils/getTagProcessor.ts
+++ b/packages/babel/src/utils/getTagProcessor.ts
@@ -447,7 +447,7 @@ export default function getTagProcessor(
 ): BaseProcessor | null {
   if (!cache.has(path.node)) {
     const root = path.scope.getProgramParent().path;
-    const { imports } = collectExportsAndImports(root, fileContext.filename);
+    const { imports } = collectExportsAndImports(root);
     try {
       const builder = getBuilderForIdentifier(
         path,

--- a/packages/shaker/src/plugins/shaker-plugin.ts
+++ b/packages/shaker/src/plugins/shaker-plugin.ts
@@ -135,7 +135,7 @@ export default function shakerPlugin(
     ifUnknownExport = 'skip-shaking',
     onlyExports,
   }: IShakerOptions
-): PluginObj<IState> {
+): PluginObj<IState & { filename: string }> {
   return {
     name: '@linaria/shaker',
     pre(file: BabelFile) {
@@ -144,7 +144,7 @@ export default function shakerPlugin(
 
       log('start', `${this.filename}, onlyExports: ${onlyExports.join(',')}`);
 
-      const collected = collectExportsAndImports(file.path, file.opts.filename);
+      const collected = collectExportsAndImports(file.path);
       const sideEffectImports = collected.imports.filter(sideEffectImport);
       log(
         'import-and-exports',

--- a/packages/testkit/src/collectExportsAndImports.test.ts
+++ b/packages/testkit/src/collectExportsAndImports.test.ts
@@ -73,7 +73,7 @@ function runWithCompiler(compiler: (code: string) => string, code: string) {
 
   const file = new File({ filename }, { code, ast });
 
-  const collected = collectExportsAndImports(file.path, filename);
+  const collected = collectExportsAndImports(file.path);
 
   const sortImports = (
     a: { imported: string | null; source: string },

--- a/packages/testkit/src/utils/isUnnecessaryReactCall.test.ts
+++ b/packages/testkit/src/utils/isUnnecessaryReactCall.test.ts
@@ -1,0 +1,102 @@
+import { join } from 'path';
+
+import * as babel from '@babel/core';
+import type { NodePath } from '@babel/core';
+import type { Program } from '@babel/types';
+import dedent from 'dedent';
+
+import type { MissedBabelCoreTypes } from '@linaria/babel-preset';
+import { isUnnecessaryReactCall } from '@linaria/utils';
+
+const { File } = babel as typeof babel & MissedBabelCoreTypes;
+
+const check = (rawCode: TemplateStringsArray): boolean => {
+  const code = dedent(rawCode);
+  const filename = join(__dirname, 'source.ts');
+  const ast = babel.parse(code, {
+    babelrc: false,
+    configFile: false,
+    filename,
+    presets: ['@babel/preset-typescript'],
+  })!;
+
+  const file = new File({ filename }, { code, ast });
+  const program = file.path.find((p) =>
+    p.isProgram()
+  ) as NodePath<Program> | null;
+  const body = program?.get('body') ?? [];
+  const lastStatement = body[body.length - 1];
+  if (!lastStatement || !lastStatement.isExpressionStatement()) {
+    throw new Error('Last statement is not an expression statement');
+  }
+
+  const expression = lastStatement.get('expression');
+  if (!expression.isCallExpression()) {
+    throw new Error('Last statement is not a call expression');
+  }
+
+  return isUnnecessaryReactCall(expression);
+};
+
+describe('isUnnecessaryReactCall', () => {
+  describe('jsx-runtime', () => {
+    it('should process simple usage', () => {
+      const result = check`
+        const jsx_runtime_1 = require("react/jsx-runtime").jsx;
+        jsx_runtime_1("span", null, "Hello World");
+      `;
+
+      expect(result).toBe(true);
+    });
+
+    it('should process usage wrapped with SequenceExpression', () => {
+      const result = check`
+        const jsx_runtime_1 = require("react/jsx-runtime").jsx;
+        (0, jsx_runtime_1)("span", null, "Hello World");
+      `;
+
+      expect(result).toBe(true);
+    });
+
+    it('should process namespaced', () => {
+      const result = check`
+        const jsx_runtime_1 = require("react/jsx-runtime");
+        (0, jsx_runtime_1.jsx)("div", null, "Hello World");
+        (0, jsx_runtime_1.jsx)("span", null, "Hello World");
+        (0, jsx_runtime_1.jsxs)("div", null, "Hello World");
+        (0, jsx_runtime_1.jsxs)("span", null, "Hello World");
+      `;
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('classic react', () => {
+    it('should process createElement', () => {
+      const result = check`
+        const react_1 = require("react");
+        (0, react_1.createElement)("div", null, "Hello World");
+      `;
+
+      expect(result).toBe(true);
+    });
+
+    it('should process hooks', () => {
+      const result = check`
+        const react_1 = require("react");
+        (0, react_1.useState)(null);
+      `;
+
+      expect(result).toBe(true);
+    });
+
+    it('should ignore createContext', () => {
+      const result = check`
+        const react_1 = require("react");
+        (0, react_1.createContext)();
+      `;
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/packages/utils/src/collectExportsAndImports.ts
+++ b/packages/utils/src/collectExportsAndImports.ts
@@ -59,7 +59,6 @@ export interface IReexport {
 export interface IState {
   exportRefs: Map<string, NodePath<MemberExpression>[]>;
   exports: IExport[];
-  filename: string | null | undefined;
   imports: (IImport | ISideEffectImport)[];
   reexports: IReexport[];
 }
@@ -902,13 +901,11 @@ function collectFromCallExpression(
 
 export default function collectExportsAndImports(
   path: NodePath,
-  filename: string | null | undefined,
   force = false
 ): IState {
   const state: IState = {
     exportRefs: new Map(),
     exports: [],
-    filename,
     imports: [],
     reexports: [],
   };

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -11,6 +11,7 @@ export { default as isNotNull } from './isNotNull';
 export { default as isRemoved } from './isRemoved';
 export { default as isRequire } from './isRequire';
 export { default as isTypedNode } from './isTypedNode';
+export { default as isUnnecessaryReactCall } from './isUnnecessaryReactCall';
 export * from './options';
 export * from './scopeHelpers';
 export { default as slugify } from './slugify';

--- a/packages/utils/src/isUnnecessaryReactCall.ts
+++ b/packages/utils/src/isUnnecessaryReactCall.ts
@@ -1,0 +1,108 @@
+import type { NodePath } from '@babel/core';
+import type { CallExpression } from '@babel/types';
+
+import type { IImport, ISideEffectImport } from './collectExportsAndImports';
+import collectExportsAndImports from './collectExportsAndImports';
+
+function getCallee(p: NodePath<CallExpression>) {
+  const callee = p.get('callee');
+  if (callee.isSequenceExpression()) {
+    const expressions = callee.get('expressions');
+    if (
+      expressions.length === 2 &&
+      expressions[0].isNumericLiteral({ value: 0 })
+    ) {
+      return expressions[1];
+    }
+
+    return callee;
+  }
+
+  return callee;
+}
+
+const JSXRuntimeSource = 'react/jsx-runtime';
+
+function isJSXRuntime(
+  p: NodePath<CallExpression>,
+  imports: (IImport | ISideEffectImport)[]
+) {
+  const jsxRuntime = imports.find((i) => i.source === JSXRuntimeSource);
+  const jsxRuntimeName =
+    jsxRuntime?.local?.isIdentifier() && jsxRuntime?.local?.node?.name;
+
+  if (jsxRuntime) {
+    const callee = getCallee(p);
+    if (jsxRuntimeName && callee.isIdentifier({ name: jsxRuntimeName })) {
+      return true;
+    }
+
+    if (
+      callee.isMemberExpression() &&
+      imports.find((i) => i.source === JSXRuntimeSource && i.local === callee)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function isHookOrCreateElement(name: string): boolean {
+  return name === 'createElement' || /use[A-Z]/.test(name);
+}
+
+function isClassicReactRuntime(
+  p: NodePath<CallExpression>,
+  imports: (IImport | ISideEffectImport)[]
+) {
+  const reactImports = imports.filter(
+    (i) =>
+      i.source === 'react' &&
+      (i.imported === 'default' ||
+        (i.imported && isHookOrCreateElement(i.imported)))
+  ) as IImport[];
+
+  if (reactImports.length === 0) return false;
+  const callee = getCallee(p);
+  if (callee.isIdentifier() && isHookOrCreateElement(callee.node.name)) {
+    const bindingPath = callee.scope.getBinding(callee.node.name)?.path;
+    return reactImports.some((i) => bindingPath?.isAncestor(i.local));
+  }
+
+  if (callee.isMemberExpression()) {
+    if (reactImports.some((i) => i.local === callee)) {
+      // It's React.createElement in CJS
+      return true;
+    }
+
+    const object = callee.get('object');
+    const property = callee.get('property');
+    const defaultImport = reactImports.find((i) => i.imported === 'default');
+    if (
+      !defaultImport ||
+      !defaultImport.local.isIdentifier() ||
+      !property.isIdentifier() ||
+      !isHookOrCreateElement(property.node.name) ||
+      !object.isIdentifier({ name: defaultImport.local.node.name })
+    ) {
+      return false;
+    }
+
+    const bindingPath = object.scope.getBinding(object.node.name)?.path;
+    return bindingPath?.isAncestor(defaultImport.local) ?? false;
+  }
+
+  return false;
+}
+
+export default function isUnnecessaryReactCall(path: NodePath<CallExpression>) {
+  const programPath = path.findParent((p) => p.isProgram());
+  if (!programPath) {
+    return false;
+  }
+
+  const { imports } = collectExportsAndImports(programPath);
+
+  return isJSXRuntime(path, imports) || isClassicReactRuntime(path, imports);
+}


### PR DESCRIPTION
## Motivation

Depending on the transpiler, `jsx-runtime` can be imported and used in many ways. Some of that ways weren't detected by Linaria, which caused excess code evaluations.

## Summary

This PR improves `jsx-runtime` detection.

## Test plan

A new set of tests was added.