### PR TITLE
fix(bable): avoid using different babel versions

### DIFF
--- a/.changeset/chatty-ants-eat.md
+++ b/.changeset/chatty-ants-eat.md
@@ -1,0 +1,7 @@
+---
+'@linaria/babel-preset': minor
+'@linaria/shaker': minor
+'@linaria/utils': minor
+---
+
+In some cases, different parts of babel-preset could use different versions of installed @babel/core. It caused the ".key is not a valid Plugin property" error. Fixed.

--- a/packages/babel/src/plugins/babel-transform.ts
+++ b/packages/babel/src/plugins/babel-transform.ts
@@ -33,6 +33,7 @@ export default function collector(
       };
 
       const prepareStageResults = prepareForEvalSync(
+        babel,
         resolveCache,
         codeCache,
         syncResolve,

--- a/packages/babel/src/transform-stages/3-prepare-for-runtime.ts
+++ b/packages/babel/src/transform-stages/3-prepare-for-runtime.ts
@@ -1,7 +1,12 @@
-import * as babel from '@babel/core';
+import type {
+  BabelFileResult,
+  PluginItem,
+  TransformOptions,
+} from '@babel/core';
 
 import { buildOptions, loadBabelOptions } from '@linaria/utils';
 
+import type { Core } from '../babel';
 import type { Options, ValueCache } from '../types';
 
 import cachedParseSync from './helpers/cachedParseSync';
@@ -12,20 +17,22 @@ import loadLinariaOptions from './helpers/loadLinariaOptions';
  * removes dead code.
  */
 export default function prepareForRuntime(
+  babel: Core,
   code: string,
   valueCache: ValueCache,
   options: Options,
-  babelConfig: babel.TransformOptions
-) {
+  babelConfig: TransformOptions
+): BabelFileResult {
   const pluginOptions = loadLinariaOptions(options.pluginOptions);
   const babelOptions = loadBabelOptions(
+    babel,
     options.filename,
     pluginOptions?.babelOptions
   );
 
-  const file = cachedParseSync(code, babelOptions);
+  const file = cachedParseSync(babel, code, babelOptions);
 
-  const transformPlugins: babel.PluginItem[] = [
+  const transformPlugins: PluginItem[] = [
     [
       require.resolve('../plugins/collector'),
       {

--- a/packages/babel/src/transform-stages/helpers/cachedParseSync.ts
+++ b/packages/babel/src/transform-stages/helpers/cachedParseSync.ts
@@ -1,5 +1,6 @@
-import * as babel from '@babel/core';
 import type { ParseResult, TransformOptions } from '@babel/core';
+
+import type { Core } from '../../babel';
 
 const cache = new WeakMap<
   Partial<TransformOptions>,
@@ -7,6 +8,7 @@ const cache = new WeakMap<
 >();
 
 export default function cachedParseSync(
+  babel: Core,
   code: string,
   babelOptions: TransformOptions
 ): ParseResult {

--- a/packages/babel/src/transform.ts
+++ b/packages/babel/src/transform.ts
@@ -8,6 +8,7 @@
  */
 
 import type { TransformOptions } from '@babel/core';
+import * as babel from '@babel/core';
 
 import type Module from './module';
 import prepareForEval, {
@@ -70,6 +71,7 @@ function syncStages(
   eventEmitter?.({ type: 'transform:stage-3:start', filename });
 
   const collectStageResult = prepareForRuntime(
+    babel,
     originalCode,
     valueCache,
     options,
@@ -132,6 +134,7 @@ export function transformSync(
   };
 
   const prepareStageResults = prepareForEvalSync(
+    babel,
     resolveCache,
     codeCache,
     syncResolve,
@@ -182,6 +185,7 @@ export default async function transform(
   });
 
   const prepareStageResults = await prepareForEval(
+    babel,
     resolveCache,
     codeCache,
     asyncResolve,

--- a/packages/shaker/src/index.ts
+++ b/packages/shaker/src/index.ts
@@ -41,8 +41,9 @@ const getShakerConfig = (only: string[] | null): TransformOptions => {
   return config;
 };
 
-const shaker: Evaluator = (filename, options, text, only = null) => {
+const shaker: Evaluator = (filename, options, text, only, babel) => {
   const transformOptions = loadBabelOptions(
+    babel,
     filename,
     buildOptions(options?.babelOptions, getShakerConfig(only))
   );

--- a/packages/utils/src/options/loadBabelOptions.ts
+++ b/packages/utils/src/options/loadBabelOptions.ts
@@ -1,5 +1,6 @@
-import * as babel from '@babel/core';
 import type { TransformOptions } from '@babel/core';
+
+import type { Core } from '../babel';
 
 const cache = new WeakMap<
   Partial<TransformOptions>,
@@ -9,6 +10,7 @@ const cache = new WeakMap<
 const empty = {};
 
 export default function loadBabelOptions(
+  babel: Core,
   filename: string,
   overrides: TransformOptions = empty
 ) {
@@ -17,7 +19,7 @@ export default function loadBabelOptions(
     return fileCache.get(filename)!;
   }
 
-  const babelOptions: babel.TransformOptions =
+  const babelOptions: TransformOptions =
     babel.loadOptions({
       ...overrides,
       filename,

--- a/packages/utils/src/options/types.ts
+++ b/packages/utils/src/options/types.ts
@@ -1,5 +1,7 @@
 import type { TransformOptions } from '@babel/core';
 
+import type { Core } from '../babel';
+
 export type ClassNameSlugVars = {
   dir: string;
   ext: string;
@@ -19,7 +21,8 @@ export type Evaluator = (
   filename: string,
   options: StrictOptions,
   text: string,
-  only: string[] | null
+  only: string[] | null,
+  babel: Core
 ) => [string, Map<string, string[]> | null];
 
 export type EvalRule = {


### PR DESCRIPTION
## Motivation

In some cases, the ".key is not a valid Plugin property" error has happened.

## Summary

The error was caused by using different babel instances (from different node_modules). To avoid that, we can explicitly pass the one babel instance through the whole call stack.
