### PR TITLE
Handle already hoisted bindings

### DIFF
--- a/.changeset/stale-bees-collect.md
+++ b/.changeset/stale-bees-collect.md
@@ -1,0 +1,7 @@
+---
+'@linaria/babel-preset': patch
+'@linaria/shaker': patch
+'@linaria/utils': patch
+---
+
+Fix function usage in string literals. Fixes #1047.

--- a/packages/babel/src/utils/collectTemplateDependencies.ts
+++ b/packages/babel/src/utils/collectTemplateDependencies.ts
@@ -139,7 +139,7 @@ function hoistIdentifier(idPath: NodePath<Identifier>): void {
     return;
   }
 
-  if (!['var', 'let', 'const'].includes(binding.kind)) {
+  if (!['var', 'let', 'const', 'hoisted'].includes(binding.kind)) {
     // This is not a variable, we can't hoist it
     throw unsupported(binding.path, 'is a function parameter');
   }


### PR DESCRIPTION
## Motivation

Fixes https://github.com/callstack/linaria/issues/1047

## Summary

This incorrectly failed with an "unsupported error" in cases where the identifier was already hoisted. 

A couple of lines down from here we return early if the `binding.scope.parent` is falsey. So I think it's safe to let this through.

## Test plan

I wasn't able to get the test suite (or bootstrap) to run with pnpm so I haven't included any tests. 

It seems like it would be fairly easy to add a snapshot test along the lines of the following to the test file [here](https://github.com/callstack/linaria/blob/master/packages/testkit/src/babel.test.ts):

```
  it('should work with already hoisted vars', async () => {
    const { code, metadata } = await transform(
      dedent`
        function color() {
          return 'red\
        }

        export const square = css\`
          color: ${'${color()}'}
      \`;
      `,
      [evaluator]
    );

    expect(code).toMatchSnapshot();
    expect(metadata).toMatchSnapshot();
  });
```

