### PR TITLE
Only lint when file can be parsed by babel (reduces noisey errors as developer types)

### DIFF
--- a/.changeset/cold-swans-unite.md
+++ b/.changeset/cold-swans-unite.md
@@ -1,0 +1,5 @@
+---
+'@linaria/postcss-linaria': patch
+---
+
+Only lint when file can be parsed by babel, reduce noisey errors during dev

--- a/packages/postcss-linaria/__tests__/parse.test.ts
+++ b/packages/postcss-linaria/__tests__/parse.test.ts
@@ -384,8 +384,7 @@ describe('parse', () => {
   });
 
   it('should return empty document if babel cannot parse file', () => {
-    const { ast } = createTestAst(`alksdjfhalksdfjhalskdfh fasd fadsfad`);
-    console.log(ast);
+    const { ast } = createTestAst(`this is not valid source code for a file`);
     expect(ast.type).toEqual('document');
     expect(ast.raws).toEqual({});
     expect(ast.nodes.length).toEqual(0);

--- a/packages/postcss-linaria/__tests__/parse.test.ts
+++ b/packages/postcss-linaria/__tests__/parse.test.ts
@@ -382,4 +382,12 @@ describe('parse', () => {
       expect(ast.source!.input.css).toEqual(source);
     });
   });
+
+  it('should return empty document if babel cannot parse file', () => {
+    const { ast } = createTestAst(`alksdjfhalksdfjhalskdfh fasd fadsfad`);
+    console.log(ast);
+    expect(ast.type).toEqual('document');
+    expect(ast.raws).toEqual({});
+    expect(ast.nodes.length).toEqual(0);
+  });
 });

--- a/packages/postcss-linaria/src/parse.ts
+++ b/packages/postcss-linaria/src/parse.ts
@@ -107,11 +107,19 @@ export const parse: Parser<Root | Document> = (
 ): Root | Document => {
   const doc = new Document();
   const sourceAsString = source.toString();
-  const ast = babelParse(sourceAsString, {
-    sourceType: 'unambiguous',
-    plugins: ['typescript', 'jsx'],
-    ranges: true,
-  });
+
+  // avoid error spam (and vscode error toasts) if babel can't parse doc
+  // allows user to type new code without constant warnings
+  let ast;
+  try {
+    ast = babelParse(sourceAsString, {
+      sourceType: 'unambiguous',
+      plugins: ['typescript', 'jsx'],
+      ranges: true,
+    });
+  } catch {
+    return doc;
+  }
   const extractedStyles = new Set<TaggedTemplateExpression>();
 
   traverse(ast, {


### PR DESCRIPTION
## Motivation

In vscode, @linaria/postcss-linaria would throw noisey errors due to babel not being able to parse the code the developer is writing as they are writing it.  

The below is a random test file being spammed with toast errors (bottom right) because babel cannot parse this file while I'm typing.
![image](https://user-images.githubusercontent.com/6117662/194964251-a49439c1-8324-4af1-affd-388bbfe73670.png)

## Summary
This adds a try/catch to essentially only lint files when the file can be parsed by babel, likely also the time the developer is done typing.

## Test plan

Added spec and tested locally