### PR TITLE
fix(shaker): avoid collision between function name and its param

### DIFF
--- a/.changeset/cuddly-laws-drum.md
+++ b/.changeset/cuddly-laws-drum.md
@@ -1,0 +1,6 @@
+---
+'@linaria/shaker': patch
+'@linaria/utils': patch
+---
+
+Fix an incorrect dead-code detection when a function has a parameter with the same name as the function itself. Fixes #1055

--- a/.changeset/poor-socks-check.md
+++ b/.changeset/poor-socks-check.md
@@ -1,0 +1,6 @@
+---
+'@linaria/shaker': patch
+'@linaria/utils': patch
+---
+
+Fix rare use case when `void`-expression causes too aggressive tree-shaking. Fixes #1055.

--- a/packages/babel/src/index.ts
+++ b/packages/babel/src/index.ts
@@ -13,6 +13,7 @@ import loadLinariaOptions from './transform-stages/helpers/loadLinariaOptions';
 
 export { slugify } from '@linaria/utils';
 
+export { default as preeval } from './plugins/preeval';
 export * from './utils/collectTemplateDependencies';
 export { default as collectTemplateDependencies } from './utils/collectTemplateDependencies';
 export { default as withLinariaMetadata } from './utils/withLinariaMetadata';

--- a/packages/shaker/src/plugins/__tests__/__snapshots__/shaker-plugin.test.ts.snap
+++ b/packages/shaker/src/plugins/__tests__/__snapshots__/shaker-plugin.test.ts.snap
@@ -20,6 +20,16 @@ exports[`shaker should process array patterns 1`] = `
 export { c };"
 `;
 
+exports[`shaker should process identifiers in void expressions as references 1`] = `
+"let _;
+
+function b(b) {
+  void _;
+}
+
+exports.b = b;"
+`;
+
 exports[`shaker should process object patterns 1`] = `
 "const {
   b: b1

--- a/packages/shaker/src/plugins/__tests__/shaker-plugin.test.ts
+++ b/packages/shaker/src/plugins/__tests__/shaker-plugin.test.ts
@@ -161,4 +161,22 @@ describe('shaker', () => {
     expect(code).toMatchSnapshot();
     expect(metadata.imports.size).toBe(0);
   });
+
+  it('should process identifiers in void expressions as references', () => {
+    const { code, metadata } = keep(['b'])`
+      let _;
+
+      const a = void _;
+
+      function b(b) {
+        void _;
+      }
+
+      exports.a = a;
+      exports.b = b;
+    `;
+
+    expect(code).toMatchSnapshot();
+    expect(metadata.imports.size).toBe(0);
+  });
 });

--- a/packages/testkit/src/__snapshots__/preeval.test.ts.snap
+++ b/packages/testkit/src/__snapshots__/preeval.test.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`preeval should keep getGlobal but remove window-related code 1`] = `
+"function getGlobal() {
+  if (typeof globalThis !== \\"undefined\\") {
+    return globalThis;
+  }
+
+  if (typeof window !== \\"undefined\\") {}
+
+  if (typeof global !== \\"undefined\\") {
+    return global;
+  }
+
+  if (typeof self !== \\"undefined\\") {
+    return self;
+  }
+
+  return mockGlobal;
+}"
+`;

--- a/packages/testkit/src/preeval.test.ts
+++ b/packages/testkit/src/preeval.test.ts
@@ -1,0 +1,62 @@
+import { join } from 'path';
+
+import { transformSync } from '@babel/core';
+import dedent from 'dedent';
+
+import { preeval } from '@linaria/babel-preset';
+
+const run = (code: TemplateStringsArray) => {
+  const filename = join(__dirname, 'source.js');
+  const formattedCode = dedent(code);
+
+  const transformed = transformSync(formattedCode, {
+    babelrc: false,
+    configFile: false,
+    filename,
+    plugins: [
+      [
+        preeval,
+        {
+          evaluate: true,
+        },
+      ],
+    ],
+  });
+
+  if (!transformed) {
+    throw new Error(`Something went wrong with ${filename}`);
+  }
+
+  return {
+    code: transformed.code,
+    // metadata: transformed.metadata.__linariaShaker,
+  };
+};
+
+describe('preeval', () => {
+  it('should keep getGlobal but remove window-related code', () => {
+    const { code } = run`
+      function getGlobal() {
+        if (typeof globalThis !== "undefined") {
+          return globalThis;
+        }
+
+        if (typeof window !== "undefined") {
+          return window;
+        }
+
+        if (typeof global !== "undefined") {
+          return global;
+        }
+
+        if (typeof self !== "undefined") {
+          return self;
+        }
+
+        return mockGlobal;
+      }
+    `;
+
+    expect(code).toMatchSnapshot();
+  });
+});

--- a/packages/utils/src/collectExportsAndImports.ts
+++ b/packages/utils/src/collectExportsAndImports.ts
@@ -27,6 +27,7 @@ import type {
 
 import { warn } from '@linaria/logger';
 
+import { getScope } from './getScope';
 import isExports from './isExports';
 import isNotNull from './isNotNull';
 import isRequire from './isRequire';
@@ -637,7 +638,7 @@ function unfoldNamespaceImport(
     return [importItem];
   }
 
-  const binding = local.scope.getBinding(local.node.name);
+  const binding = getScope(local).getBinding(local.node.name);
   if (!binding?.referenced) {
     // Imported namespace is not referenced and probably not used,
     // but it can have side effects, so we should keep it as is

--- a/packages/utils/src/findIdentifiers.ts
+++ b/packages/utils/src/findIdentifiers.ts
@@ -1,6 +1,8 @@
 import type { NodePath } from '@babel/traverse';
 import type { Node, Identifier, JSXIdentifier } from '@babel/types';
 
+import { getScope } from './getScope';
+
 type FindType = 'binding' | 'both' | 'referenced';
 
 const checkers: Record<FindType, (ex: NodePath) => boolean> = {
@@ -38,7 +40,7 @@ export default function findIdentifiers(
 
       // TODO: Is there a better way to check that it's a local variable?
 
-      const binding = path.scope.getBinding(path.node.name);
+      const binding = getScope(path).getBinding(path.node.name);
       if (!binding) {
         return;
       }

--- a/packages/utils/src/getScope.ts
+++ b/packages/utils/src/getScope.ts
@@ -1,0 +1,8 @@
+import type { NodePath } from '@babel/traverse';
+
+export function getScope(path: NodePath) {
+  // If path is a something like a function name, we should use parent scope
+  return path.key === 'id' && path.parent === path.scope.block
+    ? path.scope.parent
+    : path.scope;
+}

--- a/packages/utils/src/getScope.ts
+++ b/packages/utils/src/getScope.ts
@@ -1,7 +1,8 @@
 import type { NodePath } from '@babel/traverse';
 
 export function getScope(path: NodePath) {
-  // If path is a something like a function name, we should use parent scope
+  // In some nodes (like FunctionDeclaration) `scope` for `id` returns
+  // local function scope instead of a scope where function is declared.
   return path.key === 'id' && path.parent === path.scope.block
     ? path.scope.parent
     : path.scope;

--- a/packages/utils/src/isExports.ts
+++ b/packages/utils/src/isExports.ts
@@ -1,5 +1,7 @@
 import type { NodePath } from '@babel/traverse';
 
+import { getScope } from './getScope';
+
 /**
  * Checks that specified Identifier is a global `exports`
  * @param id
@@ -9,8 +11,9 @@ export default function isExports(id: NodePath | null | undefined) {
     return false;
   }
 
+  const scope = getScope(id);
+
   return (
-    id.scope.getBinding('exports') === undefined &&
-    id.scope.hasGlobal('exports')
+    scope.getBinding('exports') === undefined && scope.hasGlobal('exports')
   );
 }

--- a/packages/utils/src/isRequire.ts
+++ b/packages/utils/src/isRequire.ts
@@ -1,5 +1,7 @@
 import type { NodePath } from '@babel/traverse';
 
+import { getScope } from './getScope';
+
 /**
  * Checks that specified Identifier is a global `require`
  * @param id
@@ -9,8 +11,9 @@ export default function isRequire(id: NodePath | null | undefined) {
     return false;
   }
 
+  const scope = getScope(id);
+
   return (
-    id.scope.getBinding('require') === undefined &&
-    id.scope.hasGlobal('require')
+    scope.getBinding('require') === undefined && scope.hasGlobal('require')
   );
 }

--- a/packages/utils/src/isUnnecessaryReactCall.ts
+++ b/packages/utils/src/isUnnecessaryReactCall.ts
@@ -3,6 +3,7 @@ import type { CallExpression } from '@babel/types';
 
 import type { IImport, ISideEffectImport } from './collectExportsAndImports';
 import collectExportsAndImports from './collectExportsAndImports';
+import { getScope } from './getScope';
 
 function getCallee(p: NodePath<CallExpression>) {
   const callee = p.get('callee');
@@ -66,7 +67,7 @@ function isClassicReactRuntime(
   if (reactImports.length === 0) return false;
   const callee = getCallee(p);
   if (callee.isIdentifier() && isHookOrCreateElement(callee.node.name)) {
-    const bindingPath = callee.scope.getBinding(callee.node.name)?.path;
+    const bindingPath = getScope(callee).getBinding(callee.node.name)?.path;
     return reactImports.some((i) => bindingPath?.isAncestor(i.local));
   }
 
@@ -89,7 +90,7 @@ function isClassicReactRuntime(
       return false;
     }
 
-    const bindingPath = object.scope.getBinding(object.node.name)?.path;
+    const bindingPath = getScope(object).getBinding(object.node.name)?.path;
     return bindingPath?.isAncestor(defaultImport.local) ?? false;
   }
 

--- a/packages/utils/src/visitors/JSXElementsRemover.ts
+++ b/packages/utils/src/visitors/JSXElementsRemover.ts
@@ -6,6 +6,7 @@ import type {
   JSX,
 } from '@babel/types';
 
+import { getScope } from '../getScope';
 import { mutate } from '../scopeHelpers';
 
 function getFunctionName(path: NodePath<FunctionNode>): string | null {
@@ -24,7 +25,7 @@ export default function JSXElementsRemover(
 
   // We can do even more
   // If that JSX is a result of a function, we can replace the function body.
-  const functionScope = path.scope.getFunctionParent();
+  const functionScope = getScope(path).getFunctionParent();
   const scopePath = functionScope?.path;
   if (scopePath?.isFunction()) {
     const emptyBody = t.blockStatement([t.returnStatement(nullLiteral)]);


### PR DESCRIPTION
## Motivation

See #1055

## Summary

Babel resolves the wrong scope for an `id` in a `FunctionDeclaration`. If the same `FunctionDeclaration` has a parameter with the same name as the id, that parameter will be resolved as a binding of identifier used as the function name.
