### PR TITLE
fix: re-exports compiled by tsc not working

### DIFF
--- a/packages/babel/src/module.ts
+++ b/packages/babel/src/module.ts
@@ -223,11 +223,14 @@ class Module {
 
         return true;
       },
-      getOwnPropertyDescriptor() {
-        return {
-          enumerable: true,
-          configurable: true,
-        };
+      getOwnPropertyDescriptor: (target, key) => {
+        if (this.#lazyValues.has(key))
+          return {
+            enumerable: true,
+            configurable: true,
+          };
+
+        return undefined;
       },
     });
 

--- a/packages/testkit/src/__fixtures__/ts-compiled-re-exports/constants.js
+++ b/packages/testkit/src/__fixtures__/ts-compiled-re-exports/constants.js
@@ -1,0 +1,5 @@
+"use strict";
+exports.__esModule = true;
+exports.bar = exports.foo = void 0;
+exports.foo = 'foo';
+exports.bar = 'bar';

--- a/packages/testkit/src/__fixtures__/ts-compiled-re-exports/index.js
+++ b/packages/testkit/src/__fixtures__/ts-compiled-re-exports/index.js
@@ -1,0 +1,17 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+};
+exports.__esModule = true;
+__exportStar(require("./constants"), exports);

--- a/packages/testkit/src/module.test.ts
+++ b/packages/testkit/src/module.test.ts
@@ -291,3 +291,15 @@ it('correctly processes export declarations in strict mode', () => {
   expect(mod.id).toBe(filename);
   expect(mod.filename).toBe(filename);
 });
+
+it('export * compiled by typescript to commonjs works', () => {
+  const mod = createModule(getFileName(), options);
+
+  mod.evaluate(dedent`
+    const { foo } = require('./ts-compiled-re-exports');
+
+    module.exports = foo;
+  `);
+
+  expect(mod.exports).toBe('foo');
+});


### PR DESCRIPTION
## Motivation

The `getOwnPropertyDescriptor` method of the exports proxy seems to be incorrect causing `export *` compiled to commonjs by the typescript compiler to not work.

Typescript will compile `export *` to the following:
```
var __exportStar = (this && this.__exportStar) || function(m, exports) {
    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
};
```
Because `getOwnPropertyDescriptor` always return an object the `hasOwnProperty` call will always return `true` causing no exports to get added.

Here is a cut down example of this causing issues when using linaria together with @fluentui/react https://stackblitz.com/edit/linaria-bug-nl1c3w

## Summary

The only change made in this PR is to only return a property descriptor when the export exist.

## Test plan

I added a test that tests verifies that `export *` compiled to commonjs by tsc works. The test fails without my change but works with it.
