### PR TITLE
fix(babel): don't run async prepareForEval if target file is processing (fixes #1054)

### DIFF
--- a/.changeset/tasty-falcons-crash.md
+++ b/.changeset/tasty-falcons-crash.md
@@ -1,0 +1,5 @@
+---
+'@linaria/babel-preset': patch
+---
+
+Fix an issue with async resolvers that sometimes leads to attempts to evaluate unprepared code. Fixes #1054.


### PR DESCRIPTION
## Motivation

Sometimes Linaria tried to evaluate a module before it was transformed. (#1054)

## Summary

The problem was in the 1st stage of evaluation, which can be called more than once for one file in parallel. Fixed by adding a simple "mutex" that prevents execution till the previous one is finished.
