### PR TITLE
fix(shaker): get rid of "expected node to be of a type" errors

### DIFF
--- a/.changeset/forty-crabs-itch.md
+++ b/.changeset/forty-crabs-itch.md
@@ -1,0 +1,8 @@
+---
+'@linaria/babel-preset': patch
+'@linaria/testkit': patch
+'@linaria/utils': patch
+'@linaria/shaker': patch
+---
+
+Get rid of "expected node to be of a type" errors

--- a/packages/babel/src/plugins/preeval.ts
+++ b/packages/babel/src/plugins/preeval.ts
@@ -8,9 +8,10 @@ import type { Identifier } from '@babel/types';
 import { createCustomDebug } from '@linaria/logger';
 import type { StrictOptions } from '@linaria/utils';
 import {
+  JSXElementsRemover,
   getFileIdx,
   isUnnecessaryReactCall,
-  JSXElementsRemover,
+  nonType,
   removeWithRelated,
 } from '@linaria/utils';
 
@@ -24,6 +25,10 @@ export type PreevalOptions = Pick<
 >;
 
 const isGlobal = (id: NodePath<Identifier>): boolean => {
+  if (!nonType(id)) {
+    return false;
+  }
+
   const { scope } = id;
   const { name } = id.node;
   return !scope.hasBinding(name) && scope.hasGlobal(name);
@@ -141,6 +146,8 @@ export default function preeval(
               }
 
               removeWithRelated([p]);
+
+              return;
             }
 
             if (state.windowScoped.has(p.node.name)) {

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -17,6 +17,8 @@
     "typescript": "^4.7.4"
   },
   "devDependencies": {
+    "@babel/plugin-syntax-jsx": "^7.18.6",
+    "@babel/plugin-syntax-typescript": "^7.18.6",
     "@babel/plugin-transform-modules-commonjs": "^7.18.2",
     "@babel/runtime": "^7.18.3",
     "@babel/types": "^7.18.9",

--- a/packages/testkit/src/__snapshots__/preeval.test.ts.snap
+++ b/packages/testkit/src/__snapshots__/preeval.test.ts.snap
@@ -6,8 +6,6 @@ exports[`preeval should keep getGlobal but remove window-related code 1`] = `
     return globalThis;
   }
 
-  if (typeof window !== \\"undefined\\") {}
-
   if (typeof global !== \\"undefined\\") {
     return global;
   }
@@ -17,6 +15,12 @@ exports[`preeval should keep getGlobal but remove window-related code 1`] = `
   }
 
   return mockGlobal;
+}"
+`;
+
+exports[`preeval should not remove "location" in types only because it looks like a global variable 1`] = `
+"interface IProps {
+  fn: (location: string) => void;
 }"
 `;
 

--- a/packages/testkit/src/preeval.test.ts
+++ b/packages/testkit/src/preeval.test.ts
@@ -6,7 +6,7 @@ import dedent from 'dedent';
 import { preeval } from '@linaria/babel-preset';
 
 const run = (code: TemplateStringsArray) => {
-  const filename = join(__dirname, 'source.js');
+  const filename = join(__dirname, 'source.ts');
   const formattedCode = dedent(code);
 
   const transformed = transformSync(formattedCode, {
@@ -14,6 +14,7 @@ const run = (code: TemplateStringsArray) => {
     configFile: false,
     filename,
     plugins: [
+      '@babel/plugin-syntax-typescript',
       [
         preeval,
         {
@@ -68,6 +69,16 @@ describe('preeval', () => {
       }
 
       $RefreshReg$("Header");
+    `;
+
+    expect(code).toMatchSnapshot();
+  });
+
+  it('should not remove "location" in types only because it looks like a global variable', () => {
+    const { code } = run`
+      interface IProps {
+        fn: (location: string) => void;
+      }
     `;
 
     expect(code).toMatchSnapshot();

--- a/packages/testkit/src/utils/__snapshots__/removeWithRelated.test.ts.snap
+++ b/packages/testkit/src/utils/__snapshots__/removeWithRelated.test.ts.snap
@@ -15,6 +15,8 @@ exports[`removeWithRelated should remove export 1`] = `
 export { b };"
 `;
 
+exports[`removeWithRelated should remove node if it becomes invalid after removing its children 1`] = `""`;
+
 exports[`removeWithRelated should remove try/catch block 1`] = `"const a = 1;"`;
 
 exports[`removeWithRelated should shake try/catch 1`] = `""`;

--- a/packages/testkit/src/utils/removeWithRelated.test.ts
+++ b/packages/testkit/src/utils/removeWithRelated.test.ts
@@ -118,4 +118,14 @@ describe('removeWithRelated', () => {
 
     expect(code).toMatchSnapshot();
   });
+
+  it('should remove node if it becomes invalid after removing its children', () => {
+    const code = run`
+      /* remove */const mode = "DEV";
+
+      export { mode };
+    `;
+
+    expect(code).toMatchSnapshot();
+  });
 });

--- a/packages/utils/src/findIdentifiers.ts
+++ b/packages/utils/src/findIdentifiers.ts
@@ -32,7 +32,8 @@ export function nonType(path: NodePath): boolean {
       p.isTSTypeReference() ||
       p.isTSTypeQuery() ||
       p.isFlowType() ||
-      p.isFlowDeclaration()
+      p.isFlowDeclaration() ||
+      p.isTSInterfaceDeclaration()
   );
 }
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -5,7 +5,7 @@ export {
 } from './asyncResolveFallback';
 export { default as collectExportsAndImports } from './collectExportsAndImports';
 export * from './collectExportsAndImports';
-export { default as findIdentifiers } from './findIdentifiers';
+export { default as findIdentifiers, nonType } from './findIdentifiers';
 export { default as getFileIdx } from './getFileIdx';
 export { default as isExports } from './isExports';
 export { default as isNotNull } from './isNotNull';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -568,6 +568,8 @@ importers:
     specifiers:
       '@babel/core': ^7.18.9
       '@babel/generator': ^7.18.9
+      '@babel/plugin-syntax-jsx': ^7.18.6
+      '@babel/plugin-syntax-typescript': ^7.18.6
       '@babel/plugin-transform-modules-commonjs': ^7.18.2
       '@babel/runtime': ^7.18.3
       '@babel/traverse': ^7.18.9
@@ -609,6 +611,8 @@ importers:
       strip-ansi: 5.2.0
       typescript: 4.7.4
     devDependencies:
+      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.18.9
+      '@babel/plugin-syntax-typescript': 7.18.6_@babel+core@7.18.9
       '@babel/plugin-transform-modules-commonjs': 7.18.2_@babel+core@7.18.9
       '@babel/runtime': 7.18.3
       '@babel/types': 7.18.9
@@ -1044,7 +1048,7 @@ packages:
       '@babel/core': 7.18.9
       '@babel/helper-compilation-targets': 7.18.2_@babel+core@7.18.9
       '@babel/helper-module-imports': 7.16.7
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/traverse': 7.18.2
       debug: 4.3.4
       lodash.debounce: 4.0.8
@@ -1212,7 +1216,6 @@ packages:
   /@babel/helper-plugin-utils/7.19.0:
     resolution: {integrity: sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-remap-async-to-generator/7.16.8:
     resolution: {integrity: sha512-fm0gH7Flb8H51LqJHy3HJ3wnE1+qtYR2A99K06ahwrawLdOFsCEWjZOrYricXJHoPSudNKxrMBUPEIPxiIIvBw==}
@@ -1386,7 +1389,7 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.17.12_@babel+core@7.18.9:
     resolution: {integrity: sha512-/vt0hpIw0x4b6BLKUkwlvEoiGZYYLNZ96CzyHYPbtG2jZGz6LBe7/V+drYrc/d+ovrF9NBi0pmtvmNb/FsWtRQ==}
@@ -1395,7 +1398,7 @@ packages:
       '@babel/core': ^7.13.0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-skip-transparent-expression-wrappers': 7.16.0
       '@babel/plugin-proposal-optional-chaining': 7.17.12_@babel+core@7.18.9
 
@@ -1406,7 +1409,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-remap-async-to-generator': 7.16.8
       '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.18.9
     transitivePeerDependencies:
@@ -1432,7 +1435,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.9
       '@babel/helper-create-class-features-plugin': 7.18.0_@babel+core@7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.18.9
     transitivePeerDependencies:
       - supports-color
@@ -1444,7 +1447,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.18.9
 
   /@babel/plugin-proposal-export-namespace-from/7.17.12_@babel+core@7.18.9:
@@ -1464,7 +1467,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.18.9
 
   /@babel/plugin-proposal-logical-assignment-operators/7.17.12_@babel+core@7.18.9:
@@ -1474,7 +1477,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.18.9
 
   /@babel/plugin-proposal-nullish-coalescing-operator/7.17.12_@babel+core@7.18.9:
@@ -1484,7 +1487,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.18.9
 
   /@babel/plugin-proposal-numeric-separator/7.16.7_@babel+core@7.18.9:
@@ -1494,7 +1497,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.18.9
 
   /@babel/plugin-proposal-object-rest-spread/7.18.0_@babel+core@7.18.9:
@@ -1506,7 +1509,7 @@ packages:
       '@babel/compat-data': 7.17.10
       '@babel/core': 7.18.9
       '@babel/helper-compilation-targets': 7.18.2_@babel+core@7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.18.9
       '@babel/plugin-transform-parameters': 7.17.12_@babel+core@7.18.9
 
@@ -1517,7 +1520,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.18.9
 
   /@babel/plugin-proposal-optional-chaining/7.17.12_@babel+core@7.18.9:
@@ -1527,7 +1530,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-skip-transparent-expression-wrappers': 7.16.0
       '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.18.9
 
@@ -1539,7 +1542,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.9
       '@babel/helper-create-class-features-plugin': 7.18.0_@babel+core@7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
     transitivePeerDependencies:
       - supports-color
 
@@ -1552,7 +1555,7 @@ packages:
       '@babel/core': 7.18.9
       '@babel/helper-annotate-as-pure': 7.16.7
       '@babel/helper-create-class-features-plugin': 7.18.0_@babel+core@7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.18.9
     transitivePeerDependencies:
       - supports-color
@@ -1565,7 +1568,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.9
       '@babel/helper-create-regexp-features-plugin': 7.17.12_@babel+core@7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.18.9:
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
@@ -1573,7 +1576,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.18.9:
     resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
@@ -1581,7 +1584,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
   /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.18.9:
@@ -1590,7 +1593,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-syntax-class-static-block/7.14.5_@babel+core@7.18.9:
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
@@ -1599,7 +1602,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.18.9:
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
@@ -1615,7 +1618,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-syntax-import-assertions/7.17.12_@babel+core@7.18.9:
     resolution: {integrity: sha512-n/loy2zkq9ZEM8tEOwON9wTQSTNDTDEz6NujPtJGLU7qObzT1N4c4YZZf8E6ATB2AjNQg/Ib2AIpO03EZaCehw==}
@@ -1624,7 +1627,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.18.9:
     resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
@@ -1632,7 +1635,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.18.9:
@@ -1641,7 +1644,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-syntax-jsx/7.17.12_@babel+core@7.18.9:
     resolution: {integrity: sha512-spyY3E3AURfxh/RHtjx5j6hs8am5NbUBGfcZ2vB3uShSpZdQyXSf5rR5Mk76vbtlAZOelyVQ71Fg0x9SG4fsog==}
@@ -1660,7 +1663,17 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.6
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/helper-plugin-utils': 7.19.0
+    dev: true
+
+  /@babel/plugin-syntax-jsx/7.18.6_@babel+core@7.18.9:
+    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.18.9
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
   /@babel/plugin-syntax-jsx/7.18.6_@babel+core@7.19.3:
@@ -1670,7 +1683,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.3
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
   /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.18.9:
@@ -1679,7 +1692,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.18.9:
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
@@ -1687,7 +1700,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.18.9:
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
@@ -1695,7 +1708,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.18.9:
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
@@ -1703,7 +1716,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.18.9:
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
@@ -1711,7 +1724,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.18.9:
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
@@ -1719,7 +1732,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-syntax-private-property-in-object/7.14.5_@babel+core@7.18.9:
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
@@ -1728,7 +1741,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.18.9:
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
@@ -1737,16 +1750,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
-  /@babel/plugin-syntax-typescript/7.17.12_@babel+core@7.18.9:
-    resolution: {integrity: sha512-TYY0SXFiO31YXtNg3HtFwNJHjLsAyIIhAhNWkQ5whPPS7HWUFlg9z0Ta4qAQNjQbP1wsSt/oKkmZ/4/WWdMUpw==}
+  /@babel/plugin-syntax-typescript/7.18.6_@babel+core@7.18.9:
+    resolution: {integrity: sha512-mAWAuq4rvOepWCBid55JuRNvpTNf2UGVgoz4JV0fXEKolsVZDzsa4NqCef758WZJj/GDu0gVGItjKFiClTAmZA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
   /@babel/plugin-transform-arrow-functions/7.17.12_@babel+core@7.18.9:
@@ -1756,7 +1769,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-transform-async-to-generator/7.17.12_@babel+core@7.18.9:
     resolution: {integrity: sha512-J8dbrWIOO3orDzir57NRsjg4uxucvhby0L/KZuGsWDj0g7twWK3g7JhJhOrXtuXiw8MeiSdJ3E0OW9H8LYEzLQ==}
@@ -1766,7 +1779,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.9
       '@babel/helper-module-imports': 7.16.7
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-remap-async-to-generator': 7.16.8
     transitivePeerDependencies:
       - supports-color
@@ -1778,7 +1791,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-transform-block-scoping/7.18.4_@babel+core@7.18.9:
     resolution: {integrity: sha512-+Hq10ye+jlvLEogSOtq4mKvtk7qwcUQ1f0Mrueai866C82f844Yom2cttfJdMdqRLTxWpsbfbkIkOIfovyUQXw==}
@@ -1787,7 +1800,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-transform-classes/7.18.4_@babel+core@7.18.9:
     resolution: {integrity: sha512-e42NSG2mlKWgxKUAD9EJJSkZxR67+wZqzNxLSpc51T8tRU5SLFHsPmgYR5yr7sdgX4u+iHA1C5VafJ6AyImV3A==}
@@ -1800,7 +1813,7 @@ packages:
       '@babel/helper-environment-visitor': 7.18.2
       '@babel/helper-function-name': 7.17.9
       '@babel/helper-optimise-call-expression': 7.16.7
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-replace-supers': 7.18.2
       '@babel/helper-split-export-declaration': 7.16.7
       globals: 11.12.0
@@ -1814,7 +1827,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-transform-destructuring/7.18.0_@babel+core@7.18.9:
     resolution: {integrity: sha512-Mo69klS79z6KEfrLg/1WkmVnB8javh75HX4pi2btjvlIoasuxilEyjtsQW6XPrubNd7AQy0MMaNIaQE4e7+PQw==}
@@ -1823,7 +1836,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-transform-dotall-regex/7.16.7_@babel+core@7.18.9:
     resolution: {integrity: sha512-Lyttaao2SjZF6Pf4vk1dVKv8YypMpomAbygW+mU5cYP3S5cWTfCJjG8xV6CFdzGFlfWK81IjL9viiTvpb6G7gQ==}
@@ -1833,7 +1846,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.9
       '@babel/helper-create-regexp-features-plugin': 7.17.12_@babel+core@7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-transform-duplicate-keys/7.17.12_@babel+core@7.18.9:
     resolution: {integrity: sha512-EA5eYFUG6xeerdabina/xIoB95jJ17mAkR8ivx6ZSu9frKShBjpOGZPn511MTDTkiCO+zXnzNczvUM69YSf3Zw==}
@@ -1842,7 +1855,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-transform-exponentiation-operator/7.16.7_@babel+core@7.18.9:
     resolution: {integrity: sha512-8UYLSlyLgRixQvlYH3J2ekXFHDFLQutdy7FfFAMm3CPZ6q9wHCwnUyiXpQCe3gVVnQlHc5nsuiEVziteRNTXEA==}
@@ -1852,7 +1865,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.9
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.16.7
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-transform-for-of/7.18.1_@babel+core@7.18.9:
     resolution: {integrity: sha512-+TTB5XwvJ5hZbO8xvl2H4XaMDOAK57zF4miuC9qQJgysPNEAZZ9Z69rdF5LJkozGdZrjBIUAIyKUWRMmebI7vg==}
@@ -1861,7 +1874,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-transform-function-name/7.16.7_@babel+core@7.18.9:
     resolution: {integrity: sha512-SU/C68YVwTRxqWj5kgsbKINakGag0KTgq9f2iZEXdStoAbOzLHEBRYzImmA6yFo8YZhJVflvXmIHUO7GWHmxxA==}
@@ -1872,7 +1885,7 @@ packages:
       '@babel/core': 7.18.9
       '@babel/helper-compilation-targets': 7.18.2_@babel+core@7.18.9
       '@babel/helper-function-name': 7.17.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-transform-literals/7.17.12_@babel+core@7.18.9:
     resolution: {integrity: sha512-8iRkvaTjJciWycPIZ9k9duu663FT7VrBdNqNgxnVXEFwOIp55JWcZd23VBRySYbnS3PwQ3rGiabJBBBGj5APmQ==}
@@ -1881,7 +1894,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-transform-member-expression-literals/7.16.7_@babel+core@7.18.9:
     resolution: {integrity: sha512-mBruRMbktKQwbxaJof32LT9KLy2f3gH+27a5XSuXo6h7R3vqltl0PgZ80C8ZMKw98Bf8bqt6BEVi3svOh2PzMw==}
@@ -1890,7 +1903,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-transform-modules-amd/7.18.0_@babel+core@7.18.9:
     resolution: {integrity: sha512-h8FjOlYmdZwl7Xm2Ug4iX2j7Qy63NANI+NQVWQzv6r25fqgg7k2dZl03p95kvqNclglHs4FZ+isv4p1uXMA+QA==}
@@ -1900,7 +1913,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.9
       '@babel/helper-module-transforms': 7.18.0
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
       babel-plugin-dynamic-import-node: 2.3.3
     transitivePeerDependencies:
       - supports-color
@@ -1928,7 +1941,7 @@ packages:
       '@babel/core': 7.18.9
       '@babel/helper-hoist-variables': 7.16.7
       '@babel/helper-module-transforms': 7.18.0
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-validator-identifier': 7.16.7
       babel-plugin-dynamic-import-node: 2.3.3
     transitivePeerDependencies:
@@ -1942,7 +1955,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.9
       '@babel/helper-module-transforms': 7.18.0
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
     transitivePeerDependencies:
       - supports-color
 
@@ -1954,7 +1967,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.9
       '@babel/helper-create-regexp-features-plugin': 7.17.12_@babel+core@7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-transform-new-target/7.17.12_@babel+core@7.18.9:
     resolution: {integrity: sha512-CaOtzk2fDYisbjAD4Sd1MTKGVIpRtx9bWLyj24Y/k6p4s4gQ3CqDGJauFJxt8M/LEx003d0i3klVqnN73qvK3w==}
@@ -1963,7 +1976,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-transform-object-super/7.16.7_@babel+core@7.18.9:
     resolution: {integrity: sha512-14J1feiQVWaGvRxj2WjyMuXS2jsBkgB3MdSN5HuC2G5nRspa5RK9COcs82Pwy5BuGcjb+fYaUj94mYcOj7rCvw==}
@@ -1972,7 +1985,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-replace-supers': 7.18.2
     transitivePeerDependencies:
       - supports-color
@@ -1984,7 +1997,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-transform-property-literals/7.16.7_@babel+core@7.18.9:
     resolution: {integrity: sha512-z4FGr9NMGdoIl1RqavCqGG+ZuYjfZ/hkCIeuH6Do7tXmSm0ls11nYVSJqFEUOSJbDab5wC6lRE/w6YjVcr6Hqw==}
@@ -1993,7 +2006,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-transform-react-display-name/7.16.7_@babel+core@7.18.9:
     resolution: {integrity: sha512-qgIg8BcZgd0G/Cz916D5+9kqX0c7nPZyXaP8R2tLNN5tkyIZdG5fEwBrxwplzSnjC1jvQmyMNVwUCZPcbGY7Pg==}
@@ -2002,7 +2015,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
   /@babel/plugin-transform-react-display-name/7.18.6_@babel+core@7.18.6:
@@ -2012,7 +2025,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.6
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
   /@babel/plugin-transform-react-jsx-development/7.16.7_@babel+core@7.18.9:
@@ -2052,7 +2065,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.3
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
   /@babel/plugin-transform-react-jsx-source/7.18.6_@babel+core@7.19.3:
@@ -2062,7 +2075,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.3
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
   /@babel/plugin-transform-react-jsx/7.17.12_@babel+core@7.18.9:
@@ -2074,8 +2087,8 @@ packages:
       '@babel/core': 7.18.9
       '@babel/helper-annotate-as-pure': 7.16.7
       '@babel/helper-module-imports': 7.16.7
-      '@babel/helper-plugin-utils': 7.17.12
-      '@babel/plugin-syntax-jsx': 7.17.12_@babel+core@7.18.9
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.18.9
       '@babel/types': 7.18.4
     dev: true
 
@@ -2088,7 +2101,7 @@ packages:
       '@babel/core': 7.18.6
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.18.6
       '@babel/types': 7.19.4
     dev: true
@@ -2102,7 +2115,7 @@ packages:
       '@babel/core': 7.19.3
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.19.3
       '@babel/types': 7.19.4
     dev: true
@@ -2129,7 +2142,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.9
       '@babel/helper-annotate-as-pure': 7.16.7
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
   /@babel/plugin-transform-react-pure-annotations/7.18.6_@babel+core@7.18.6:
@@ -2140,7 +2153,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.6
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
   /@babel/plugin-transform-regenerator/7.18.0_@babel+core@7.18.9:
@@ -2150,7 +2163,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
       regenerator-transform: 0.15.0
 
   /@babel/plugin-transform-reserved-words/7.17.12_@babel+core@7.18.9:
@@ -2160,7 +2173,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-transform-runtime/7.18.2_@babel+core@7.18.9:
     resolution: {integrity: sha512-mr1ufuRMfS52ttq+1G1PD8OJNqgcTFjq3hwn8SZ5n1x1pBhi0E36rYMdTK0TsKtApJ4lDEdfXJwtGobQMHSMPg==}
@@ -2186,7 +2199,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-transform-spread/7.17.12_@babel+core@7.18.9:
     resolution: {integrity: sha512-9pgmuQAtFi3lpNUstvG9nGfk9DkrdmWNp9KeKPFmuZCpEnxRzYlS8JgwPjYj+1AWDOSvoGN0H30p1cBOmT/Svg==}
@@ -2195,7 +2208,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-skip-transparent-expression-wrappers': 7.16.0
 
   /@babel/plugin-transform-sticky-regex/7.16.7_@babel+core@7.18.9:
@@ -2205,7 +2218,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-transform-template-literals/7.18.2_@babel+core@7.18.9:
     resolution: {integrity: sha512-/cmuBVw9sZBGZVOMkpAEaVLwm4JmK2GZ1dFKOGGpMzEHWFmyZZ59lUU0PdRr8YNYeQdNzTDwuxP2X2gzydTc9g==}
@@ -2223,7 +2236,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-transform-typescript/7.18.4_@babel+core@7.18.9:
     resolution: {integrity: sha512-l4vHuSLUajptpHNEOUDEGsnpl9pfRLsN1XUoDQDD/YBuXTM+v37SHGS+c6n4jdcZy96QtuUuSvZYMLSSsjH8Mw==}
@@ -2233,8 +2246,8 @@ packages:
     dependencies:
       '@babel/core': 7.18.9
       '@babel/helper-create-class-features-plugin': 7.18.0_@babel+core@7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
-      '@babel/plugin-syntax-typescript': 7.17.12_@babel+core@7.18.9
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/plugin-syntax-typescript': 7.18.6_@babel+core@7.18.9
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2246,7 +2259,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-transform-unicode-regex/7.16.7_@babel+core@7.18.9:
     resolution: {integrity: sha512-oC5tYYKw56HO75KZVLQ+R/Nl3Hro9kf8iG0hXoaHP7tjAyCpvqBiSNe6vGrZni1Z6MggmUOC6A7VP7AVmw225Q==}
@@ -2256,7 +2269,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.9
       '@babel/helper-create-regexp-features-plugin': 7.17.12_@babel+core@7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/preset-env/7.18.2_@babel+core@7.18.9:
     resolution: {integrity: sha512-PfpdxotV6afmXMU47S08F9ZKIm2bJIQ0YbAAtDfIENX7G1NUAXigLREh69CWDjtgUy7dYn7bsMzkgdtAlmS68Q==}
@@ -2349,7 +2362,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/plugin-proposal-unicode-property-regex': 7.17.12_@babel+core@7.18.9
       '@babel/plugin-transform-dotall-regex': 7.16.7_@babel+core@7.18.9
       '@babel/types': 7.18.4
@@ -8648,7 +8661,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.9
       '@babel/generator': 7.19.5
-      '@babel/plugin-syntax-typescript': 7.17.12_@babel+core@7.18.9
+      '@babel/plugin-syntax-typescript': 7.18.6_@babel+core@7.18.9
       '@babel/traverse': 7.18.2
       '@babel/types': 7.19.4
       '@jest/expect-utils': 28.1.0


### PR DESCRIPTION
## Motivation

Sometimes Linaria tries to remove a node from AST that is crucial for another node. Such cases produce errors like `Property name of JSXOpeningElement expected node to be of a type ["JSXIdentifier","JSXMemberExpression","JSXNamespacedName"] but instead got undefined`.

## Summary

This PR introduces a common validator for all removing nodes that prevents such errors.

## Test plan

New tests were added.
