### PR TITLE
feat(solid): initial draft implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ esm/
 types/
 dist/
 build/
-tsconfig.tsbuildinfo
+*.tsbuildinfo
 
 .linaria-cache
+
+# IntelliJ IDEA
+.idea

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Zero-runtime CSS in JS library.
 - Use **JavaScript for logic**, no CSS preprocessor needed
 - Optionally use any **CSS preprocessor** such as Sass or PostCSS
 - Supports **atomic styles** with `@linaria/atomic`
+- Supports [solidjs](https://solidjs.com/) with `@linaria/sollid`
 
 **[Why use Linaria](/docs/BENEFITS.md)**
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -76,12 +76,5 @@ module.exports = {
         },
       },
     },
-    {
-      /**
-       * we have to transpile JSX in tests
-       */
-      test: /\/(__tests__|__fixtures__|packages\/teskit\/src)\//,
-      presets: ['@babel/preset-react'],
-    },
   ],
 };

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -1,0 +1,46 @@
+<p align="center">
+  <img alt="Linaria" src="https://raw.githubusercontent.com/callstack/linaria/HEAD/website/assets/linaria-logo@2x.png" width="496">
+</p>
+
+<p align="center">
+Zero-runtime CSS in JS library.
+</p>
+
+---
+
+# @linaria/solid
+
+### 📖 Please refer to the [GitHub](https://github.com/callstack/linaria#readme) for full documentation.
+
+**[Why use Linaria](../../docs/BENEFITS.md)**
+
+## Features
+
+- supports a subset of `styled-components` syntax (`styled.div`, `styled(Component)`, property interpolations)
+
+## Limitations
+
+- does not support theming through arguments to property interpolations (yet)
+
+## Installation
+
+```sh
+npm install @linaria/babel-preset @linaria/solid babel-preset-solid
+```
+
+or
+
+```sh
+yarn install @linaria/babel-preset @linaria/solid babel-preset-solid
+```
+
+## Configuration
+
+For the time of this writing, `@linaria/solid` supports configuration only via babel configuration.
+Just add `solid` to the `"presets"` section in your `babel.config.js` _after_ `"@linaria"`:
+
+```json
+{
+  "presets": ["@linaria", "solid"]
+}
+```

--- a/packages/solid/__tests__/processors/components.linaria.tsx
+++ b/packages/solid/__tests__/processors/components.linaria.tsx
@@ -1,0 +1,9 @@
+import { styled } from '../../src';
+
+interface TagProps {
+  readonly background?: string;
+}
+export const Tag = styled.div<TagProps>`
+  color: red;
+  background: ${(props) => props.background};
+`;

--- a/packages/solid/__tests__/processors/foo.ts
+++ b/packages/solid/__tests__/processors/foo.ts
@@ -1,0 +1,1 @@
+export const FOO = 123;

--- a/packages/solid/__tests__/processors/foo.ts
+++ b/packages/solid/__tests__/processors/foo.ts
@@ -1,1 +1,0 @@
-export const FOO = 123;

--- a/packages/solid/__tests__/processors/polyfill.ts
+++ b/packages/solid/__tests__/processors/polyfill.ts
@@ -1,0 +1,6 @@
+import { TextEncoder, TextDecoder } from 'util';
+
+Object.assign(global, {
+  TextEncoder,
+  TextDecoder,
+});

--- a/packages/solid/__tests__/processors/styled.test.tsx
+++ b/packages/solid/__tests__/processors/styled.test.tsx
@@ -1,42 +1,71 @@
-// import * as babel from '@babel/core';
-// import {} from '@linaria/babel-preset';
-// import dedent from 'dedent';
+import './polyfill';
 
-import { styled } from '../../src';
-// import { styled } from '@linaria/react';
+import * as babel from '@babel/core';
+import { JSDOM } from 'jsdom';
+import type { JSX } from 'solid-js';
 
-// function transform(source: string): string {
-//   const result = babel.transform(source, {
-//     babelrc: false,
-//     configFile: false,
-//     filename: 'test.tsx',
-//     presets: ['@linaria/babel-preset'],
-//   });
-//   if (!result || !result.code)
-//     throw new Error('Babel cannot parse source code');
-//   return dedent(result.code.trim());
-// }
+import * as linaria from '@linaria/babel-preset';
 
-// describe('styled processor', () => {
-//   it('renders tag', () => {
-//     // const result = transform(`
-//     //   import { styled } from '@linaria/solid'
-//     //   export const Component = styled.div\`\`
-//     // `);
-//     // expect(result).toEqual(
-//     //   dedent(`
-//     //   export const Component = props => {
-//     //     const className = "cg10ziu" + (props.class ? " " + props.class : "");
-//     //     const style = props.style;
-//     //     return <div {...props} class={className} style={style} />;
-//     //   };
-//     // `)
-//     // );
-//     // const Component = styled.div`
-//     //   color: blue;
-//     // `;
-//     // console.log(Component);
-//     console.log(styled.div``);
-//   });
-// });
-console.log(styled.div``);
+import { Tag } from './components.linaria';
+
+function transform(source: string): string {
+  const result = babel.transform(source, {
+    filename: 'test.tsx',
+    presets: ['@linaria'],
+  });
+  if (!result || !result.code)
+    throw new Error('Cannot transform source with babel');
+  return result.code;
+}
+
+function toHTMLElement(element: JSX.Element): HTMLElement {
+  if (element instanceof HTMLElement) {
+    return element;
+  }
+  throw new Error('Element is not an HTMLElement');
+}
+
+describe('styled processor', () => {
+  describe('simple tag', () => {
+    it('renders tag with class', () => {
+      const result = toHTMLElement(<Tag>hi</Tag>);
+      expect(result.classList.length).toBe(1);
+    });
+    it('renders children', () => {
+      const result = toHTMLElement(<Tag>hi</Tag>);
+      expect(result.textContent).toEqual('hi');
+    });
+    it('sets attributes', () => {
+      const result = toHTMLElement(<Tag data-foo={'foo'} />);
+      expect(result.dataset.foo).toEqual('foo');
+    });
+    it('sets class', () => {
+      const result = toHTMLElement(<Tag class={'foo'} />);
+      expect(result.classList).toContain('foo');
+    });
+    it('sets style', () => {
+      const result = toHTMLElement(<Tag style={{ color: 'blue' }} />);
+      expect(result.style.color).toEqual('blue');
+    });
+    // it('jsdom with classes', () => {
+    //   const style = document.createElement('style');
+    //   style.textContent = `
+    //     .foo { color: blue; }
+    //   `;
+    //   document.head.append(style);
+    //   const div = document.createElement('div');
+    //   div.textContent = 'div';
+    //   div.classList.add('foo');
+    //   document.body.append(div);
+    //   expect(window.getComputedStyle(div).color).toBe('blue');
+    //   style.remove();
+    //   div.remove();
+    //   console.log('1', document.body.firstChild);
+    // });
+    // it('2', () => {
+    //   console.log('2', document.body.firstChild);
+    //   const span = document.createElement('span');
+    //   document.body.append(span);
+    // });
+  });
+});

--- a/packages/solid/__tests__/processors/styled.test.tsx
+++ b/packages/solid/__tests__/processors/styled.test.tsx
@@ -27,45 +27,115 @@ function toHTMLElement(element: JSX.Element): HTMLElement {
 
 describe('styled processor', () => {
   describe('simple tag', () => {
-    it('renders tag with class', () => {
-      const result = toHTMLElement(<Tag>hi</Tag>);
-      expect(result.classList.length).toBe(1);
-    });
-    it('renders children', () => {
-      const result = toHTMLElement(<Tag>hi</Tag>);
-      expect(result.textContent).toEqual('hi');
-    });
-    it('sets attributes', () => {
-      const result = toHTMLElement(<Tag data-foo={'foo'} />);
-      expect(result.dataset.foo).toEqual('foo');
-    });
-    it('sets class', () => {
-      const result = toHTMLElement(<Tag class={'foo'} />);
-      expect(result.classList).toContain('foo');
-    });
-    it('sets style', () => {
-      const result = toHTMLElement(<Tag style={{ color: 'blue' }} />);
-      expect(result.style.color).toEqual('blue');
-    });
-    // it('jsdom with classes', () => {
-    //   const style = document.createElement('style');
-    //   style.textContent = `
-    //     .foo { color: blue; }
-    //   `;
-    //   document.head.append(style);
-    //   const div = document.createElement('div');
-    //   div.textContent = 'div';
-    //   div.classList.add('foo');
-    //   document.body.append(div);
-    //   expect(window.getComputedStyle(div).color).toBe('blue');
-    //   style.remove();
-    //   div.remove();
-    //   console.log('1', document.body.firstChild);
+    // it('renders tag with class', () => {
+    //   const result = toHTMLElement(<Tag>hi</Tag>);
+    //   expect(result.classList.length).toBe(1);
     // });
-    // it('2', () => {
-    //   console.log('2', document.body.firstChild);
-    //   const span = document.createElement('span');
-    //   document.body.append(span);
+    // it('renders children', () => {
+    //   const result = toHTMLElement(<Tag>hi</Tag>);
+    //   expect(result.textContent).toEqual('hi');
     // });
+    // it('sets attributes', () => {
+    //   const result = toHTMLElement(<Tag data-foo={'foo'} />);
+    //   expect(result.dataset.foo).toEqual('foo');
+    // });
+    // it('sets class', () => {
+    //   const result = toHTMLElement(<Tag class={'foo'} />);
+    //   expect(result.classList).toContain('foo');
+    // });
+    // it('sets style', () => {
+    //   const result = toHTMLElement(<Tag style={{ color: 'blue' }} />);
+    //   expect(result.style.color).toEqual('blue');
+    // });
+    // it('interpolates props', async () => {
+    //   // const result = toHTMLElement(<Tag background={'red'} />);
+    //   // console.log(Tag.toString());
+    //   // // expect(result.style.background).toEqual('red');
+    //   const source = `
+    //     import { styled } from '@linaria/react';
+    //     const Tag = styled.div\`color: blue\`;
+    //   `.trim();
+    //   const babelResult = transform(source);
+    //   const linariaResult = await linaria.transform(
+    //     source,
+    //     {
+    //       filename: 'test.tsx',
+    //       pluginOptions: {},
+    //     },
+    //     (s) => Promise.resolve(s)
+    //   );
+    //   console.log(linariaResult.cssText);
+    // });
+    it('jsdom with classes', () => {
+      const style = document.createElement('style');
+      style.textContent = `
+        .foo { color: blue; }
+      `;
+      document.head.append(style);
+      const div = document.createElement('div');
+      div.textContent = 'div';
+      div.classList.add('foo');
+      document.body.append(div);
+      expect(window.getComputedStyle(div).color).toBe('blue');
+      style.remove();
+      div.remove();
+      console.log('1', document.body.firstChild);
+    });
+    it('2', () => {
+      console.log('2', document.body.firstChild);
+      const span = document.createElement('span');
+      document.body.append(span);
+    });
+    // it('test jsdom', () => {
+    //   const dom = new JSDOM(
+    //     `
+    //     <!DOCTYPE html>
+    //     <head>
+    //       <style>
+    //         .foo { color: red; }
+    //       </style>
+    //     </head>
+    //     <body>
+    //       <div id="foo" class="foo">hi</div>
+    //     </body>
+    //   `,
+    //     {
+    //       url: 'http://localhost',
+    //       runScripts: 'dangerously',
+    //       pretendToBeVisual: true,
+    //     }
+    //   );
+    //   const div = dom.window.document.getElementById('foo');
+    //   if (div instanceof dom.window.HTMLElement) {
+    //     // div.style.setProperty('color', 'blue');
+    //     // expect(div.style.getPropertyValue('color')).toBe('blue');
+    //     console.log(dom.window.getComputedStyle(div).color);
+    //     console.log('color', div.style.color);
+    //     console.log(
+    //       'getPropertyValue(color)',
+    //       div.style.getPropertyValue('color')
+    //     );
+    //   }
+    // });
+    it('fff', async () => {
+      const source = `
+        import { styled } from '@linaria/solid'
+        const Foo = styled.div\`color: blue\`
+      `;
+      const result = await linaria.transform(
+        source,
+        {
+          filename: 'test.tsx',
+        },
+        (what: string, importer: string, stack: string[]) => {
+          console.info({
+            what,
+            importer,
+          });
+          return Promise.resolve('');
+        }
+      );
+      console.log(result);
+    });
   });
 });

--- a/packages/solid/__tests__/processors/styled.test.tsx
+++ b/packages/solid/__tests__/processors/styled.test.tsx
@@ -1,0 +1,7 @@
+import { styled } from '../../src/styled';
+
+describe('styled processor', () => {
+  it('renders tag', () => {
+    const Test = styled.div``;
+  });
+});

--- a/packages/solid/__tests__/processors/styled.test.tsx
+++ b/packages/solid/__tests__/processors/styled.test.tsx
@@ -1,7 +1,40 @@
-import { styled } from '../../src/styled';
+import * as babel from '@babel/core';
+// import {} from '@linaria/babel-preset';
+import dedent from 'dedent';
+
+import { styled } from '@linaria/solid';
+
+function transform(source: string): string {
+  const result = babel.transform(source, {
+    babelrc: false,
+    configFile: false,
+    filename: 'test.tsx',
+    presets: ['@linaria/babel-preset'],
+  });
+  if (!result || !result.code)
+    throw new Error('Babel cannot parse source code');
+  return dedent(result.code.trim());
+}
 
 describe('styled processor', () => {
   it('renders tag', () => {
-    const Test = styled.div``;
+    // const result = transform(`
+    //   import { styled } from '@linaria/solid'
+    //   export const Component = styled.div\`\`
+    // `);
+    // expect(result).toEqual(
+    //   dedent(`
+    //   export const Component = props => {
+    //     const className = "cg10ziu" + (props.class ? " " + props.class : "");
+    //     const style = props.style;
+    //     return <div {...props} class={className} style={style} />;
+    //   };
+    // `)
+    // );
+    // const Component = styled.div`
+    //   color: blue;
+    // `;
+    // console.log(Component);
+    console.log(styled);
   });
 });

--- a/packages/solid/__tests__/processors/styled.test.tsx
+++ b/packages/solid/__tests__/processors/styled.test.tsx
@@ -1,8 +1,12 @@
 import './polyfill';
 
+import path from 'path';
+
 import * as babel from '@babel/core';
-import { JSDOM } from 'jsdom';
+import * as esbuild from 'esbuild';
+import { JSDOM, VirtualConsole } from 'jsdom';
 import type { JSX } from 'solid-js';
+import { render } from 'solid-js/web';
 
 import * as linaria from '@linaria/babel-preset';
 
@@ -25,8 +29,55 @@ function toHTMLElement(element: JSX.Element): HTMLElement {
   throw new Error('Element is not an HTMLElement');
 }
 
+async function transpile(
+  source: string
+): Promise<[code: readonly string[], css: string]> {
+  const linariaResult = await linaria.transform(
+    source,
+    { filename: 'test.tsx' },
+    (what) => Promise.resolve(require.resolve(what))
+  );
+  if (linariaResult.code === undefined || linariaResult.cssText === undefined) {
+    throw new Error('Cannot transpile source with linaria');
+  }
+  const solidResult = babel.transform(linariaResult.code, {
+    babelrc: false,
+    configFile: false,
+    presets: ['solid'],
+  });
+  if (solidResult === null || !solidResult.code) {
+    throw new Error('Cannot transpile source with babel+solid');
+  }
+  const { code } = solidResult;
+  const esbuildResult = await esbuild.build({
+    entryPoints: [path.resolve(__dirname, './esbuild.root.ts')],
+    treeShaking: true,
+    bundle: true,
+    platform: 'browser',
+    write: false,
+    plugins: [
+      {
+        name: 'virtual-entry-point',
+        setup(build) {
+          build.onLoad({ filter: /esbuild\.root\.ts$/ }, () => {
+            return {
+              contents: code,
+              loader: 'js',
+            };
+          });
+        },
+      },
+    ],
+  });
+  const content = esbuildResult.outputFiles.map((file) => file.text);
+  return [content, linariaResult.cssText];
+}
+
 describe('styled processor', () => {
   describe('simple tag', () => {
+    it('foo', () => {
+      expect(Tag.toString()).toMatchSnapshot('s1');
+    });
     // it('renders tag with class', () => {
     //   const result = toHTMLElement(<Tag>hi</Tag>);
     //   expect(result.classList.length).toBe(1);
@@ -66,26 +117,26 @@ describe('styled processor', () => {
     //   );
     //   console.log(linariaResult.cssText);
     // });
-    it('jsdom with classes', () => {
-      const style = document.createElement('style');
-      style.textContent = `
-        .foo { color: blue; }
-      `;
-      document.head.append(style);
-      const div = document.createElement('div');
-      div.textContent = 'div';
-      div.classList.add('foo');
-      document.body.append(div);
-      expect(window.getComputedStyle(div).color).toBe('blue');
-      style.remove();
-      div.remove();
-      console.log('1', document.body.firstChild);
-    });
-    it('2', () => {
-      console.log('2', document.body.firstChild);
-      const span = document.createElement('span');
-      document.body.append(span);
-    });
+    // it('jsdom with classes', () => {
+    //   const style = document.createElement('style');
+    //   style.textContent = `
+    //     .foo { color: blue; }
+    //   `;
+    //   document.head.append(style);
+    //   const div = document.createElement('div');
+    //   div.textContent = 'div';
+    //   div.classList.add('foo');
+    //   document.body.append(div);
+    //   expect(window.getComputedStyle(div).color).toBe('blue');
+    //   style.remove();
+    //   div.remove();
+    //   console.log('1', document.body.firstChild);
+    // });
+    // it('2', () => {
+    //   console.log('2', document.body.firstChild);
+    //   const span = document.createElement('span');
+    //   document.body.append(span);
+    // });
     // it('test jsdom', () => {
     //   const dom = new JSDOM(
     //     `
@@ -117,25 +168,133 @@ describe('styled processor', () => {
     //     );
     //   }
     // });
+    it('fffff', async () => {
+      const [modules, css] = await transpile(`
+        import { styled } from '@linaria/solid';
+        import { render } from 'solid-js/web';
+        const Foo = styled.div\`color: blue\`;
+        render(() => <Foo>hi</Foo>, document.getElementById('root'));
+      `);
+      const virtualConsole = new VirtualConsole();
+      virtualConsole.sendTo(console);
+      const dom = new JSDOM(
+        `
+          <!DOCTYPE html>
+          <head>
+            <style>${css}</style>
+          </head>
+          <body>
+            <div id="root"></div>
+            ${modules.map((m) => `<script>${m}</script>`)}
+          </body>
+        `,
+        {
+          url: 'http://localhost',
+          runScripts: 'dangerously',
+          pretendToBeVisual: true,
+        }
+      );
+      const root = dom.window.document.getElementById('root');
+      console.log(root?.innerHTML);
+    });
     it('fff', async () => {
       const source = `
-        import { styled } from '@linaria/solid'
-        const Foo = styled.div\`color: blue\`
+        import { styled } from '@linaria/solid';
+        import { render } from 'solid-js/web';
+        const Foo = styled.div\`color: blue\`;
+        render(() => <Foo>hi</Foo>, document.getElementById('root'));
       `;
       const result = await linaria.transform(
         source,
+        { filename: 'test.tsx' },
+        (what) => Promise.resolve(require.resolve(what))
+      );
+      if (!result.code || !result.cssText) {
+        throw new Error('Cannot transpile source with linaria');
+      }
+      const result2 = babel.transform(result.code, {
+        babelrc: false,
+        configFile: false,
+        presets: ['solid'],
+      });
+      if (!result2?.code) {
+        throw new Error('Cannot transpile source with babel');
+      }
+      // const result3 = esbuild.transformSync(result2.code, {
+      //   platform: 'browser',
+      //   treeShaking: true,
+      //   bundle: true
+      // });
+      const r = await esbuild.build({
+        entryPoints: [path.resolve(__dirname, './esbuild.root.ts')],
+        treeShaking: true,
+        bundle: true,
+        platform: 'browser',
+        write: false,
+        plugins: [
+          {
+            name: 'virtual-entry-point',
+            setup(build) {
+              build.onResolve(
+                { filter: /^@linaria\/solid\/test-entry$/ },
+                (args) => ({
+                  path: args.path,
+                  namespace: '@linaria/solid/test-entry',
+                })
+              );
+              build.onLoad({ filter: /^@linaria\/solid\/test-entry$/ }, () => {
+                return {
+                  contents: JSON.stringify({ foo: 123 }),
+                  loader: 'json',
+                };
+              });
+            },
+          },
+        ],
+      });
+      // console.log(r.outputFiles.map((f) => f.text));
+      // return;
+      const virtualConsole = new VirtualConsole();
+      virtualConsole.sendTo(console);
+      const dom = new JSDOM(
+        `
+          <!DOCTYPE html>
+          <head>
+            <style>
+              #root { color: blue; }
+            </style>
+          </head>
+          <body>
+            <div id="root"></div>
+            <script>
+              const child = document.createElement('div')
+              child.textContent = 'child'
+              document.getElementById('root').appendChild(child)
+              console.log('Hello from jsdom')
+              // throw new Error('Error from jsdom')
+            </script>
+<!--            <script type="module">-->
+<!--              const root = document.getElementById('root')-->
+<!--              root.innerText = 'HEYA'-->
+<!--              console.log('WOHOO')-->
+<!--            </script>-->
+          </body>
+        `,
         {
-          filename: 'test.tsx',
-        },
-        (what: string, importer: string, stack: string[]) => {
-          console.info({
-            what,
-            importer,
-          });
-          return Promise.resolve('');
+          url: 'http://localhost',
+          runScripts: 'dangerously',
+          pretendToBeVisual: true,
         }
       );
-      console.log(result);
+      // console.log(result2.code);
+      const root = dom.window.document.getElementById('root');
+      if (!root) throw new Error('Cannot find root');
+      // root.textContent = 'BAR';
+      // console.info({
+      //   color: dom.window.getComputedStyle(root).color,
+      //   content: root.textContent,
+      // });
+      // console.log(root?.textContent);
     });
   });
 });

--- a/packages/solid/__tests__/processors/styled.test.tsx
+++ b/packages/solid/__tests__/processors/styled.test.tsx
@@ -1,40 +1,42 @@
-import * as babel from '@babel/core';
+// import * as babel from '@babel/core';
 // import {} from '@linaria/babel-preset';
-import dedent from 'dedent';
+// import dedent from 'dedent';
 
-import { styled } from '@linaria/solid';
+import { styled } from '../../src';
+// import { styled } from '@linaria/react';
 
-function transform(source: string): string {
-  const result = babel.transform(source, {
-    babelrc: false,
-    configFile: false,
-    filename: 'test.tsx',
-    presets: ['@linaria/babel-preset'],
-  });
-  if (!result || !result.code)
-    throw new Error('Babel cannot parse source code');
-  return dedent(result.code.trim());
-}
+// function transform(source: string): string {
+//   const result = babel.transform(source, {
+//     babelrc: false,
+//     configFile: false,
+//     filename: 'test.tsx',
+//     presets: ['@linaria/babel-preset'],
+//   });
+//   if (!result || !result.code)
+//     throw new Error('Babel cannot parse source code');
+//   return dedent(result.code.trim());
+// }
 
-describe('styled processor', () => {
-  it('renders tag', () => {
-    // const result = transform(`
-    //   import { styled } from '@linaria/solid'
-    //   export const Component = styled.div\`\`
-    // `);
-    // expect(result).toEqual(
-    //   dedent(`
-    //   export const Component = props => {
-    //     const className = "cg10ziu" + (props.class ? " " + props.class : "");
-    //     const style = props.style;
-    //     return <div {...props} class={className} style={style} />;
-    //   };
-    // `)
-    // );
-    // const Component = styled.div`
-    //   color: blue;
-    // `;
-    // console.log(Component);
-    console.log(styled);
-  });
-});
+// describe('styled processor', () => {
+//   it('renders tag', () => {
+//     // const result = transform(`
+//     //   import { styled } from '@linaria/solid'
+//     //   export const Component = styled.div\`\`
+//     // `);
+//     // expect(result).toEqual(
+//     //   dedent(`
+//     //   export const Component = props => {
+//     //     const className = "cg10ziu" + (props.class ? " " + props.class : "");
+//     //     const style = props.style;
+//     //     return <div {...props} class={className} style={style} />;
+//     //   };
+//     // `)
+//     // );
+//     // const Component = styled.div`
+//     //   color: blue;
+//     // `;
+//     // console.log(Component);
+//     console.log(styled.div``);
+//   });
+// });
+console.log(styled.div``);

--- a/packages/solid/babel.config.js
+++ b/packages/solid/babel.config.js
@@ -1,0 +1,3 @@
+const config = require('../../babel.config');
+
+module.exports = config;

--- a/packages/solid/babel.config.js
+++ b/packages/solid/babel.config.js
@@ -1,3 +1,9 @@
-const config = require('../../babel.config');
-
-module.exports = config;
+module.exports = {
+  extends: '../../babel.config',
+  overrides: [
+    {
+      test: /\/(__tests__)\//,
+      presets: ['@linaria', 'solid'],
+    },
+  ],
+};

--- a/packages/solid/jest.config.js
+++ b/packages/solid/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  preset: 'babel-jest',
+  testEnvironment: 'node',
+};

--- a/packages/solid/jest.config.js
+++ b/packages/solid/jest.config.js
@@ -5,4 +5,5 @@ module.exports = {
   transform: {
     '\\.[jt]sx?$': 'babel-jest',
   },
+  testMatch: ['**/*.test.tsx'],
 };

--- a/packages/solid/jest.config.js
+++ b/packages/solid/jest.config.js
@@ -1,5 +1,8 @@
-/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
-  preset: 'babel-jest',
+  collectCoverageFrom: ['src/*.ts'],
+  transformIgnorePatterns: ['node_modules/(?!@linaria)'],
   testEnvironment: 'node',
+  transform: {
+    '\\.[jt]sx?$': 'babel-jest',
+  },
 };

--- a/packages/solid/jest.config.js
+++ b/packages/solid/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   collectCoverageFrom: ['src/*.ts'],
   transformIgnorePatterns: ['node_modules/(?!@linaria)'],
-  testEnvironment: 'node',
+  testEnvironment: 'jsdom',
   transform: {
     '\\.[jt]sx?$': 'babel-jest',
   },

--- a/packages/solid/linaria.config.js
+++ b/packages/solid/linaria.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  evaluate: true,
+  displayName: true,
+  tagResolver: (source, tag) => {
+    if (tag === 'styled') {
+      return require.resolve('./lib/processors/styled.js');
+    }
+    return undefined;
+  },
+};

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -22,6 +22,7 @@
     "@types/dedent": "^0.7.0",
     "@types/node": "^17.0.39",
     "babel-preset-jest": "^28.1.0",
+    "babel-preset-solid": "^1.5.4",
     "dedent": "^0.7.0",
     "solid-js": "^1.4.8"
   },
@@ -45,7 +46,8 @@
     "esm/",
     "lib/",
     "processors/",
-    "types/"
+    "types/",
+    "linaria.config.js"
   ],
   "homepage": "https://github.com/callstack/linaria#readme",
   "keywords": [
@@ -56,11 +58,6 @@
     "styled-components"
   ],
   "license": "MIT",
-  "linaria": {
-    "tags": {
-      "styled": "./lib/processors/styled.js"
-    }
-  },
   "main": "lib/index.js",
   "module": "esm/index.js",
   "peerDependencies": {
@@ -76,11 +73,10 @@
     "build:declarations": "tsc -p tsconfig.lib.json --emitDeclarationOnly --noEmit false --outDir types",
     "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "test": "jest --config ../../jest.config.js --rootDir .",
+    "test": "jest --config ./jest.config.js --rootDir . --verbose",
     "test:dts": "dtslint --localTs ../../node_modules/typescript/lib __dtslint__",
     "typecheck": "tsc -b tsconfig.spec.json",
-    "watch": "npm run build --watch",
-    "t": "tsc --listFiles -p tsconfig.lib.json"
+    "watch": "npm run build --watch"
   },
   "sideEffects": false,
   "types": "types/index.d.ts",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -25,6 +25,7 @@
     "babel-preset-jest": "^28.1.0",
     "babel-preset-solid": "^1.5.4",
     "dedent": "^0.7.0",
+    "esbuild": "^0.15.7",
     "jest-environment-jsdom": "^28.1.0",
     "jsdom": "^20.0.0",
     "solid-js": "^1.4.8"
@@ -80,7 +81,7 @@
     "test:dts": "dtslint --localTs ../../node_modules/typescript/lib __dtslint__",
     "typecheck": "tsc -b tsconfig.spec.json",
     "watch": "npm run build --watch",
-    "build:tests": "babel ./__tests__/processors/styled.test.tsx -o ./tmp/out.js --verbose"
+    "t": "node __tests__/processors/test.js"
   },
   "sideEffects": false,
   "types": "types/index.d.ts",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,0 +1,89 @@
+{
+  "name": "@linaria/solid",
+  "description": "Blazing fast zero-runtime CSS in JS library for SolidJS",
+  "version": "4.0.0",
+  "bugs": "https://github.com/callstack/linaria/issues",
+  "contributors": [
+    {
+      "name": "Kirill Agalakov",
+      "email": "raveclassic@gmail.com",
+      "url": "https://github.com/raveclassic"
+    }
+  ],
+  "dependencies": {
+    "@linaria/core": "workspace:^",
+    "@linaria/tags": "workspace:^"
+  },
+  "devDependencies": {
+    "@babel/types": "^7.18.9",
+    "@types/babel__core": "^7.1.19",
+    "@types/node": "^17.0.39",
+    "solid-js": "^1.4.8"
+  },
+  "engines": {
+    "node": "^12.16.0 || >=13.7.0"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./types/index.d.ts",
+      "import": "./esm/index.js",
+      "default": "./lib/index.js"
+    },
+    "./*": {
+      "types": "./types/*.d.ts",
+      "import": "./esm/*.js",
+      "default": "./lib/*.js"
+    }
+  },
+  "files": [
+    "esm/",
+    "lib/",
+    "processors/",
+    "types/"
+  ],
+  "homepage": "https://github.com/callstack/linaria#readme",
+  "keywords": [
+    "css",
+    "css-in-js",
+    "linaria",
+    "solid",
+    "styled-components"
+  ],
+  "license": "MIT",
+  "linaria": {
+    "tags": {
+      "styled": "./lib/processors/styled.js"
+    }
+  },
+  "main": "lib/index.js",
+  "module": "esm/index.js",
+  "peerDependencies": {
+    "solid-js": "^1.4.8"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": "git@github.com:callstack/linaria.git",
+  "scripts": {
+    "build": "npm run build:lib && npm run build:esm && npm run build:declarations",
+    "build:corejs-test": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --ignore \"src/processors/**/*\"",
+    "build:declarations": "tsc -p tsconfig.lib.json --emitDeclarationOnly --outDir types",
+    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "test": "jest --config ../../jest.config.js --rootDir .",
+    "test:dts": "dtslint --localTs ../../node_modules/typescript/lib __dtslint__",
+    "typecheck": "tsc -b tsconfig.spec.json",
+    "watch": "npm run build --watch",
+    "t": "tsc --listFiles -p tsconfig.lib.json"
+  },
+  "sideEffects": false,
+  "types": "types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "processors/*": [
+        "./types/processors/*.d.ts"
+      ]
+    }
+  }
+}

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -15,9 +15,13 @@
     "@linaria/tags": "workspace:^"
   },
   "devDependencies": {
+    "@babel/core": "^7.18.9",
     "@babel/types": "^7.18.9",
+    "@linaria/babel-preset": "workspace:^",
     "@types/babel__core": "^7.1.19",
+    "@types/dedent": "^0.7.0",
     "@types/node": "^17.0.39",
+    "babel-preset-jest": "^28.1.0",
     "dedent": "^0.7.0",
     "solid-js": "^1.4.8"
   },

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -18,6 +18,7 @@
     "@babel/types": "^7.18.9",
     "@types/babel__core": "^7.1.19",
     "@types/node": "^17.0.39",
+    "dedent": "^0.7.0",
     "solid-js": "^1.4.8"
   },
   "engines": {
@@ -68,7 +69,7 @@
   "scripts": {
     "build": "npm run build:lib && npm run build:esm && npm run build:declarations",
     "build:corejs-test": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --ignore \"src/processors/**/*\"",
-    "build:declarations": "tsc -p tsconfig.lib.json --emitDeclarationOnly --outDir types",
+    "build:declarations": "tsc -p tsconfig.lib.json --emitDeclarationOnly --noEmit false --outDir types",
     "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "test": "jest --config ../../jest.config.js --rootDir .",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -20,10 +20,13 @@
     "@linaria/babel-preset": "workspace:^",
     "@types/babel__core": "^7.1.19",
     "@types/dedent": "^0.7.0",
+    "@types/jsdom": "^20.0.0",
     "@types/node": "^17.0.39",
     "babel-preset-jest": "^28.1.0",
     "babel-preset-solid": "^1.5.4",
     "dedent": "^0.7.0",
+    "jest-environment-jsdom": "^28.1.0",
+    "jsdom": "^20.0.0",
     "solid-js": "^1.4.8"
   },
   "engines": {
@@ -76,7 +79,8 @@
     "test": "jest --config ./jest.config.js --rootDir . --verbose",
     "test:dts": "dtslint --localTs ../../node_modules/typescript/lib __dtslint__",
     "typecheck": "tsc -b tsconfig.spec.json",
-    "watch": "npm run build --watch"
+    "watch": "npm run build --watch",
+    "build:tests": "babel ./__tests__/processors/styled.test.tsx -o ./tmp/out.js --verbose"
   },
   "sideEffects": false,
   "types": "types/index.d.ts",

--- a/packages/solid/processors/styled.js
+++ b/packages/solid/processors/styled.js
@@ -1,0 +1,5 @@
+Object.defineProperty(exports, '__esModule', {
+  value: true,
+});
+
+exports.default = require('../lib/processors/styled').default;

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -1,2 +1,7 @@
-export { styled } from './styled';
+export {
+  styled,
+  type Styled,
+  type StyledTag,
+  type StyledComponent,
+} from './styled';
 export { default as SolidStyledProcessor } from './processors/styled';

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -1,0 +1,2 @@
+export { styled } from './styled';
+export { default as SolidStyledProcessor } from './processors/styled';

--- a/packages/solid/src/processors/styled.ts
+++ b/packages/solid/src/processors/styled.ts
@@ -8,8 +8,8 @@ import type {
   VariableDeclaration,
 } from '@babel/types';
 
-import type { IInterpolation } from '@linaria/tags';
 import {
+  type IInterpolation,
   hasMeta,
   type Params,
   type Rules,

--- a/packages/solid/src/processors/styled.ts
+++ b/packages/solid/src/processors/styled.ts
@@ -289,3 +289,5 @@ export default class StyledProcessor extends TaggedTemplateProcessor {
     return unit ? t.binaryExpression('+', call, t.stringLiteral(unit)) : call;
   }
 }
+
+console.log('TS styled processor');

--- a/packages/solid/src/processors/styled.ts
+++ b/packages/solid/src/processors/styled.ts
@@ -1,0 +1,291 @@
+import type {
+  Expression,
+  Identifier,
+  ObjectExpression,
+  ReturnStatement,
+  SourceLocation,
+  Statement,
+  VariableDeclaration,
+} from '@babel/types';
+
+import type { IInterpolation } from '@linaria/tags';
+import {
+  hasMeta,
+  type Params,
+  type Rules,
+  TaggedTemplateProcessor,
+  type TailProcessorParams,
+  validateParams,
+  type ValueCache,
+  type WrappedNode,
+} from '@linaria/tags';
+
+export default class StyledProcessor extends TaggedTemplateProcessor {
+  public component: WrappedNode;
+
+  #variableIdx = 0;
+
+  #variablesCache = new Map<string, string>();
+
+  constructor(params: Params, ...args: TailProcessorParams) {
+    validateParams(
+      params,
+      ['tag', ['call', 'member'], ['template', 'call']],
+      'Invalid usage of `styled` tag'
+    );
+
+    const [tag, tagOp, template] = params;
+
+    super([tag, template[0] === 'call' ? ['template', []] : template], ...args);
+
+    let component: WrappedNode | undefined;
+    if (tagOp[0] === 'call' && tagOp.length === 2) {
+      const value = tagOp[1];
+      component = {
+        node: value.ex,
+        source: value.source,
+      };
+
+      this.dependencies.push(value);
+    }
+
+    if (tagOp[0] === 'member') {
+      [, component] = tagOp;
+    }
+
+    if (!component) {
+      throw new Error('Invalid usage of `styled` tag');
+    }
+
+    this.component = component;
+  }
+
+  public override addInterpolation(
+    node: Expression,
+    source: string,
+    unit = ''
+  ): string {
+    const id = this.getVariableId(source + unit);
+
+    this.interpolations.push({
+      id,
+      node,
+      source,
+      unit,
+    });
+
+    return id;
+  }
+
+  public override doEvaltimeReplacement(): void {
+    this.replacer(this.value, false);
+  }
+
+  public override doRuntimeReplacement(): void {
+    const t = this.astService;
+
+    const statements: Statement[] = [
+      this.getClassNameConstantDeclaration(),
+      this.getStyleConstantDeclaration(),
+    ];
+    if (typeof this.component === 'string') {
+      // tag
+      statements.push(this.getComponentReturnStatement(this.component));
+    } else {
+      // component or anonymous function
+      statements.push(
+        this.getComponentConstantDeclaration(this.component.node, 'Component'),
+        this.getComponentReturnStatement('Component')
+      );
+    }
+    const body = t.arrowFunctionExpression(
+      [t.identifier('props')],
+      t.blockStatement(statements)
+    );
+    this.replacer(body, false);
+  }
+
+  public override extractRules(
+    valueCache: ValueCache,
+    cssText: string,
+    loc?: SourceLocation | null
+  ): Rules {
+    const rules: Rules = {};
+
+    let selector = `.${this.className}`;
+
+    // If `styled` wraps another component and not a primitive,
+    // get its class name to create a more specific selector
+    // it'll ensure that styles are overridden properly
+    let value =
+      typeof this.component === 'string'
+        ? null
+        : valueCache.get(this.component.node.name);
+    while (hasMeta(value)) {
+      selector += `.${value.__linaria.className}`;
+      value = value.__linaria.extends;
+    }
+
+    rules[selector] = {
+      cssText,
+      className: this.className,
+      displayName: this.displayName,
+      start: loc?.start ?? null,
+    };
+
+    return rules;
+  }
+
+  public override get asSelector(): string {
+    return `.${this.className}`;
+  }
+
+  public override get value(): ObjectExpression {
+    const t = this.astService;
+    const extendsNode =
+      typeof this.component === 'string' ? null : this.component.node.name;
+
+    return t.objectExpression([
+      t.objectProperty(
+        t.stringLiteral('displayName'),
+        t.stringLiteral(this.displayName)
+      ),
+      t.objectProperty(
+        t.stringLiteral('__linaria'),
+        t.objectExpression([
+          t.objectProperty(
+            t.stringLiteral('className'),
+            t.stringLiteral(this.className)
+          ),
+          t.objectProperty(
+            t.stringLiteral('extends'),
+            extendsNode
+              ? t.callExpression(t.identifier(extendsNode), [])
+              : t.nullLiteral()
+          ),
+        ])
+      ),
+    ]);
+  }
+
+  public override toString(): string {
+    if (typeof this.component === 'string') {
+      return `${this.tagSourceCode()}('${this.component}')\`…\``;
+    }
+
+    return `${this.tagSourceCode()}('${this.component.source}')\`…\``;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected getVariableId(value: string): string {
+    if (!this.#variablesCache.has(value)) {
+      // make the variable unique to this styled component
+      // eslint-disable-next-line no-plusplus
+      this.#variablesCache.set(value, `${this.slug}-${this.#variableIdx++}`);
+    }
+
+    return this.#variablesCache.get(value)!;
+  }
+
+  private getClassNameConstantDeclaration(): VariableDeclaration {
+    const t = this.astService;
+    return t.variableDeclaration('const', [
+      t.variableDeclarator(
+        t.identifier('className'),
+        t.binaryExpression(
+          '+',
+          t.stringLiteral(this.className),
+          t.conditionalExpression(
+            t.memberExpression(t.identifier('props'), t.identifier('class')),
+            t.binaryExpression(
+              '+',
+              t.stringLiteral(' '),
+              t.memberExpression(t.identifier('props'), t.identifier('class'))
+            ),
+            t.stringLiteral('')
+          )
+        )
+      ),
+    ]);
+  }
+
+  private getComponentConstantDeclaration(
+    node: Identifier,
+    constantName: string
+  ): VariableDeclaration {
+    const t = this.astService;
+
+    return t.variableDeclaration('const', [
+      t.variableDeclarator(
+        t.identifier(constantName),
+        t.callExpression(node, [])
+      ),
+    ]);
+  }
+
+  private getComponentReturnStatement(componentName: string): ReturnStatement {
+    const t = this.astService;
+    return t.returnStatement(
+      t.jsxElement(
+        t.jsxOpeningElement(
+          t.jsxIdentifier(componentName),
+          [
+            t.jsxSpreadAttribute(t.identifier('props')),
+            t.jsxAttribute(
+              t.jsxIdentifier('class'),
+              t.jsxExpressionContainer(t.identifier('className'))
+            ),
+            t.jsxAttribute(
+              t.jsxIdentifier('style'),
+              t.jsxExpressionContainer(t.identifier('style'))
+            ),
+          ],
+          true
+        ),
+        undefined,
+        []
+      )
+    );
+  }
+
+  private getStyleConstantDeclaration(): VariableDeclaration {
+    const t = this.astService;
+
+    return t.variableDeclaration('const', [
+      t.variableDeclarator(
+        t.identifier('style'),
+        this.getStyleConstantValueExpression()
+      ),
+    ]);
+  }
+
+  private getStyleConstantValueExpression(): Expression {
+    const t = this.astService;
+
+    if (this.interpolations.length === 0) {
+      return t.memberExpression(t.identifier('props'), t.identifier('style'));
+    }
+    const vars: Record<string, Expression> = {};
+    this.interpolations.forEach((interpolation) => {
+      vars[`--${interpolation.id}`] = this.getVarExpression(interpolation);
+    });
+    const wrapped = Object.entries(vars).map(([id, expression]) =>
+      t.objectProperty(t.stringLiteral(id), expression)
+    );
+    return t.objectExpression([
+      ...wrapped,
+      t.spreadElement(
+        t.memberExpression(t.identifier('props'), t.identifier('style'))
+      ),
+    ]);
+  }
+
+  private getVarExpression(interpolation: IInterpolation): Expression {
+    const t = this.astService;
+    const { node, unit } = interpolation;
+    const call = t.callExpression(t.callExpression(node, []), [
+      t.identifier('props'),
+    ]);
+    return unit ? t.binaryExpression('+', call, t.stringLiteral(unit)) : call;
+  }
+}

--- a/packages/solid/src/processors/styled.ts
+++ b/packages/solid/src/processors/styled.ts
@@ -289,5 +289,3 @@ export default class StyledProcessor extends TaggedTemplateProcessor {
     return unit ? t.binaryExpression('+', call, t.stringLiteral(unit)) : call;
   }
 }
-
-console.log('TS styled processor');

--- a/packages/solid/src/styled.ts
+++ b/packages/solid/src/styled.ts
@@ -8,18 +8,22 @@ type TagExpression<Props> =
   | number
   | CSSProperties
   | StyledMeta
-  | ((props: Props) => string | number);
+  | ((props: Props) => string | number | undefined);
 
-interface StyledComponent<Props> extends StyledMeta, Component<Props> {}
+export interface StyledComponent<Props> extends StyledMeta, Component<Props> {}
 
-interface StyledTag<Props> {
+export interface StyledTag<Props> {
+  (
+    strings: TemplateStringsArray,
+    ...expressions: readonly TagExpression<Props>[]
+  ): StyledComponent<Props>;
   <AdditionalProps = Record<string, unknown>>(
     strings: TemplateStringsArray,
     ...expressions: readonly TagExpression<Props & AdditionalProps>[]
   ): StyledComponent<Props & AdditionalProps>;
 }
 
-interface Styled {
+export interface Styled {
   <Props>(component: Component<Props>): StyledTag<Props>;
   <TagName extends keyof JSX.IntrinsicElements>(tagName: TagName): StyledTag<
     JSX.IntrinsicElements[TagName]

--- a/packages/solid/src/styled.ts
+++ b/packages/solid/src/styled.ts
@@ -1,0 +1,36 @@
+import type { JSX, Component } from 'solid-js';
+
+import type { CSSProperties } from '@linaria/core';
+import type { StyledMeta } from '@linaria/tags';
+
+type TagExpression<Props> =
+  | string
+  | number
+  | CSSProperties
+  | StyledMeta
+  | ((props: Props) => string | number);
+
+interface StyledComponent<Props> extends StyledMeta, Component<Props> {}
+
+interface StyledTag<Props> {
+  <AdditionalProps = Record<string, unknown>>(
+    strings: TemplateStringsArray,
+    ...expressions: readonly TagExpression<Props & AdditionalProps>[]
+  ): StyledComponent<Props & AdditionalProps>;
+}
+
+interface Styled {
+  <Props>(component: Component<Props>): StyledTag<Props>;
+  <TagName extends keyof JSX.IntrinsicElements>(tagName: TagName): StyledTag<
+    JSX.IntrinsicElements[TagName]
+  >;
+  (component: 'The target component must have a className prop'): never;
+}
+
+type StyledJSXIntrinsics = {
+  readonly [TagName in keyof JSX.IntrinsicElements]: StyledTag<
+    JSX.IntrinsicElements[TagName]
+  >;
+};
+
+export declare const styled: Styled & StyledJSXIntrinsics;

--- a/packages/solid/tsconfig.json
+++ b/packages/solid/tsconfig.json
@@ -4,6 +4,7 @@
     "paths": {},
     "types": [],
     "noEmit": true,
+    "composite": false
   },
   "files": [],
   "include": [],

--- a/packages/solid/tsconfig.json
+++ b/packages/solid/tsconfig.json
@@ -8,7 +8,7 @@
   },
   "files": [],
   "include": [],
-  "exclude": ["types", "esm", "lib", ".turbo"],
+  "exclude": [],
   "references": [
 //    { "path": "../core" },
     { "path": "./tsconfig.lib.json" },

--- a/packages/solid/tsconfig.json
+++ b/packages/solid/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "paths": {},
+    "types": [],
+    "noEmit": true,
+  },
+  "files": [],
+  "include": [],
+  "exclude": ["types", "esm", "lib", ".turbo"],
+  "references": [
+//    { "path": "../core" },
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.spec.json" }
+  ]
+}

--- a/packages/solid/tsconfig.json
+++ b/packages/solid/tsconfig.json
@@ -4,7 +4,9 @@
     "paths": {},
     "types": [],
     "noEmit": true,
-    "composite": false
+    "composite": false,
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js"
   },
   "files": [],
   "include": [],

--- a/packages/solid/tsconfig.lib.json
+++ b/packages/solid/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src/",
+    "types": ["node"]
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["__dtslint__", "__tests__"]
+}

--- a/packages/solid/tsconfig.lib.json
+++ b/packages/solid/tsconfig.lib.json
@@ -5,5 +5,5 @@
     "types": ["node"]
   },
   "include": ["**/*.ts", "**/*.tsx"],
-  "exclude": ["__tests__"]
+  "exclude": ["__tests__", "types", "esm", "lib", ".turbo"]
 }

--- a/packages/solid/tsconfig.lib.json
+++ b/packages/solid/tsconfig.lib.json
@@ -5,5 +5,5 @@
     "types": ["node"]
   },
   "include": ["**/*.ts", "**/*.tsx"],
-  "exclude": ["__tests__", "types", "esm", "lib", ".turbo"]
+  "exclude": ["__tests__", "types", "esm", "lib", ".turbo", "tmp"]
 }

--- a/packages/solid/tsconfig.lib.json
+++ b/packages/solid/tsconfig.lib.json
@@ -5,5 +5,5 @@
     "types": ["node"]
   },
   "include": ["**/*.ts", "**/*.tsx"],
-  "exclude": ["__dtslint__", "__tests__"]
+  "exclude": ["__tests__"]
 }

--- a/packages/solid/tsconfig.spec.json
+++ b/packages/solid/tsconfig.spec.json
@@ -4,5 +4,6 @@
     "noEmit": true,
     "types": ["jest", "node"]
   },
-  "include": ["__tests__"]
+  "include": ["__tests__"],
+  "exclude": ["types", "esm", "lib", ".turbo"]
 }

--- a/packages/solid/tsconfig.spec.json
+++ b/packages/solid/tsconfig.spec.json
@@ -4,5 +4,5 @@
     "noEmit": true,
     "types": ["jest", "node"]
   },
-  "include": ["__tests__", "__dtslint__"]
+  "include": ["__tests__"]
 }

--- a/packages/solid/tsconfig.spec.json
+++ b/packages/solid/tsconfig.spec.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["__tests__", "__dtslint__"]
+}

--- a/packages/solid/tsconfig.spec.json
+++ b/packages/solid/tsconfig.spec.json
@@ -5,5 +5,5 @@
     "types": ["jest", "node"]
   },
   "include": ["__tests__"],
-  "exclude": ["types", "esm", "lib", ".turbo"]
+  "exclude": ["types", "esm", "lib", ".turbo", "tmp"]
 }

--- a/packages/testkit/babel.config.js
+++ b/packages/testkit/babel.config.js
@@ -2,7 +2,7 @@ module.exports = {
   extends: '../../babel.config',
   overrides: [
     {
-      test: ['__tests__/**/*.tsx'],
+      test: 'src',
       presets: ['@babel/preset-react'],
     },
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -520,19 +520,39 @@ importers:
 
   packages/solid:
     specifiers:
+      '@babel/core': ^7.18.9
       '@babel/types': ^7.18.9
+      '@linaria/babel-preset': workspace:^
       '@linaria/core': workspace:^
       '@linaria/tags': workspace:^
       '@types/babel__core': ^7.1.19
+      '@types/dedent': ^0.7.0
+      '@types/jsdom': ^20.0.0
       '@types/node': ^17.0.39
+      babel-preset-jest: ^28.1.0
+      babel-preset-solid: ^1.5.4
+      dedent: ^0.7.0
+      esbuild: ^0.15.7
+      jest-environment-jsdom: ^28.1.0
+      jsdom: ^20.0.0
       solid-js: ^1.4.8
     dependencies:
       '@linaria/core': link:../core
       '@linaria/tags': link:../tags
     devDependencies:
+      '@babel/core': 7.19.3
       '@babel/types': 7.18.9
+      '@linaria/babel-preset': link:../babel
       '@types/babel__core': 7.1.19
+      '@types/dedent': 0.7.0
+      '@types/jsdom': 20.0.0
       '@types/node': 17.0.39
+      babel-preset-jest: 28.1.3_@babel+core@7.19.3
+      babel-preset-solid: 1.6.0_@babel+core@7.19.3
+      dedent: 0.7.0
+      esbuild: 0.15.12
+      jest-environment-jsdom: 28.1.3
+      jsdom: 20.0.1
       solid-js: 1.4.8
 
   packages/stylelint:
@@ -837,12 +857,6 @@ packages:
       chokidar: 3.5.3
     dev: true
 
-  /@babel/code-frame/7.16.7:
-    resolution: {integrity: sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/highlight': 7.17.12
-
   /@babel/code-frame/7.18.6:
     resolution: {integrity: sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==}
     engines: {node: '>=6.9.0'}
@@ -1104,7 +1118,7 @@ packages:
     resolution: {integrity: sha512-0mWMxV1aC97dhjCah5U5Ua7668r5ZmSC2DLfH2EZnf9c3/dHZKiFa5pRLMH5tjSl471tY6496ZWk/kjNONBxhw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.18.6
+      '@babel/template': 7.18.10
       '@babel/types': 7.19.4
     dev: true
 
@@ -1121,7 +1135,6 @@ packages:
     dependencies:
       '@babel/template': 7.18.10
       '@babel/types': 7.19.4
-    dev: true
 
   /@babel/helper-hoist-variables/7.16.7:
     resolution: {integrity: sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==}
@@ -1140,6 +1153,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.19.4
+
+  /@babel/helper-module-imports/7.16.0:
+    resolution: {integrity: sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.19.4
+    dev: true
 
   /@babel/helper-module-imports/7.16.7:
     resolution: {integrity: sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==}
@@ -1315,8 +1335,8 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-function-name': 7.17.9
-      '@babel/template': 7.16.7
-      '@babel/traverse': 7.18.2
+      '@babel/template': 7.18.10
+      '@babel/traverse': 7.19.4
       '@babel/types': 7.19.4
     transitivePeerDependencies:
       - supports-color
@@ -1353,19 +1373,11 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/highlight/7.17.12:
-    resolution: {integrity: sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.19.1
-      chalk: 2.4.2
-      js-tokens: 4.0.0
-
   /@babel/highlight/7.18.6:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.18.6
+      '@babel/helper-validator-identifier': 7.19.1
       chalk: 2.4.2
       js-tokens: 4.0.0
 
@@ -1382,6 +1394,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.18.9
+    dev: true
 
   /@babel/parser/7.18.8:
     resolution: {integrity: sha512-RSKRfYX20dyH+elbJK2uqAkVyucL+xXzhqlMD5/ZXx+dAAwpyB7HsvnHe/ZUGOF+xLr5Wx9/JoXVTj6BQE2/oA==}
@@ -1397,7 +1410,6 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.19.4
-    dev: true
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.17.12_@babel+core@7.18.9:
     resolution: {integrity: sha512-xCJQXl4EeQ3J9C4yOmpTrtVGmzpm2iSzyxbkZHw7UCnZBftHpF/hpII80uWVyVrc40ytIClHjgWGTG1g/yB+aw==}
@@ -1595,12 +1607,30 @@ packages:
       '@babel/core': 7.18.9
       '@babel/helper-plugin-utils': 7.19.0
 
+  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.19.3:
+    resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
+    dev: true
+
   /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.18.9:
     resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
+      '@babel/helper-plugin-utils': 7.19.0
+    dev: true
+
+  /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.19.3:
+    resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.19.3
       '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
@@ -1611,6 +1641,15 @@ packages:
     dependencies:
       '@babel/core': 7.18.9
       '@babel/helper-plugin-utils': 7.19.0
+
+  /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.19.3:
+    resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
+    dev: true
 
   /@babel/plugin-syntax-class-static-block/7.14.5_@babel+core@7.18.9:
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
@@ -1655,6 +1694,15 @@ packages:
       '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
+  /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.19.3:
+    resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
+    dev: true
+
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.18.9:
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
     peerDependencies:
@@ -1662,6 +1710,15 @@ packages:
     dependencies:
       '@babel/core': 7.18.9
       '@babel/helper-plugin-utils': 7.19.0
+
+  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.19.3:
+    resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
+    dev: true
 
   /@babel/plugin-syntax-jsx/7.18.6_@babel+core@7.18.6:
     resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
@@ -1701,6 +1758,15 @@ packages:
       '@babel/core': 7.18.9
       '@babel/helper-plugin-utils': 7.19.0
 
+  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.19.3:
+    resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
+    dev: true
+
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.18.9:
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
     peerDependencies:
@@ -1708,6 +1774,15 @@ packages:
     dependencies:
       '@babel/core': 7.18.9
       '@babel/helper-plugin-utils': 7.19.0
+
+  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.19.3:
+    resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
+    dev: true
 
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.18.9:
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
@@ -1717,6 +1792,15 @@ packages:
       '@babel/core': 7.18.9
       '@babel/helper-plugin-utils': 7.19.0
 
+  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.19.3:
+    resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
+    dev: true
+
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.18.9:
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
     peerDependencies:
@@ -1724,6 +1808,15 @@ packages:
     dependencies:
       '@babel/core': 7.18.9
       '@babel/helper-plugin-utils': 7.19.0
+
+  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.19.3:
+    resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
+    dev: true
 
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.18.9:
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
@@ -1733,6 +1826,15 @@ packages:
       '@babel/core': 7.18.9
       '@babel/helper-plugin-utils': 7.19.0
 
+  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.19.3:
+    resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
+    dev: true
+
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.18.9:
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
     peerDependencies:
@@ -1740,6 +1842,15 @@ packages:
     dependencies:
       '@babel/core': 7.18.9
       '@babel/helper-plugin-utils': 7.19.0
+
+  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.19.3:
+    resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
+    dev: true
 
   /@babel/plugin-syntax-private-property-in-object/7.14.5_@babel+core@7.18.9:
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
@@ -1759,6 +1870,16 @@ packages:
       '@babel/core': 7.18.9
       '@babel/helper-plugin-utils': 7.19.0
 
+  /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.19.3:
+    resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.19.3
+      '@babel/helper-plugin-utils': 7.19.0
+    dev: true
+
   /@babel/plugin-syntax-typescript/7.18.6_@babel+core@7.18.9:
     resolution: {integrity: sha512-mAWAuq4rvOepWCBid55JuRNvpTNf2UGVgoz4JV0fXEKolsVZDzsa4NqCef758WZJj/GDu0gVGItjKFiClTAmZA==}
     engines: {node: '>=6.9.0'}
@@ -1766,6 +1887,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.9
+      '@babel/helper-plugin-utils': 7.19.0
+    dev: true
+
+  /@babel/plugin-syntax-typescript/7.18.6_@babel+core@7.19.3:
+    resolution: {integrity: sha512-mAWAuq4rvOepWCBid55JuRNvpTNf2UGVgoz4JV0fXEKolsVZDzsa4NqCef758WZJj/GDu0gVGItjKFiClTAmZA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.19.3
       '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
@@ -2437,8 +2568,8 @@ packages:
     resolution: {integrity: sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.16.7
-      '@babel/parser': 7.18.4
+      '@babel/code-frame': 7.18.6
+      '@babel/parser': 7.19.4
       '@babel/types': 7.19.4
 
   /@babel/template/7.18.10:
@@ -2448,7 +2579,6 @@ packages:
       '@babel/code-frame': 7.18.6
       '@babel/parser': 7.19.4
       '@babel/types': 7.19.4
-    dev: true
 
   /@babel/template/7.18.6:
     resolution: {integrity: sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==}
@@ -2462,13 +2592,13 @@ packages:
     resolution: {integrity: sha512-9eNwoeovJ6KH9zcCNnENY7DMFwTU9JdGCFtqNLfUAqtUHRCOsTOqWoffosP8vKmNYeSBUv3yVJXjfd8ucwOjUA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.16.7
+      '@babel/code-frame': 7.18.6
       '@babel/generator': 7.19.5
       '@babel/helper-environment-visitor': 7.18.2
       '@babel/helper-function-name': 7.17.9
       '@babel/helper-hoist-variables': 7.16.7
       '@babel/helper-split-export-declaration': 7.16.7
-      '@babel/parser': 7.18.4
+      '@babel/parser': 7.19.4
       '@babel/types': 7.19.4
       debug: 4.3.4
       globals: 11.12.0
@@ -2485,7 +2615,7 @@ packages:
       '@babel/helper-function-name': 7.18.6
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.18.8
+      '@babel/parser': 7.19.4
       '@babel/types': 7.19.4
       debug: 4.3.4
       globals: 11.12.0
@@ -2526,7 +2656,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/types/7.18.4:
     resolution: {integrity: sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==}
@@ -2928,29 +3057,11 @@ packages:
     resolution: {integrity: sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==}
     dev: false
 
-  /@esbuild/android-arm/0.15.11:
-    resolution: {integrity: sha512-PzMcQLazLBkwDEkrNPi9AbjFt6+3I7HKbiYF2XtWQ7wItrHvEOeO3T8Am434zAozWtVP7lrTue1bEfc2nYWeCA==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/android-arm/0.15.12:
     resolution: {integrity: sha512-IC7TqIqiyE0MmvAhWkl/8AEzpOtbhRNDo7aph47We1NbE5w2bt/Q+giAhe0YYeVpYnIhGMcuZY92qDK6dQauvA==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-loong64/0.15.11:
-    resolution: {integrity: sha512-geWp637tUhNmhL3Xgy4Bj703yXB9dqiLJe05lCUfjSFDrQf9C/8pArusyPUbUbPwlC/EAUjBw32sxuIl/11dZw==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
     requiresBuild: true
     dev: true
     optional: true
@@ -3087,6 +3198,16 @@ packages:
       jest-mock: 28.1.0
     dev: true
 
+  /@jest/environment/28.1.3:
+    resolution: {integrity: sha512-1bf40cMFTEkKyEf585R9Iz1WayDjHoHqvts0XFYEqyKM3cFWDpeMoqKKTAF9LSYQModPUlh8FKptoM2YcMWAXA==}
+    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    dependencies:
+      '@jest/fake-timers': 28.1.3
+      '@jest/types': 28.1.3
+      '@types/node': 17.0.39
+      jest-mock: 28.1.3
+    dev: true
+
   /@jest/expect-utils/28.1.0:
     resolution: {integrity: sha512-5BrG48dpC0sB80wpeIX5FU6kolDJI4K0n5BM9a5V38MGx0pyRvUBSS0u2aNTdDzmOrCjhOg8pGs6a20ivYkdmw==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
@@ -3114,6 +3235,18 @@ packages:
       jest-message-util: 28.1.0
       jest-mock: 28.1.0
       jest-util: 28.1.0
+    dev: true
+
+  /@jest/fake-timers/28.1.3:
+    resolution: {integrity: sha512-D/wOkL2POHv52h+ok5Oj/1gOG9HSywdoPtFsRCUmlCILXNn5eIWmcnd3DIiWlJnpGvQtmajqBP95Ei0EimxfLw==}
+    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    dependencies:
+      '@jest/types': 28.1.3
+      '@sinonjs/fake-timers': 9.1.2
+      '@types/node': 17.0.39
+      jest-message-util: 28.1.3
+      jest-mock: 28.1.3
+      jest-util: 28.1.3
     dev: true
 
   /@jest/globals/28.1.0:
@@ -3171,6 +3304,13 @@ packages:
       '@sinclair/typebox': 0.23.5
     dev: true
 
+  /@jest/schemas/28.1.3:
+    resolution: {integrity: sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    dependencies:
+      '@sinclair/typebox': 0.24.48
+    dev: true
+
   /@jest/source-map/28.0.2:
     resolution: {integrity: sha512-Y9dxC8ZpN3kImkk0LkK5XCEneYMAXlZ8m5bflmSL5vrwyeUpJfentacCUg6fOb8NOpOO7hz2+l37MV77T6BFPw==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
@@ -3204,7 +3344,7 @@ packages:
     resolution: {integrity: sha512-omy2xe5WxlAfqmsTjTPxw+iXRTRnf+NtX0ToG+4S0tABeb4KsKmPUHq5UBuwunHg3tJRwgEQhEp0M/8oiatLEA==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
-      '@babel/core': 7.18.9
+      '@babel/core': 7.19.3
       '@jest/types': 28.1.0
       '@jridgewell/trace-mapping': 0.3.13
       babel-plugin-istanbul: 6.1.1
@@ -3228,6 +3368,18 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/schemas': 28.0.2
+      '@types/istanbul-lib-coverage': 2.0.4
+      '@types/istanbul-reports': 3.0.1
+      '@types/node': 17.0.39
+      '@types/yargs': 17.0.10
+      chalk: 4.1.2
+    dev: true
+
+  /@jest/types/28.1.3:
+    resolution: {integrity: sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==}
+    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    dependencies:
+      '@jest/schemas': 28.1.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
       '@types/node': 17.0.39
@@ -3448,6 +3600,10 @@ packages:
     resolution: {integrity: sha512-AFBVi/iT4g20DHoujvMH1aEDn8fGJh4xsRGCP6d8RpLPMqsNPvW01Jcn0QysXTsg++/xj25NmJsGyH9xug/wKg==}
     dev: true
 
+  /@sinclair/typebox/0.24.48:
+    resolution: {integrity: sha512-WPGpRNHbkOsfBDmh8QHU7a5NWzEuYNThST8x1cISvX0RpP+1+V8zjuJqNwGJkHGIlhdIIhv6qVYqXz2q5/gjAA==}
+    dev: true
+
   /@sinonjs/commons/1.8.3:
     resolution: {integrity: sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==}
     dependencies:
@@ -3465,10 +3621,15 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
+  /@tootallnate/once/2.0.0:
+    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+    engines: {node: '>= 10'}
+    dev: true
+
   /@types/babel__core/7.1.19:
     resolution: {integrity: sha512-WEOTgRsbYkvA/KCsDwVEGkd7WAr1e3g31VHQ8zy5gul/V1qKullU/BU5I68X5v7V3GnB9eotmom4v5a5gjxorw==}
     dependencies:
-      '@babel/parser': 7.18.9
+      '@babel/parser': 7.19.4
       '@babel/types': 7.18.9
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
@@ -3634,6 +3795,22 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
+  /@types/jsdom/16.2.15:
+    resolution: {integrity: sha512-nwF87yjBKuX/roqGYerZZM0Nv1pZDMAT5YhOHYeM/72Fic+VEqJh4nyoqoapzJnW3pUlfxPY5FhgsJtM+dRnQQ==}
+    dependencies:
+      '@types/node': 17.0.39
+      '@types/parse5': 6.0.3
+      '@types/tough-cookie': 4.0.2
+    dev: true
+
+  /@types/jsdom/20.0.0:
+    resolution: {integrity: sha512-YfAchFs0yM1QPDrLm2VHe+WHGtqms3NXnXAMolrgrVP6fgBHHXy1ozAbo/dFtPNtZC/m66bPiCTWYmqp1F14gA==}
+    dependencies:
+      '@types/node': 17.0.39
+      '@types/tough-cookie': 4.0.2
+      parse5: 7.1.1
+    dev: true
+
   /@types/json-schema/7.0.11:
     resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
     dev: true
@@ -3697,6 +3874,10 @@ packages:
 
   /@types/parse-json/4.0.0:
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
+
+  /@types/parse5/6.0.3:
+    resolution: {integrity: sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==}
+    dev: true
 
   /@types/parsimmon/1.10.6:
     resolution: {integrity: sha512-FwAQwMRbkhx0J6YELkwIpciVzCcgEqXEbIrIn3a2P5d3kGEHQ3wVhlN3YdVepYP+bZzCYO6OjmD4o9TGOZ40rA==}
@@ -3787,6 +3968,10 @@ packages:
 
   /@types/tapable/1.0.8:
     resolution: {integrity: sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==}
+    dev: true
+
+  /@types/tough-cookie/4.0.2:
+    resolution: {integrity: sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==}
     dev: true
 
   /@types/uglify-js/3.13.3:
@@ -4140,12 +4325,30 @@ packages:
       through: 2.3.8
     dev: true
 
+  /abab/2.0.6:
+    resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
+    dev: true
+
   /accepts/1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
     dependencies:
       mime-types: 2.1.35
       negotiator: 0.6.3
+
+  /acorn-globals/6.0.0:
+    resolution: {integrity: sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==}
+    dependencies:
+      acorn: 7.4.1
+      acorn-walk: 7.2.0
+    dev: true
+
+  /acorn-globals/7.0.1:
+    resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
+    dependencies:
+      acorn: 8.8.0
+      acorn-walk: 8.2.0
+    dev: true
 
   /acorn-import-assertions/1.8.0_acorn@8.7.1:
     resolution: {integrity: sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==}
@@ -4163,8 +4366,30 @@ packages:
       acorn: 8.7.1
     dev: true
 
+  /acorn-walk/7.2.0:
+    resolution: {integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==}
+    engines: {node: '>=0.4.0'}
+    dev: true
+
+  /acorn-walk/8.2.0:
+    resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
+    engines: {node: '>=0.4.0'}
+    dev: true
+
+  /acorn/7.4.1:
+    resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
+
   /acorn/8.7.1:
     resolution: {integrity: sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
+
+  /acorn/8.8.0:
+    resolution: {integrity: sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
@@ -4488,6 +4713,24 @@ packages:
       - supports-color
     dev: true
 
+  /babel-jest/28.1.0_@babel+core@7.19.3:
+    resolution: {integrity: sha512-zNKk0yhDZ6QUwfxh9k07GII6siNGMJWVUU49gmFj5gfdqDKLqa2RArXOF2CODp4Dr7dLxN2cvAV+667dGJ4b4w==}
+    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    peerDependencies:
+      '@babel/core': ^7.8.0
+    dependencies:
+      '@babel/core': 7.19.3
+      '@jest/transform': 28.1.0
+      '@types/babel__core': 7.1.19
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 28.0.2_@babel+core@7.19.3
+      chalk: 4.1.2
+      graceful-fs: 4.2.10
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /babel-loader/8.2.5_fswvdo7jykdwhfxrdcvghfn6pa:
     resolution: {integrity: sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==}
     engines: {node: '>= 8.9'}
@@ -4558,10 +4801,32 @@ packages:
     resolution: {integrity: sha512-Kizhn/ZL+68ZQHxSnHyuvJv8IchXD62KQxV77TBDV/xoBFBOfgRAk97GNs6hXdTTCiVES9nB2I6+7MXXrk5llQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
-      '@babel/template': 7.16.7
+      '@babel/template': 7.18.10
       '@babel/types': 7.19.4
       '@types/babel__core': 7.1.19
       '@types/babel__traverse': 7.17.1
+    dev: true
+
+  /babel-plugin-jest-hoist/28.1.3:
+    resolution: {integrity: sha512-Ys3tUKAmfnkRUpPdpa98eYrAR0nV+sSFUZZEGuQ2EbFd1y4SOLtD5QDNHAq+bb9a+bbXvYQC4b+ID/THIMcU6Q==}
+    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    dependencies:
+      '@babel/template': 7.18.10
+      '@babel/types': 7.19.4
+      '@types/babel__core': 7.1.19
+      '@types/babel__traverse': 7.17.1
+    dev: true
+
+  /babel-plugin-jsx-dom-expressions/0.35.1_@babel+core@7.19.3:
+    resolution: {integrity: sha512-OnSFhoYE+tfuhiNCBtC4ZZvc/4kuEaJzhVnH/FfNVkCIGCPr+lG8PLeeFejkW8GSY88Ryt9T75TFABNb7y405g==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.19.3
+      '@babel/helper-module-imports': 7.16.0
+      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.19.3
+      '@babel/types': 7.19.4
+      html-entities: 2.3.2
     dev: true
 
   /babel-plugin-module-resolver/4.1.0:
@@ -4640,6 +4905,26 @@ packages:
       '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.18.9
     dev: true
 
+  /babel-preset-current-node-syntax/1.0.1_@babel+core@7.19.3:
+    resolution: {integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.19.3
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.19.3
+      '@babel/plugin-syntax-bigint': 7.8.3_@babel+core@7.19.3
+      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.19.3
+      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.19.3
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.19.3
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.19.3
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.19.3
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.19.3
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.19.3
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.19.3
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.19.3
+      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.19.3
+    dev: true
+
   /babel-preset-jest/28.0.2_@babel+core@7.18.9:
     resolution: {integrity: sha512-sYzXIdgIXXroJTFeB3S6sNDWtlJ2dllCdTEsnZ65ACrMojj3hVNFRmnJ1HZtomGi+Be7aqpY/HJ92fr8OhKVkQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
@@ -4649,6 +4934,37 @@ packages:
       '@babel/core': 7.18.9
       babel-plugin-jest-hoist: 28.0.2
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.18.9
+    dev: true
+
+  /babel-preset-jest/28.0.2_@babel+core@7.19.3:
+    resolution: {integrity: sha512-sYzXIdgIXXroJTFeB3S6sNDWtlJ2dllCdTEsnZ65ACrMojj3hVNFRmnJ1HZtomGi+Be7aqpY/HJ92fr8OhKVkQ==}
+    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.19.3
+      babel-plugin-jest-hoist: 28.0.2
+      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.19.3
+    dev: true
+
+  /babel-preset-jest/28.1.3_@babel+core@7.19.3:
+    resolution: {integrity: sha512-L+fupJvlWAHbQfn74coNX3zf60LXMJsezNvvx8eIh7iOR1luJ1poxYgQk1F8PYtNq/6QODDHCqsSnTFSWC491A==}
+    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.19.3
+      babel-plugin-jest-hoist: 28.1.3
+      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.19.3
+    dev: true
+
+  /babel-preset-solid/1.6.0_@babel+core@7.19.3:
+    resolution: {integrity: sha512-Unv2mU+H+AQ0PiGMlwywqAJqmDRZy8kfRkTDnTup3SYIp1UFkP5KcHg76O/2+wZ7mEgY071BsgeVcV1Cw96Fvg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.19.3
+      babel-plugin-jsx-dom-expressions: 0.35.1_@babel+core@7.19.3
     dev: true
 
   /babel-runtime/6.26.0:
@@ -4765,6 +5081,10 @@ packages:
     resolution: {integrity: sha512-ex5W9DoOQ/LUEU3PMdLs9ua/CYZl1678NUkKOdUSi8Aw5F1idieaiRURCBFJCwVcrD1J8Iy3vfWSloaMwO2qFg==}
     dependencies:
       wcwidth: 1.0.1
+    dev: true
+
+  /browser-process-hrtime/1.0.0:
+    resolution: {integrity: sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==}
     dev: true
 
   /browserslist/4.20.3:
@@ -5434,6 +5754,21 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  /cssom/0.3.8:
+    resolution: {integrity: sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==}
+    dev: true
+
+  /cssom/0.5.0:
+    resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
+    dev: true
+
+  /cssstyle/2.3.0:
+    resolution: {integrity: sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==}
+    engines: {node: '>=8'}
+    dependencies:
+      cssom: 0.3.8
+    dev: true
+
   /csstype/3.1.0:
     resolution: {integrity: sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==}
 
@@ -5481,6 +5816,15 @@ packages:
       assert-plus: 1.0.0
     dev: true
 
+  /data-urls/3.0.2:
+    resolution: {integrity: sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      abab: 2.0.6
+      whatwg-mimetype: 3.0.0
+      whatwg-url: 11.0.0
+    dev: true
+
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -5523,6 +5867,10 @@ packages:
   /decamelize/1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
+
+  /decimal.js/10.4.2:
+    resolution: {integrity: sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA==}
+    dev: true
 
   /dedent/0.7.0:
     resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
@@ -5681,6 +6029,13 @@ packages:
       esutils: 2.0.3
     dev: true
 
+  /domexception/4.0.0:
+    resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
+    engines: {node: '>=12'}
+    dependencies:
+      webidl-conversions: 7.0.0
+    dev: true
+
   /dot-prop/3.0.0:
     resolution: {integrity: sha512-k4ELWeEU3uCcwub7+dWydqQBRjAjkV9L33HjVRG5Xo2QybI6ja/v+4W73SRi8ubCqJz0l9XsTP1NbewfyqaSlw==}
     engines: {node: '>=0.10.0'}
@@ -5800,6 +6155,11 @@ packages:
       ansi-colors: 4.1.3
     dev: true
 
+  /entities/4.4.0:
+    resolution: {integrity: sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==}
+    engines: {node: '>=0.12'}
+    dev: true
+
   /envinfo/7.8.1:
     resolution: {integrity: sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==}
     engines: {node: '>=4'}
@@ -5875,15 +6235,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-android-64/0.15.11:
-    resolution: {integrity: sha512-rrwoXEiuI1kaw4k475NJpexs8GfJqQUKcD08VR8sKHmuW9RUuTR2VxcupVvHdiGh9ihxL9m3lpqB1kju92Ialw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-android-64/0.15.12:
     resolution: {integrity: sha512-MJKXwvPY9g0rGps0+U65HlTsM1wUs9lbjt5CU19RESqycGFDRijMDQsh68MtbzkqWSRdEtiKS1mtPzKneaAI0Q==}
     engines: {node: '>=12'}
@@ -5895,15 +6246,6 @@ packages:
 
   /esbuild-android-arm64/0.14.48:
     resolution: {integrity: sha512-vptI3K0wGALiDq+EvRuZotZrJqkYkN5282iAfcffjI5lmGG9G1ta/CIVauhY42MBXwEgDJkweiDcDMRLzBZC4g==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-android-arm64/0.15.11:
-    resolution: {integrity: sha512-/hDubOg7BHOhUUsT8KUIU7GfZm5bihqssvqK5PfO4apag7YuObZRZSzViyEKcFn2tPeHx7RKbSBXvAopSHDZJQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -5929,15 +6271,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-darwin-64/0.15.11:
-    resolution: {integrity: sha512-1DqHD0ms3AhiwkKnjRUzmiW7JnaJJr5FKrPiR7xuyMwnjDqvNWDdMq4rKSD9OC0piFNK6n0LghsglNMe2MwJtA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-darwin-64/0.15.12:
     resolution: {integrity: sha512-qkmqrTVYPFiePt5qFjP8w/S+GIUMbt6k8qmiPraECUWfPptaPJUGkCKrWEfYFRWB7bY23FV95rhvPyh/KARP8Q==}
     engines: {node: '>=12'}
@@ -5949,15 +6282,6 @@ packages:
 
   /esbuild-darwin-arm64/0.14.48:
     resolution: {integrity: sha512-bFjnNEXjhZT+IZ8RvRGNJthLWNHV5JkCtuOFOnjvo5pC0sk2/QVk0Qc06g2PV3J0TcU6kaPC3RN9yy9w2PSLEA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-darwin-arm64/0.15.11:
-    resolution: {integrity: sha512-OMzhxSbS0lwwrW40HHjRCeVIJTURdXFA8c3GU30MlHKuPCcvWNUIKVucVBtNpJySXmbkQMDJdJNrXzNDyvoqvQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -5983,15 +6307,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-freebsd-64/0.15.11:
-    resolution: {integrity: sha512-8dKP26r0/Qyez8nTCwpq60QbuYKOeBygdgOAWGCRalunyeqWRoSZj9TQjPDnTTI9joxd3QYw3UhVZTKxO9QdRg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-freebsd-64/0.15.12:
     resolution: {integrity: sha512-XFL7gKMCKXLDiAiBjhLG0XECliXaRLTZh6hsyzqUqPUf/PY4C6EJDTKIeqqPKXaVJ8+fzNek88285krSz1QECw==}
     engines: {node: '>=12'}
@@ -6003,15 +6318,6 @@ packages:
 
   /esbuild-freebsd-arm64/0.14.48:
     resolution: {integrity: sha512-gXqKdO8wabVcYtluAbikDH2jhXp+Klq5oCD5qbVyUG6tFiGhrC9oczKq3vIrrtwcxDQqK6+HDYK8Zrd4bCA9Gw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-freebsd-arm64/0.15.11:
-    resolution: {integrity: sha512-aSGiODiukLGGnSg/O9+cGO2QxEacrdCtCawehkWYTt5VX1ni2b9KoxpHCT9h9Y6wGqNHmXFnB47RRJ8BIqZgmQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -6037,15 +6343,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-32/0.15.11:
-    resolution: {integrity: sha512-lsrAfdyJBGx+6aHIQmgqUonEzKYeBnyfJPkT6N2dOf1RoXYYV1BkWB6G02tjsrz1d5wZzaTc3cF+TKmuTo/ZwA==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-linux-32/0.15.12:
     resolution: {integrity: sha512-uSQuSEyF1kVzGzuIr4XM+v7TPKxHjBnLcwv2yPyCz8riV8VUCnO/C4BF3w5dHiVpCd5Z1cebBtZJNlC4anWpwA==}
     engines: {node: '>=12'}
@@ -6057,15 +6354,6 @@ packages:
 
   /esbuild-linux-64/0.14.48:
     resolution: {integrity: sha512-vni3p/gppLMVZLghI7oMqbOZdGmLbbKR23XFARKnszCIBpEMEDxOMNIKPmMItQrmH/iJrL1z8Jt2nynY0bE1ug==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-64/0.15.11:
-    resolution: {integrity: sha512-Y2Rh+PcyVhQqXKBTacPCltINN3uIw2xC+dsvLANJ1SpK5NJUtxv8+rqWpjmBgaNWKQT1/uGpMmA9olALy9PLVA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -6091,15 +6379,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-arm/0.15.11:
-    resolution: {integrity: sha512-TJllTVk5aSyqPFvvcHTvf6Wu1ZKhWpJ/qNmZO8LL/XeB+LXCclm7HQHNEIz6MT7IX8PmlC1BZYrOiw2sXSB95A==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-linux-arm/0.15.12:
     resolution: {integrity: sha512-Wf7T0aNylGcLu7hBnzMvsTfEXdEdJY/hY3u36Vla21aY66xR0MS5I1Hw8nVquXjTN0A6fk/vnr32tkC/C2lb0A==}
     engines: {node: '>=12'}
@@ -6111,15 +6390,6 @@ packages:
 
   /esbuild-linux-arm64/0.14.48:
     resolution: {integrity: sha512-3CFsOlpoxlKPRevEHq8aAntgYGYkE1N9yRYAcPyng/p4Wyx0tPR5SBYsxLKcgPB9mR8chHEhtWYz6EZ+H199Zw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-arm64/0.15.11:
-    resolution: {integrity: sha512-uhcXiTwTmD4OpxJu3xC5TzAAw6Wzf9O1XGWL448EE9bqGjgV1j+oK3lIHAfsHnuIn8K4nDW8yjX0Sv5S++oRuw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -6145,15 +6415,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-mips64le/0.15.11:
-    resolution: {integrity: sha512-WD61y/R1M4BLe4gxXRypoQ0Ci+Vjf714QYzcPNkiYv5I8K8WDz2ZR8Bm6cqKxd6rD+e/rZgPDbhQ9PCf7TMHmA==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-linux-mips64le/0.15.12:
     resolution: {integrity: sha512-Qol3+AvivngUZkTVFgLpb0H6DT+N5/zM3V1YgTkryPYFeUvuT5JFNDR3ZiS6LxhyF8EE+fiNtzwlPqMDqVcc6A==}
     engines: {node: '>=12'}
@@ -6165,15 +6426,6 @@ packages:
 
   /esbuild-linux-ppc64le/0.14.48:
     resolution: {integrity: sha512-+2F0vJMkuI0Wie/wcSPDCqXvSFEELH7Jubxb7mpWrA/4NpT+/byjxDz0gG6R1WJoeDefcrMfpBx4GFNN1JQorQ==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-ppc64le/0.15.11:
-    resolution: {integrity: sha512-JVleZS9oPVLTlBhPTWgOwxFWU/wMUdlBwTbGA4GF8c38sLbS13cupj+C8bLq929jU7EMWry4SaL+tKGIaTlqKg==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -6199,15 +6451,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-riscv64/0.15.11:
-    resolution: {integrity: sha512-9aLIalZ2HFHIOZpmVU11sEAS9F8TnHw49daEjcgMpBXHFF57VuT9f9/9LKJhw781Gda0P9jDkuCWJ0tFbErvJw==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-linux-riscv64/0.15.12:
     resolution: {integrity: sha512-G9w6NcuuCI6TUUxe6ka0enjZHDnSVK8bO+1qDhMOCtl7Tr78CcZilJj8SGLN00zO5iIlwNRZKHjdMpfFgNn1VA==}
     engines: {node: '>=12'}
@@ -6219,15 +6462,6 @@ packages:
 
   /esbuild-linux-s390x/0.14.48:
     resolution: {integrity: sha512-tndw/0B9jiCL+KWKo0TSMaUm5UWBLsfCKVdbfMlb3d5LeV9WbijZ8Ordia8SAYv38VSJWOEt6eDCdOx8LqkC4g==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-s390x/0.15.11:
-    resolution: {integrity: sha512-sZHtiXXOKsLI3XGBGoYO4qKBzJlb8xNsWmvFiwFMHFzA4AXgDP1KDp7Dawe9C2pavTRBDvl+Ok4n/DHQ59oaTg==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -6253,15 +6487,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-netbsd-64/0.15.11:
-    resolution: {integrity: sha512-hUC9yN06K9sg7ju4Vgu9ChAPdsEgtcrcLfyNT5IKwKyfpLvKUwCMZSdF+gRD3WpyZelgTQfJ+pDx5XFbXTlB0A==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-netbsd-64/0.15.12:
     resolution: {integrity: sha512-jlUxCiHO1dsqoURZDQts+HK100o0hXfi4t54MNRMCAqKGAV33JCVvMplLAa2FwviSojT/5ZG5HUfG3gstwAG8w==}
     engines: {node: '>=12'}
@@ -6273,15 +6498,6 @@ packages:
 
   /esbuild-openbsd-64/0.14.48:
     resolution: {integrity: sha512-+IHf4JcbnnBl4T52egorXMatil/za0awqzg2Vy6FBgPcBpisDWT2sVz/tNdrK9kAqj+GZG/jZdrOkj7wsrNTKA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-openbsd-64/0.15.11:
-    resolution: {integrity: sha512-0bBo9SQR4t66Wd91LGMAqmWorzO0TTzVjYiifwoFtel8luFeXuPThQnEm5ztN4g0fnvcp7AnUPPzS/Depf17wQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -6307,15 +6523,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-sunos-64/0.15.11:
-    resolution: {integrity: sha512-EuBdTGlsMTjEl1sQnBX2jfygy7iR6CKfvOzi+gEOfhDqbHXsmY1dcpbVtcwHAg9/2yUZSfMJHMAgf1z8M4yyyw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-sunos-64/0.15.12:
     resolution: {integrity: sha512-nkl251DpoWoBO9Eq9aFdoIt2yYmp4I3kvQjba3jFKlMXuqQ9A4q+JaqdkCouG3DHgAGnzshzaGu6xofGcXyPXg==}
     engines: {node: '>=12'}
@@ -6327,15 +6534,6 @@ packages:
 
   /esbuild-windows-32/0.14.48:
     resolution: {integrity: sha512-EPgRuTPP8vK9maxpTGDe5lSoIBHGKO/AuxDncg5O3NkrPeLNdvvK8oywB0zGaAZXxYWfNNSHskvvDgmfVTguhg==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-windows-32/0.15.11:
-    resolution: {integrity: sha512-O0/Wo1Wk6dc0rZSxkvGpmTNIycEznHmkObTFz2VHBhjPsO4ZpCgfGxNkCpz4AdAIeMczpTXt/8d5vdJNKEGC+Q==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -6361,15 +6559,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-windows-64/0.15.11:
-    resolution: {integrity: sha512-x977Q4HhNjnHx00b4XLAnTtj5vfbdEvkxaQwC1Zh5AN8g5EX+izgZ6e5QgqJgpzyRNJqh4hkgIJF1pyy1be0mQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-windows-64/0.15.12:
     resolution: {integrity: sha512-VActO3WnWZSN//xjSfbiGOSyC+wkZtI8I4KlgrTo5oHJM6z3MZZBCuFaZHd8hzf/W9KPhF0lY8OqlmWC9HO5AA==}
     engines: {node: '>=12'}
@@ -6381,15 +6570,6 @@ packages:
 
   /esbuild-windows-arm64/0.14.48:
     resolution: {integrity: sha512-HHaOMCsCXp0rz5BT2crTka6MPWVno121NKApsGs/OIW5QC0ggC69YMGs1aJct9/9FSUF4A1xNE/cLvgB5svR4g==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-windows-arm64/0.15.11:
-    resolution: {integrity: sha512-VwUHFACuBahrvntdcMKZteUZ9HaYrBRODoKe4tIWxguQRvvYoYb7iu5LrcRS/FQx8KPZNaa72zuqwVtHeXsITw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -6438,36 +6618,6 @@ packages:
       esbuild-windows-32: 0.14.48
       esbuild-windows-64: 0.14.48
       esbuild-windows-arm64: 0.14.48
-    dev: true
-
-  /esbuild/0.15.11:
-    resolution: {integrity: sha512-OgHGuhlfZ//mToxjte1D5iiiQgWfJ2GByVMwEC/IuoXsBGkuyK1+KrjYu0laSpnN/L1UmLUCv0s25vObdc1bVg==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/android-arm': 0.15.11
-      '@esbuild/linux-loong64': 0.15.11
-      esbuild-android-64: 0.15.11
-      esbuild-android-arm64: 0.15.11
-      esbuild-darwin-64: 0.15.11
-      esbuild-darwin-arm64: 0.15.11
-      esbuild-freebsd-64: 0.15.11
-      esbuild-freebsd-arm64: 0.15.11
-      esbuild-linux-32: 0.15.11
-      esbuild-linux-64: 0.15.11
-      esbuild-linux-arm: 0.15.11
-      esbuild-linux-arm64: 0.15.11
-      esbuild-linux-mips64le: 0.15.11
-      esbuild-linux-ppc64le: 0.15.11
-      esbuild-linux-riscv64: 0.15.11
-      esbuild-linux-s390x: 0.15.11
-      esbuild-netbsd-64: 0.15.11
-      esbuild-openbsd-64: 0.15.11
-      esbuild-sunos-64: 0.15.11
-      esbuild-windows-32: 0.15.11
-      esbuild-windows-64: 0.15.11
-      esbuild-windows-arm64: 0.15.11
     dev: true
 
   /esbuild/0.15.12:
@@ -6519,6 +6669,19 @@ packages:
   /escape-string-regexp/4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+    dev: true
+
+  /escodegen/2.0.0:
+    resolution: {integrity: sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==}
+    engines: {node: '>=6.0'}
+    hasBin: true
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+      optionator: 0.8.3
+    optionalDependencies:
+      source-map: 0.6.1
     dev: true
 
   /eslint-config-airbnb-base/15.0.0_btspkuwbqkl4adpiufzbathtpi:
@@ -6916,8 +7079,8 @@ packages:
       '@jest/expect-utils': 28.1.0
       jest-get-type: 28.0.2
       jest-matcher-utils: 28.1.0
-      jest-message-util: 28.1.0
-      jest-util: 28.1.0
+      jest-message-util: 28.1.3
+      jest-util: 28.1.3
     dev: true
 
   /express/4.18.1:
@@ -7170,6 +7333,15 @@ packages:
   /form-data/2.3.3:
     resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
     engines: {node: '>= 0.12'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+    dev: true
+
+  /form-data/4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -7602,6 +7774,17 @@ packages:
       wbuf: 1.7.3
     dev: true
 
+  /html-encoding-sniffer/3.0.0:
+    resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
+    engines: {node: '>=12'}
+    dependencies:
+      whatwg-encoding: 2.0.0
+    dev: true
+
+  /html-entities/2.3.2:
+    resolution: {integrity: sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ==}
+    dev: true
+
   /html-entities/2.3.3:
     resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
     dev: true
@@ -7666,6 +7849,17 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       '@tootallnate/once': 1.1.2
+      agent-base: 6.0.2
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /http-proxy-agent/5.0.0:
+    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
+    engines: {node: '>= 6'}
+    dependencies:
+      '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
       debug: 4.3.4
     transitivePeerDependencies:
@@ -7750,6 +7944,13 @@ packages:
 
   /iconv-lite/0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      safer-buffer: 2.1.2
+    dev: true
+
+  /iconv-lite/0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
@@ -8105,6 +8306,10 @@ packages:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
 
+  /is-potential-custom-element-name/1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+    dev: true
+
   /is-redirect/1.0.0:
     resolution: {integrity: sha512-cr/SlUEe5zOGmzvj9bUyC4LVvkNVAXu4GytXLNMr1pny+a65MpQ9IJzFHD5vi7FyJgb4qt27+eS3TuQnqB+RQw==}
     engines: {node: '>=0.10.0'}
@@ -8226,8 +8431,8 @@ packages:
     resolution: {integrity: sha512-6Lthe1hqXHBNsqvgDzGO6l03XNeu3CrG4RqQ1KM9+l5+jNGpEJfIELx1NS3SEHmJQA8np/u+E4EPRKRiu6m19A==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/core': 7.18.9
-      '@babel/parser': 7.18.4
+      '@babel/core': 7.19.3
+      '@babel/parser': 7.19.4
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.0
@@ -8275,10 +8480,10 @@ packages:
     resolution: {integrity: sha512-rNYfqfLC0L0zQKRKsg4n4J+W1A2fbyGH7Ss/kDIocp9KXD9iaL111glsLu7+Z7FHuZxwzInMDXq+N1ZIBkI/TQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
-      '@jest/environment': 28.1.0
+      '@jest/environment': 28.1.3
       '@jest/expect': 28.1.0
       '@jest/test-result': 28.1.0
-      '@jest/types': 28.1.0
+      '@jest/types': 28.1.3
       '@types/node': 17.0.39
       chalk: 4.1.2
       co: 4.6.0
@@ -8286,10 +8491,10 @@ packages:
       is-generator-fn: 2.1.0
       jest-each: 28.1.0
       jest-matcher-utils: 28.1.0
-      jest-message-util: 28.1.0
+      jest-message-util: 28.1.3
       jest-runtime: 28.1.0
       jest-snapshot: 28.1.0
-      jest-util: 28.1.0
+      jest-util: 28.1.3
       pretty-format: 28.1.0
       slash: 3.0.0
       stack-utils: 2.0.5
@@ -8366,10 +8571,10 @@ packages:
       ts-node:
         optional: true
     dependencies:
-      '@babel/core': 7.18.9
+      '@babel/core': 7.19.3
       '@jest/test-sequencer': 28.1.0
       '@jest/types': 28.1.0
-      babel-jest: 28.1.0_@babel+core@7.18.9
+      babel-jest: 28.1.0_@babel+core@7.19.3
       chalk: 4.1.2
       ci-info: 3.3.1
       deepmerge: 4.2.2
@@ -8404,11 +8609,11 @@ packages:
       ts-node:
         optional: true
     dependencies:
-      '@babel/core': 7.18.9
+      '@babel/core': 7.19.3
       '@jest/test-sequencer': 28.1.0
       '@jest/types': 28.1.0
       '@types/node': 17.0.39
-      babel-jest: 28.1.0_@babel+core@7.18.9
+      babel-jest: 28.1.0_@babel+core@7.19.3
       chalk: 4.1.2
       ci-info: 3.3.1
       deepmerge: 4.2.2
@@ -8462,23 +8667,42 @@ packages:
     resolution: {integrity: sha512-a/XX02xF5NTspceMpHujmOexvJ4GftpYXqr6HhhmKmExtMXsyIN/fvanQlt/BcgFoRKN4OCXxLQKth9/n6OPFg==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
-      '@jest/types': 28.1.0
+      '@jest/types': 28.1.3
       chalk: 4.1.2
       jest-get-type: 28.0.2
-      jest-util: 28.1.0
+      jest-util: 28.1.3
       pretty-format: 28.1.0
+    dev: true
+
+  /jest-environment-jsdom/28.1.3:
+    resolution: {integrity: sha512-HnlGUmZRdxfCByd3GM2F100DgQOajUBzEitjGqIREcb45kGjZvRrKUdlaF6escXBdcXNl0OBh+1ZrfeZT3GnAg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    dependencies:
+      '@jest/environment': 28.1.3
+      '@jest/fake-timers': 28.1.3
+      '@jest/types': 28.1.3
+      '@types/jsdom': 16.2.15
+      '@types/node': 17.0.39
+      jest-mock: 28.1.3
+      jest-util: 28.1.3
+      jsdom: 19.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - utf-8-validate
     dev: true
 
   /jest-environment-node/28.1.0:
     resolution: {integrity: sha512-gBLZNiyrPw9CSMlTXF1yJhaBgWDPVvH0Pq6bOEwGMXaYNzhzhw2kA/OijNF8egbCgDS0/veRv97249x2CX+udQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
-      '@jest/environment': 28.1.0
-      '@jest/fake-timers': 28.1.0
-      '@jest/types': 28.1.0
+      '@jest/environment': 28.1.3
+      '@jest/fake-timers': 28.1.3
+      '@jest/types': 28.1.3
       '@types/node': 17.0.39
-      jest-mock: 28.1.0
-      jest-util: 28.1.0
+      jest-mock: 28.1.3
+      jest-util: 28.1.3
     dev: true
 
   /jest-get-type/27.5.1:
@@ -8495,14 +8719,14 @@ packages:
     resolution: {integrity: sha512-xyZ9sXV8PtKi6NCrJlmq53PyNVHzxmcfXNVvIRHpHmh1j/HChC4pwKgyjj7Z9us19JMw8PpQTJsFWOsIfT93Dw==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
-      '@jest/types': 28.1.0
+      '@jest/types': 28.1.3
       '@types/graceful-fs': 4.1.5
       '@types/node': 17.0.39
       anymatch: 3.1.2
       fb-watchman: 2.0.1
       graceful-fs: 4.2.10
       jest-regex-util: 28.0.2
-      jest-util: 28.1.0
+      jest-util: 28.1.3
       jest-worker: 28.1.0
       micromatch: 4.0.5
       walker: 1.0.8
@@ -8542,7 +8766,7 @@ packages:
     resolution: {integrity: sha512-RpA8mpaJ/B2HphDMiDlrAZdDytkmwFqgjDZovM21F35lHGeUeCvYmm6W+sbQ0ydaLpg5bFAUuWG1cjqOl8vqrw==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
-      '@babel/code-frame': 7.16.7
+      '@babel/code-frame': 7.18.6
       '@jest/types': 28.1.0
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
@@ -8553,11 +8777,34 @@ packages:
       stack-utils: 2.0.5
     dev: true
 
+  /jest-message-util/28.1.3:
+    resolution: {integrity: sha512-PFdn9Iewbt575zKPf1286Ht9EPoJmYT7P0kY+RibeYZ2XtOr53pDLEFoTWXbd1h4JiGiWpTBC84fc8xMXQMb7g==}
+    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    dependencies:
+      '@babel/code-frame': 7.18.6
+      '@jest/types': 28.1.3
+      '@types/stack-utils': 2.0.1
+      chalk: 4.1.2
+      graceful-fs: 4.2.10
+      micromatch: 4.0.5
+      pretty-format: 28.1.3
+      slash: 3.0.0
+      stack-utils: 2.0.5
+    dev: true
+
   /jest-mock/28.1.0:
     resolution: {integrity: sha512-H7BrhggNn77WhdL7O1apG0Q/iwl0Bdd5E1ydhCJzL3oBLh/UYxAwR3EJLsBZ9XA3ZU4PA3UNw4tQjduBTCTmLw==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.0
+      '@types/node': 17.0.39
+    dev: true
+
+  /jest-mock/28.1.3:
+    resolution: {integrity: sha512-o3J2jr6dMMWYVH4Lh/NKmDXdosrsJgi4AviS8oXLujcjpCMBb1FMsblDnOXKZKfSiHLxYub1eS0IHuRXsio9eA==}
+    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    dependencies:
+      '@jest/types': 28.1.3
       '@types/node': 17.0.39
     dev: true
 
@@ -8666,17 +8913,17 @@ packages:
     resolution: {integrity: sha512-ex49M2ZrZsUyQLpLGxQtDbahvgBjlLPgklkqGM0hq/F7W/f8DyqZxVHjdy19QKBm4O93eDp+H5S23EiTbbUmHw==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
-      '@babel/core': 7.18.9
+      '@babel/core': 7.19.3
       '@babel/generator': 7.19.5
-      '@babel/plugin-syntax-typescript': 7.18.6_@babel+core@7.18.9
-      '@babel/traverse': 7.18.2
+      '@babel/plugin-syntax-typescript': 7.18.6_@babel+core@7.19.3
+      '@babel/traverse': 7.19.4
       '@babel/types': 7.19.4
       '@jest/expect-utils': 28.1.0
       '@jest/transform': 28.1.0
       '@jest/types': 28.1.0
       '@types/babel__traverse': 7.17.1
       '@types/prettier': 2.6.3
-      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.18.9
+      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.19.3
       chalk: 4.1.2
       expect: 28.1.0
       graceful-fs: 4.2.10
@@ -8698,6 +8945,18 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.0
+      '@types/node': 17.0.39
+      chalk: 4.1.2
+      ci-info: 3.3.1
+      graceful-fs: 4.2.10
+      picomatch: 2.3.1
+    dev: true
+
+  /jest-util/28.1.3:
+    resolution: {integrity: sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==}
+    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    dependencies:
+      '@jest/types': 28.1.3
       '@types/node': 17.0.39
       chalk: 4.1.2
       ci-info: 3.3.1
@@ -8815,6 +9074,89 @@ packages:
 
   /jsbn/0.1.1:
     resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
+    dev: true
+
+  /jsdom/19.0.0:
+    resolution: {integrity: sha512-RYAyjCbxy/vri/CfnjUWJQQtZ3LKlLnDqj+9XLNnJPgEGeirZs3hllKR20re8LUZ6o1b1X4Jat+Qd26zmP41+A==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      canvas: ^2.5.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+    dependencies:
+      abab: 2.0.6
+      acorn: 8.8.0
+      acorn-globals: 6.0.0
+      cssom: 0.5.0
+      cssstyle: 2.3.0
+      data-urls: 3.0.2
+      decimal.js: 10.4.2
+      domexception: 4.0.0
+      escodegen: 2.0.0
+      form-data: 4.0.0
+      html-encoding-sniffer: 3.0.0
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.2
+      parse5: 6.0.1
+      saxes: 5.0.1
+      symbol-tree: 3.2.4
+      tough-cookie: 4.1.2
+      w3c-hr-time: 1.0.2
+      w3c-xmlserializer: 3.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 2.0.0
+      whatwg-mimetype: 3.0.0
+      whatwg-url: 10.0.0
+      ws: 8.9.0
+      xml-name-validator: 4.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /jsdom/20.0.1:
+    resolution: {integrity: sha512-pksjj7Rqoa+wdpkKcLzQRHhJCEE42qQhl/xLMUKHgoSejaKOdaXEAnqs6uDNwMl/fciHTzKeR8Wm8cw7N+g98A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      canvas: ^2.5.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+    dependencies:
+      abab: 2.0.6
+      acorn: 8.8.0
+      acorn-globals: 7.0.1
+      cssom: 0.5.0
+      cssstyle: 2.3.0
+      data-urls: 3.0.2
+      decimal.js: 10.4.2
+      domexception: 4.0.0
+      escodegen: 2.0.0
+      form-data: 4.0.0
+      html-encoding-sniffer: 3.0.0
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.2
+      parse5: 7.1.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 4.1.2
+      w3c-xmlserializer: 3.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 2.0.0
+      whatwg-mimetype: 3.0.0
+      whatwg-url: 11.0.0
+      ws: 8.9.0
+      xml-name-validator: 4.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
     dev: true
 
   /jsesc/0.5.0:
@@ -9053,6 +9395,14 @@ packages:
   /leven/3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
+    dev: true
+
+  /levn/0.3.0:
+    resolution: {integrity: sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      prelude-ls: 1.1.2
+      type-check: 0.3.2
     dev: true
 
   /levn/0.4.1:
@@ -9661,6 +10011,10 @@ packages:
     dev: true
     optional: true
 
+  /nwsapi/2.2.2:
+    resolution: {integrity: sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==}
+    dev: true
+
   /oauth-sign/0.9.0:
     resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
     dev: true
@@ -9765,6 +10119,18 @@ packages:
       define-lazy-prop: 2.0.0
       is-docker: 2.2.1
       is-wsl: 2.2.0
+    dev: true
+
+  /optionator/0.8.3:
+    resolution: {integrity: sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.3.0
+      prelude-ls: 1.1.2
+      type-check: 0.3.2
+      word-wrap: 1.2.3
     dev: true
 
   /optionator/0.9.1:
@@ -9910,6 +10276,16 @@ packages:
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  /parse5/6.0.1:
+    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
+    dev: true
+
+  /parse5/7.1.1:
+    resolution: {integrity: sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==}
+    dependencies:
+      entities: 4.4.0
+    dev: true
 
   /parseurl/1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -10174,6 +10550,11 @@ packages:
       which-pm: 2.0.0
     dev: true
 
+  /prelude-ls/1.1.2:
+    resolution: {integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==}
+    engines: {node: '>= 0.8.0'}
+    dev: true
+
   /prelude-ls/1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -10217,6 +10598,16 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/schemas': 28.0.2
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 18.1.0
+    dev: true
+
+  /pretty-format/28.1.3:
+    resolution: {integrity: sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==}
+    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    dependencies:
+      '@jest/schemas': 28.1.3
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 18.1.0
@@ -10308,6 +10699,10 @@ packages:
     resolution: {integrity: sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==}
     engines: {node: '>=0.4.x'}
     deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
+    dev: true
+
+  /querystringify/2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
     dev: true
 
   /queue-microtask/1.2.3:
@@ -10846,6 +11241,20 @@ packages:
 
   /safer-buffer/2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    dev: true
+
+  /saxes/5.0.1:
+    resolution: {integrity: sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==}
+    engines: {node: '>=10'}
+    dependencies:
+      xmlchars: 2.2.0
+    dev: true
+
+  /saxes/6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+    dependencies:
+      xmlchars: 2.2.0
     dev: true
 
   /scheduler/0.19.1:
@@ -11530,6 +11939,10 @@ packages:
   /svg-tags/1.0.0:
     resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
 
+  /symbol-tree/3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+    dev: true
+
   /syncpack/8.0.0:
     resolution: {integrity: sha512-/hiK6UXYM+ttfyonZ9WCPnm+ORTxAmzc5wlTwQfnw1nojHW19RVWCWBe5Z8G9HLbYzaBdVUCmvRCjNuqsU1YNw==}
     engines: {node: '>=10'}
@@ -11751,12 +12164,29 @@ packages:
       punycode: 2.1.1
     dev: true
 
+  /tough-cookie/4.1.2:
+    resolution: {integrity: sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==}
+    engines: {node: '>=6'}
+    dependencies:
+      psl: 1.8.0
+      punycode: 2.1.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+    dev: true
+
   /tr46/0.0.3:
     resolution: {integrity: sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=}
     dev: true
 
   /tr46/1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+    dependencies:
+      punycode: 2.1.1
+    dev: true
+
+  /tr46/3.0.0:
+    resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
+    engines: {node: '>=12'}
     dependencies:
       punycode: 2.1.1
     dev: true
@@ -12069,6 +12499,13 @@ packages:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
     dev: true
 
+  /type-check/0.3.2:
+    resolution: {integrity: sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      prelude-ls: 1.1.2
+    dev: true
+
   /type-check/0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -12163,6 +12600,11 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  /universalify/0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+    dev: true
+
   /universalify/2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
@@ -12219,6 +12661,13 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       prepend-http: 1.0.4
+    dev: true
+
+  /url-parse/1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
     dev: true
 
   /url/0.11.0:
@@ -12282,7 +12731,7 @@ packages:
     engines: {node: '>= 0.8'}
 
   /verror/1.10.0:
-    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
+    resolution: {integrity: sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=}
     engines: {'0': node >=0.6.0}
     dependencies:
       assert-plus: 1.0.0
@@ -12309,12 +12758,26 @@ packages:
       terser:
         optional: true
     dependencies:
-      esbuild: 0.15.11
+      esbuild: 0.15.12
       postcss: 8.4.16
       resolve: 1.22.1
       rollup: 2.78.1
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
+
+  /w3c-hr-time/1.0.2:
+    resolution: {integrity: sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==}
+    deprecated: Use your platform's native performance.now() and performance.timeOrigin.
+    dependencies:
+      browser-process-hrtime: 1.0.0
+    dev: true
+
+  /w3c-xmlserializer/3.0.0:
+    resolution: {integrity: sha512-3WFqGEgSXIyGhOmAFtlicJNMjEps8b1MG31NCA0/vOF9+nKMUW1ckhi9cnNHmf88Rzw5V+dwIwsm2C7X8k9aQg==}
+    engines: {node: '>=12'}
+    dependencies:
+      xml-name-validator: 4.0.0
     dev: true
 
   /walker/1.0.8:
@@ -12349,6 +12812,11 @@ packages:
 
   /webidl-conversions/4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+    dev: true
+
+  /webidl-conversions/7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
     dev: true
 
   /webpack-cli/4.9.2_hp63p7q42cvfilxmz3bdou5zeq:
@@ -12592,6 +13060,34 @@ packages:
     engines: {node: '>=0.8.0'}
     dev: true
 
+  /whatwg-encoding/2.0.0:
+    resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
+    engines: {node: '>=12'}
+    dependencies:
+      iconv-lite: 0.6.3
+    dev: true
+
+  /whatwg-mimetype/3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /whatwg-url/10.0.0:
+    resolution: {integrity: sha512-CLxxCmdUby142H5FZzn4D8ikO1cmypvXVQktsgosNy4a4BHrDHeciBBGZhb0bNoR5/MltoCatso+vFjjGx8t0w==}
+    engines: {node: '>=12'}
+    dependencies:
+      tr46: 3.0.0
+      webidl-conversions: 7.0.0
+    dev: true
+
+  /whatwg-url/11.0.0:
+    resolution: {integrity: sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      tr46: 3.0.0
+      webidl-conversions: 7.0.0
+    dev: true
+
   /whatwg-url/5.0.0:
     resolution: {integrity: sha1-lmRU6HZUYuN2RNNib2dCzotwll0=}
     dependencies:
@@ -12722,9 +13218,31 @@ packages:
         optional: true
     dev: true
 
+  /ws/8.9.0:
+    resolution: {integrity: sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: true
+
   /xdg-basedir/3.0.0:
     resolution: {integrity: sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=}
     engines: {node: '>=4'}
+    dev: true
+
+  /xml-name-validator/4.0.0:
+    resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /xmlchars/2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
     dev: true
 
   /y18n/4.0.3:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -518,6 +518,23 @@ importers:
       ts-jest: 28.0.4_ppxpzp26on3nfwb7yosvsqarey
       typescript: 4.7.4
 
+  packages/solid:
+    specifiers:
+      '@babel/types': ^7.18.9
+      '@linaria/core': workspace:^
+      '@linaria/tags': workspace:^
+      '@types/babel__core': ^7.1.19
+      '@types/node': ^17.0.39
+      solid-js: ^1.4.8
+    dependencies:
+      '@linaria/core': link:../core
+      '@linaria/tags': link:../tags
+    devDependencies:
+      '@babel/types': 7.18.9
+      '@types/babel__core': 7.1.19
+      '@types/node': 17.0.39
+      solid-js: 1.4.8
+
   packages/stylelint:
     specifiers:
       '@linaria/babel-preset': workspace:^
@@ -3451,7 +3468,7 @@ packages:
   /@types/babel__core/7.1.19:
     resolution: {integrity: sha512-WEOTgRsbYkvA/KCsDwVEGkd7WAr1e3g31VHQ8zy5gul/V1qKullU/BU5I68X5v7V3GnB9eotmom4v5a5gjxorw==}
     dependencies:
-      '@babel/parser': 7.18.4
+      '@babel/parser': 7.18.9
       '@babel/types': 7.18.9
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
@@ -11055,6 +11072,10 @@ packages:
       faye-websocket: 0.11.4
       uuid: 8.3.2
       websocket-driver: 0.7.4
+    dev: true
+
+  /solid-js/1.4.8:
+    resolution: {integrity: sha512-XErZdnnYYXF7OwGSUAPcua2y5/ELB/c53zFCpWiEGqxTNoH1iQghzI8EsHJXk06sNn+Z/TGhb8bPDNNGSgimag==}
     dev: true
 
   /sort-keys/1.1.2:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

This PR introduces an initial implementation of linaria processor for solid.

<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->

## Summary

The idea is to completely eliminate any extra runtime components and transpile the code into intermediate representation suitable for further transpilation with solid (this means, the processor doesn't transpile the code down to solid's output, it should be the responsibility of the end developer to pipe transformations correctly: first goes @linaria/solid, then the code must be transformed by solid with either babel plugin, vite plugin etc.)
<!--
Explain how your implementation works and your thoughts behind the solution.
It will help maintainers to review your PR.
You can skip it if PR is trivial.
-->

## Test plan
The tests are not working at the moment as it turns out it's quite hard to write any meaningful tests without the actual transpilation test. Testing snapshots seems too fragile and unmaintainable.

Instead I tried to take an approach on transpiling the code of tests with linaria+solid in a custom jest transform. It works but I'd still like to avoid testing stringified (or jsonified) output. Instead, it would be really cool to make use of JSDom to _run_ the output, render generated components and test _interaction_ with them. E.g. a reactive prop on a component must update components runtime structure etc.

At the moment I'm able to transpile the code with both jest transform (seamlessly transpiles the whole test and we can use regular TSX to write the code - huge win) and with a custom transpile step (takes a stringified input and transpiles down to solid's output - not so good as we lose TSX and still need to eval the code somehow).

Another thing to consider is that jest transform throws away generated css and I'd like to render it with JSDom so that interactions with components can be fully tested (e.g. when we set a prop on a component, component's color turns blue).
But this would require adding a _build_ step with esbuild/vite/etc and somehow integrate it into jest+jsdom - the first thing that comes to mind is a custom jest environment based on jest-environment-jsdom, this _might_ work. Also we could take a look at `@testing-library/react` and see what they are doing and try to implement the same things in the jest environment.

All these turned out to be much more work, so I stopped on that as unfortunately I don't have enough time at the moment.

Still, I'm opening the PR to demonstrate possible implementation of processor, as @Anber suggested in DM 👌 

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->
