### PR TITLE
fix(react): force interop check to fix @emotion/is-prop-valid esm import

### DIFF
--- a/.changeset/wild-hairs-grin.md
+++ b/.changeset/wild-hairs-grin.md
@@ -1,0 +1,5 @@
+---
+'@linaria/react': patch
+---
+
+force interop check to fix @emotion/is-prop-valid esm import

--- a/packages/react/src/styled.ts
+++ b/packages/react/src/styled.ts
@@ -65,8 +65,15 @@ function filterProps<T extends Record<string, unknown>, TKeys extends keyof T>(
     component.indexOf('-') === -1 &&
     !isCapital(component[0])
   ) {
+    /**
+     * A failsafe check for esModule import issues
+     * if validAttr !== 'function' then it is an object of { default: Fn }
+     */
+    const interopValidAttr =
+      typeof validAttr === 'function' ? { default: validAttr } : validAttr;
+
     Object.keys(filteredProps).forEach((key) => {
-      if (!validAttr(key)) {
+      if (!interopValidAttr.default(key)) {
         // Don't pass through invalid attributes to HTML elements
         delete filteredProps[key];
       }


### PR DESCRIPTION
## Motivation

I've setup a minimal codesandbox with fixed package versions that should highlight the issue: https://codesandbox.io/p/sandbox/sharp-brook-3298j7?file=%2Fpages%2Findex.tsx

Use of the `styled` function in a next.js project causes a runtime exception seen in a stack trace here https://3298j7-3000.preview.csb.app

```
TypeError: validAttr is not a function
./node_modules/@linaria/react/dist/index.mjs (18:12)
```

## Summary

Related: #1057 & #1093

It seems like a bug has been introduced after the support was added for esm exports in v4.2 where trying to import @emotion/is-prop-valid in @linaria/react

## Test plan

I've added a possible fix for this where we can pre-emptively transform the import before use in the module interop style, where we can check the typeof for the import and normalise the shape to `{default: Fn}`