### PR TITLE
feat: add ignored and excluded classes to critical CSS extraction in `collect`

### DIFF
--- a/.changeset/wet-cheetahs-approve.md
+++ b/.changeset/wet-cheetahs-approve.md
@@ -1,0 +1,6 @@
+---
+'@linaria/server': minor
+---
+
+- 714a8e86: Modify the handling of CSS @ rules in `collect` to only include child rules if critical
+- 1559cfa9: Add support in `collect` for ignoring and blocking classes from the regex for critical CSS extraction

--- a/packages/server/__tests__/__snapshots__/collect.test.ts.snap
+++ b/packages/server/__tests__/__snapshots__/collect.test.ts.snap
@@ -213,14 +213,18 @@ exports[`include atrule once critical 1`] = `
   h1 {
     font-size: 20px;
   }
+}
+"
+`;
+
+exports[`include atrule once other 1`] = `
+"@media screen {
   .class {
     font-size: 15px;
   }
 }
 "
 `;
-
-exports[`include atrule once other 1`] = `""`;
 
 exports[`simple class name critical 1`] = `
 ".linaria {

--- a/packages/server/__tests__/collect.test.ts
+++ b/packages/server/__tests__/collect.test.ts
@@ -251,3 +251,37 @@ describe('ignore empty class attribute', () => {
   const { critical } = collect(code, css);
   test('critical should be empty', () => expect(critical).toEqual(''));
 });
+
+test('does not match selectors in ignoredClasses list', () => {
+  const code = dedent`
+    <div class="lily ltr dir"></div>
+  `;
+
+  const css = dedent`
+    .linaria.dir {}
+    .linaria.ltr {}
+    .lily {}
+  `;
+
+  const { critical, other } = collect(code, css, {
+    ignoredClasses: ['ltr', 'dir'],
+  });
+  expect(critical).toMatchInlineSnapshot(`".lily {}"`);
+  expect(other).toMatchInlineSnapshot(`".linaria.dir {}.linaria.ltr {}"`);
+});
+
+test('does not match selectors in blockedClasses list', () => {
+  const code = dedent`
+    <div class="lily linaria ltr dir"></div>
+  `;
+
+  const css = dedent`
+    .linaria.ltr {}
+    .linaria.rtl {}
+    .lily {}
+  `;
+
+  const { critical, other } = collect(code, css, { blockedClasses: ['rtl'] });
+  expect(critical).toMatchInlineSnapshot(`".linaria.ltr {}.lily {}"`);
+  expect(other).toMatchInlineSnapshot(`".linaria.rtl {}"`);
+});

--- a/packages/server/__tests__/collect.test.ts
+++ b/packages/server/__tests__/collect.test.ts
@@ -285,3 +285,41 @@ test('does not match selectors in blockedClasses list', () => {
   expect(critical).toMatchInlineSnapshot(`".linaria.ltr {}.lily {}"`);
   expect(other).toMatchInlineSnapshot(`".linaria.rtl {}"`);
 });
+
+test('does not match child selectors in blockedClasses list for media queries', () => {
+  const code = dedent`
+    <div class="lily linaria ltr dir"></div>
+  `;
+
+  const css = dedent`
+  @media only screen and (max-width:561.5px) {
+    .dir-ltr.left_6_3_l9xil3s {
+      padding-left: 24px !important;
+    }
+
+    .dir-rtl.left_6_3_l9xil3s {
+      padding-right: 24px !important;
+    }
+  }
+  `;
+
+  const { critical, other } = collect(code, css, {
+    blockedClasses: ['dir-rtl'],
+  });
+
+  expect(critical).toMatchInlineSnapshot(`
+    "@media only screen and (max-width:561.5px) {
+      .dir-ltr.left_6_3_l9xil3s {
+        padding-left: 24px !important;
+      }
+    }"
+  `);
+  expect(other).toMatchInlineSnapshot(`
+    "@media only screen and (max-width:561.5px) {
+
+      .dir-rtl.left_6_3_l9xil3s {
+        padding-right: 24px !important;
+      }
+    }"
+  `);
+});

--- a/packages/server/src/collect.ts
+++ b/packages/server/src/collect.ts
@@ -83,23 +83,30 @@ export default function collect(
   };
 
   const handleAtRule = (rule: AtRule) => {
-    let addedToCritical = false;
-
-    rule.each((childRule) => {
-      if (isCritical(childRule) && !addedToCritical) {
-        critical.append(rule.clone());
-        addedToCritical = true;
-      }
-    });
-
     if (rule.name === 'keyframes') {
       return;
     }
 
-    if (addedToCritical) {
-      rule.remove();
-    } else {
-      other.append(rule);
+    const criticalRule = rule.clone();
+    const otherRule = rule.clone();
+
+    let removedNodesFromOther = 0;
+    criticalRule.each((childRule: ChildNode, index: number) => {
+      if (isCritical(childRule)) {
+        otherRule.nodes[index - removedNodesFromOther]?.remove();
+        removedNodesFromOther += 1;
+      } else {
+        childRule.remove();
+      }
+    });
+
+    rule.remove();
+
+    if (criticalRule.nodes.length > 0) {
+      critical.append(criticalRule);
+    }
+    if (otherRule.nodes.length > 0) {
+      other.append(otherRule);
     }
   };
 

--- a/packages/server/src/collect.ts
+++ b/packages/server/src/collect.ts
@@ -1,7 +1,3 @@
-/**
- * This utility extracts critical CSS from given HTML and CSS file to be used in SSR environments
- */
-
 import type { AtRule, ChildNode } from 'postcss';
 import postcss from 'postcss';
 
@@ -10,19 +6,35 @@ type CollectResult = {
   other: string;
 };
 
-const extractClassesFromHtml = (html: string): RegExp => {
+interface ClassnameModifiers {
+  ignoredClasses?: string[];
+  blockedClasses?: string[];
+}
+
+/**
+ * Used to escape `RegExp`
+ * [syntax characters](https://262.ecma-international.org/7.0/#sec-regular-expressions-patterns).
+ */
+function escapeRegex(string: string) {
+  return string.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
+}
+
+const extractClassesFromHtml = (
+  html: string,
+  ignoredClasses: string[]
+): RegExp => {
   const htmlClasses: string[] = [];
   const regex = /\s+class="([^"]+)"/gm;
   let match = regex.exec(html);
+  const ignoredClassesDeduped = new Set(ignoredClasses);
 
   while (match !== null) {
     match[1].split(' ').forEach((className) => {
       // eslint-disable-next-line no-param-reassign
-      className = className.replace(
-        /\\|\^|\$|\{|\}|\[|\]|\(|\)|\.|\*|\+|\?|\|/g,
-        '\\$&'
-      );
-      htmlClasses.push(className);
+      className = escapeRegex(className);
+      if (className !== '' && !ignoredClassesDeduped.has(className)) {
+        htmlClasses.push(className);
+      }
     });
     match = regex.exec(html);
   }
@@ -30,16 +42,40 @@ const extractClassesFromHtml = (html: string): RegExp => {
   return new RegExp(htmlClasses.join('|'), 'gm');
 };
 
-export default function collect(html: string, css: string): CollectResult {
+/**
+ * This utility extracts critical CSS from given HTML and CSS file to be used in SSR environments
+ * @param {string} html the HTML from which classes will be parsed
+ * @param {string} css the CSS file from which selectors will be parsed and determined as critical or other
+ * @param {string[]} ignoredClasses classes that, when present in the HTML, will not be included in the regular expression used to match selectors
+ * @param {string[]} blockedClasses classes that, when contained in a selector, will cause the selector to be marked as not critical
+ * @returns {CollectResult} object containing the critical and other CSS styles
+ */
+export default function collect(
+  html: string,
+  css: string,
+  classnameModifiers?: ClassnameModifiers
+): CollectResult {
   const animations = new Set();
   const other = postcss.root();
   const critical = postcss.root();
   const stylesheet = postcss.parse(css);
-  const htmlClassesRegExp = extractClassesFromHtml(html);
+  const ignoredClasses = classnameModifiers?.ignoredClasses ?? [];
+  const blockedClasses = classnameModifiers?.blockedClasses ?? [];
+
+  const htmlClassesRegExp = extractClassesFromHtml(html, ignoredClasses);
+  const blockedClassesSanitized = blockedClasses.map(escapeRegex);
+  const blockedClassesRegExp = new RegExp(
+    blockedClassesSanitized.join('|'),
+    'gm'
+  );
 
   const isCritical = (rule: ChildNode) => {
     // Only check class names selectors
     if ('selector' in rule && rule.selector.startsWith('.')) {
+      const isExcluded =
+        blockedClasses.length > 0 && blockedClassesRegExp.test(rule.selector);
+      if (isExcluded) return false;
+
       return Boolean(rule.selector.match(htmlClassesRegExp));
     }
 


### PR DESCRIPTION
## Motivation

Our codebase uses the [postcss-rtlcss](https://www.npmjs.com/package/postcss-rtlcss) package to add `.dir-ltr`, `.dir-rtl`, or `.dir` prefixes to our CSS selectors, so that most of them are in the following format:
```
.dir-ltr.otherClassname {
   padding-bottom: 12px;
}
```

Since our HTML contains the `dir-ltr` class, when we use Linaria's `collect` function, a lot of unnecessary selectors are added to the critical CSS even though `otherClassname` is not present.

Also, we have media queries in this format:
```
@media(...) {
  .dir-ltr.otherClassname {
    padding-left: 12px;
  }
  .dir-rtl.otherClassname {
    padding-right: 12px;
  }
}
```

We want to specifically exclude the RTL selector when the direction is LTR and vice versa.

## Summary

This PR proposes to add an opt-in `ignoredClasses` parameter to `collect` so that we can ignore `dir-ltr`, `dir-rtl`, and `dir` from the regex used to determine critical CSS styles when it is present in the HTML.

Also, the `excludedClasses` parameter will allow `dir-rtl` to be excluded, so that even if `otherClassname` is in the HTML, the `.dir-rtl.otherClassname` selector will not be critical.

## Test plan

Tested with unit tests for the new parameters to the `collect` function.