### PR TITLE
docs: add vite configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Linaria currently supports webpack and Rollup to extract the CSS at build time. 
 - [webpack](/docs/BUNDLERS_INTEGRATION.md#webpack)
 - [esbuild](/docs/BUNDLERS_INTEGRATION.md#esbuild)
 - [Rollup](/docs/BUNDLERS_INTEGRATION.md#rollup)
+- [Vite](/docs/BUNDLERS_INTEGRATION.md#vite)
 - [Svelte](/docs/BUNDLERS_INTEGRATION.md#svelte)
 
 Or configure Linaria with one of the following integrations:

--- a/docs/BUNDLERS_INTEGRATION.md
+++ b/docs/BUNDLERS_INTEGRATION.md
@@ -311,6 +311,46 @@ export default {
 };
 ```
 
+### Vite
+
+Since Vite supports Rollup plugin, you can use `@linaria/rollup`. Vite handles CSS by itself, you don't need a css plugin.
+
+```sh
+yarn add --dev @linaria/rollup
+```
+
+Then add them to your `vite.config.js`:
+
+```js
+import { defineConfig } from 'vite';
+import linaria from '@linaria/rollup';
+
+export default defineConfig(() => ({
+  // ...
+  plugins: [linaria()],
+}));
+```
+
+If you are using language features that requires a babel transform (such as typescript), ensure the proper babel presets or plugins are passed to linaria.
+
+```js
+import { defineConfig } from 'vite';
+import linaria from '@linaria/rollup';
+
+// example to support typescript syntax:
+export default defineConfig(() => ({
+  // ...
+  plugins: [
+    linaria({
+      include: ['**/*.{ts,tsx}'],
+      babelOptions: {
+        presets: ['@babel/preset-typescript', '@babel/preset-react'],
+      },
+    }),
+  ],
+}));
+```
+
 ### Svelte
 
 #### Contents


### PR DESCRIPTION

## Motivation

It seems like users struggle to find documentation on how to configure vite + typescript + linear #959

## Summary

I added a simple vite configuration, and one that uses typescript.

I noted that `enforce: 'pre'` is added to the plugin in the example. I am not sure why so I omitted it in the examples. 

## Alternative

It could be useful to also add another entry in the [examples](https://github.com/callstack/linaria/tree/master/examples) directory, for vite + typescript + linear.

I don't think it will be interesting for the example to build the website ( as the website does not uses typescript ). Maybe include the source for a simple hello world page instead ?


