### PR TITLE
chore: npm cmd to pnpm

### DIFF
--- a/examples/gatsby/custom-config/package.json
+++ b/examples/gatsby/custom-config/package.json
@@ -31,7 +31,7 @@
     "build": "gatsby build",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
-    "start": "npm run develop",
+    "start": "pnpm develop",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1"

--- a/examples/gatsby/plugin/package.json
+++ b/examples/gatsby/plugin/package.json
@@ -31,7 +31,7 @@
     "build": "gatsby build",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
-    "start": "npm run develop",
+    "start": "pnpm develop",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -45,13 +45,14 @@
     "typescript": "^4.7.4"
   },
   "engines": {
-    "node": "^12.16.0 || >=13.7.0"
+    "node": "^12.16.0 || >=13.7.0",
+    "pnpm": "^7.16.0"
   },
   "homepage": "https://github.com/callstack/linaria#readme",
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-commit": "npm run check:all"
+      "pre-commit": "pnpm check:all"
     }
   },
   "license": "MIT",
@@ -64,7 +65,7 @@
   "scripts": {
     "add-contributor": "all-contributors add",
     "bootstrap": "pnpm install",
-    "check:all": "turbo run check:all --output-logs=new-only && npm run lint && npm run sp:check",
+    "check:all": "turbo run check:all --output-logs=new-only && pnpm lint && pnpm sp:check",
     "clean": "del 'packages/*/{coverage,dist,esm,lib,types,tsconfig.tsbuildinfo}'",
     "lint": "eslint --ext .js,.ts,.tsx .",
     "prepare": "turbo run build --output-logs=new-only",
@@ -77,7 +78,6 @@
     "test:coverage": "turbo run test -- -- --coverage",
     "test:dts": "turbo run test:dts",
     "typecheck": "turbo run typecheck",
-    "watch": "turbo run --parallel watch",
     "website": "pnpm --filter=linaria-website"
   },
   "workspaces": [

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -60,11 +60,11 @@
   },
   "repository": "git@github.com:callstack/linaria.git",
   "scripts": {
-    "build": "npm run build:dist && npm run build:declarations",
+    "build": "pnpm build:dist && pnpm build:declarations",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
     "build:dist": "tsup --format cjs,esm",
     "typecheck": "tsc --noEmit --composite false",
-    "watch": "npm run build --watch"
+    "watch": "pnpm build:dist --watch & pnpm build:declarations --watch"
   },
   "sideEffects": false,
   "tsup": {

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -61,13 +61,13 @@
   },
   "repository": "git@github.com:callstack/linaria.git",
   "scripts": {
-    "build": "npm run build:lib && npm run build:esm && npm run build:declarations",
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
     "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "test": "jest --config ./jest.config.js --rootDir src",
     "typecheck": "tsc --noEmit --composite false",
-    "watch": "npm run build --watch"
+    "watch": "pnpm build:lib --watch & pnpm build:declarations --watch"
   },
   "types": "types"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,11 +48,11 @@
   },
   "repository": "git@github.com:callstack/linaria.git",
   "scripts": {
-    "build": "npm run build:lib && npm run build:esm && npm run build:declarations",
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
     "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "typecheck": "tsc --noEmit --composite false",
-    "watch": "npm run build --watch"
+    "watch": "pnpm build --watch"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,14 +57,14 @@
   },
   "repository": "git@github.com:callstack/linaria.git",
   "scripts": {
-    "build": "npm run build:dist && npm run build:declarations",
+    "build": "pnpm build:dist && pnpm build:declarations",
     "build:corejs-test": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --ignore \"src/processors/**/*\"",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
     "build:dist": "tsup --format cjs,esm",
     "test": "jest --config ../../jest.config.js --rootDir .",
     "test:dts": "dtslint --localTs ../../node_modules/typescript/lib __dtslint__",
     "typecheck": "tsc --noEmit --composite false",
-    "watch": "npm run build --watch"
+    "watch": "pnpm build:dist --watch & pnpm build:declarations --watch"
   },
   "sideEffects": false,
   "tsup": {

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -43,11 +43,11 @@
   },
   "repository": "git@github.com:callstack/linaria.git",
   "scripts": {
-    "build": "npm run build:dist && npm run build:declarations",
+    "build": "pnpm build:dist && pnpm build:declarations",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
     "build:dist": "tsup --format cjs,esm",
     "typecheck": "tsc --noEmit --composite false",
-    "watch": "npm run build --watch"
+    "watch": "pnpm build:dist --watch & pnpm build:declarations --watch"
   },
   "tsup": {
     "entry": [

--- a/packages/extractor/package.json
+++ b/packages/extractor/package.json
@@ -29,12 +29,12 @@
   },
   "repository": "git@github.com:callstack/linaria.git",
   "scripts": {
-    "build": "npm run build:lib && npm run build:esm && npm run build:declarations",
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
     "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "typecheck": "tsc --noEmit --composite false",
-    "watch": "npm run build --watch"
+    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
   },
   "types": "types"
 }

--- a/packages/griffel/package.json
+++ b/packages/griffel/package.json
@@ -43,12 +43,12 @@
   },
   "repository": "git@github.com:callstack/linaria.git",
   "scripts": {
-    "build": "npm run build:lib && npm run build:esm && npm run build:declarations",
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
     "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "typecheck": "tsc --noEmit --composite false",
-    "watch": "npm run build --watch"
+    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
   },
   "sideEffects": false,
   "types": "types/index.d.ts"

--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -30,13 +30,13 @@
   },
   "repository": "git@github.com:callstack/linaria.git",
   "scripts": {
-    "build": "npm run build:lib && npm run build:esm && npm run build:declarations",
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
     "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "test": "jest --config ../../jest.config.js --rootDir .",
     "typecheck": "tsc --noEmit --composite false",
-    "watch": "npm run build --watch"
+    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
   },
   "types": "types"
 }

--- a/packages/linaria/package.json
+++ b/packages/linaria/package.json
@@ -53,12 +53,12 @@
   },
   "repository": "git@github.com:callstack/linaria.git",
   "scripts": {
-    "build": "npm run build:lib && npm run build:esm && npm run build:declarations",
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
     "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "typecheck": "tsc --noEmit --composite false",
-    "watch": "npm run build --watch"
+    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
   },
   "types": "types/core.d.ts"
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -35,12 +35,12 @@
   },
   "repository": "git@github.com:callstack/linaria.git",
   "scripts": {
-    "build": "npm run build:lib && npm run build:esm && npm run build:declarations",
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
     "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "typecheck": "tsc --noEmit --composite false",
-    "watch": "npm run build --watch"
+    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
   },
   "types": "types"
 }

--- a/packages/postcss-linaria/package.json
+++ b/packages/postcss-linaria/package.json
@@ -49,12 +49,12 @@
   },
   "repository": "git@github.com:callstack/linaria.git",
   "scripts": {
-    "build": "npm run build:lib && npm run build:esm && npm run build:declarations",
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
     "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "typecheck": "tsc --noEmit --composite false",
-    "watch": "npm run build --watch"
+    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
   },
   "sideEffects": false,
   "types": "types/index.d.ts"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -64,14 +64,14 @@
   },
   "repository": "git@github.com:callstack/linaria.git",
   "scripts": {
-    "build": "npm run build:dist && npm run build:declarations",
+    "build": "pnpm build:dist && pnpm build:declarations",
     "build:corejs-test": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --ignore \"src/processors/**/*\"",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
     "build:dist": "tsup --format cjs,esm",
     "test": "jest --config ../../jest.config.js --rootDir .",
     "test:dts": "dtslint --localTs ../../node_modules/typescript/lib __dtslint__",
     "typecheck": "tsc --noEmit --composite false",
-    "watch": "npm run build --watch"
+    "watch": "pnpm build:dist --watch & pnpm build:declarations --watch"
   },
   "sideEffects": false,
   "tsup": {

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -45,11 +45,11 @@
   },
   "repository": "git@github.com:callstack/linaria.git",
   "scripts": {
-    "build": "npm run build:dist && npm run build:declarations",
+    "build": "pnpm build:dist && pnpm build:declarations",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
     "build:dist": "tsup --format cjs,esm",
     "typecheck": "tsc --noEmit --composite false",
-    "watch": "npm run build --watch"
+    "watch": "pnpm build:dist --watch & pnpm build:declarations --watch"
   },
   "tsup": {
     "entry": [

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -35,12 +35,12 @@
   },
   "repository": "git@github.com:callstack/linaria.git",
   "scripts": {
-    "build": "npm run build:lib && npm run build:esm && npm run build:declarations",
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
     "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "typecheck": "tsc --noEmit --composite false",
-    "watch": "npm run build --watch"
+    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
   },
   "types": "types"
 }

--- a/packages/shaker/package.json
+++ b/packages/shaker/package.json
@@ -54,13 +54,13 @@
   },
   "repository": "git@github.com:callstack/linaria.git",
   "scripts": {
-    "build": "npm run build:lib && npm run build:esm && npm run build:declarations",
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
     "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "test": "jest --config ./jest.config.js --rootDir src",
     "typecheck": "tsc --noEmit --composite false",
-    "watch": "npm run build --watch"
+    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
   },
   "types": "types"
 }

--- a/packages/stylelint-config-standard-linaria/package.json
+++ b/packages/stylelint-config-standard-linaria/package.json
@@ -39,12 +39,12 @@
   },
   "repository": "git@github.com:callstack/linaria.git",
   "scripts": {
-    "build": "npm run build:lib && npm run build:esm && npm run build:declarations",
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
     "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "typecheck": "tsc --noEmit --composite false",
-    "watch": "npm run build --watch"
+    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
   },
   "sideEffects": false,
   "types": "types/index.d.ts"

--- a/packages/stylelint/package.json
+++ b/packages/stylelint/package.json
@@ -35,12 +35,12 @@
   },
   "repository": "git@github.com:callstack/linaria.git",
   "scripts": {
-    "build": "npm run build:lib && npm run build:esm && npm run build:declarations",
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
     "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "typecheck": "tsc --noEmit --composite false",
-    "watch": "npm run build --watch"
+    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
   },
   "types": "types"
 }

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -40,12 +40,12 @@
   },
   "repository": "git@github.com:callstack/linaria.git",
   "scripts": {
-    "build": "npm run build:lib && npm run build:esm && npm run build:declarations",
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
     "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "typecheck": "tsc --noEmit --composite false",
-    "watch": "npm run build --watch"
+    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
   },
   "sideEffects": false,
   "types": "types/index.d.ts"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -42,12 +42,12 @@
   },
   "repository": "git@github.com:callstack/linaria.git",
   "scripts": {
-    "build": "npm run build:lib && npm run build:esm && npm run build:declarations",
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
     "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "typecheck": "tsc --noEmit --composite false",
-    "watch": "npm run build --watch"
+    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
   },
   "sideEffects": false,
   "types": "types/index.d.ts"

--- a/packages/webpack-loader/package.json
+++ b/packages/webpack-loader/package.json
@@ -33,12 +33,12 @@
   },
   "repository": "git@github.com:callstack/linaria.git",
   "scripts": {
-    "build": "npm run build:lib && npm run build:esm && npm run build:declarations",
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
     "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "typecheck": "tsc --noEmit --composite false",
-    "watch": "npm run build --watch"
+    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
   },
   "types": "types/index.d.ts"
 }

--- a/packages/webpack4-loader/package.json
+++ b/packages/webpack4-loader/package.json
@@ -47,12 +47,12 @@
   },
   "repository": "git@github.com:callstack/linaria.git",
   "scripts": {
-    "build": "npm run build:lib && npm run build:esm && npm run build:declarations",
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
     "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "typecheck": "tsc --noEmit --composite false",
-    "watch": "npm run build --watch"
+    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & --watch & pnpm build:declarations --watch"
   },
   "types": "types"
 }

--- a/packages/webpack5-loader/package.json
+++ b/packages/webpack5-loader/package.json
@@ -45,12 +45,12 @@
   },
   "repository": "git@github.com:callstack/linaria.git",
   "scripts": {
-    "build": "npm run build:lib && npm run build:esm && npm run build:declarations",
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
     "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "typecheck": "tsc --noEmit --composite false",
-    "watch": "npm run build --watch"
+    "watch": "pnpm build --watch"
   },
   "types": "types"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
     "declaration": true,
     "typeRoots": ["node_modules/@types", "typings"],
     "skipLibCheck": true,
-    "skipDefaultLibCheck": true
+    "skipDefaultLibCheck": true,
+    "preserveWatchOutput": true,
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://turborepo.org/schema.json",
-  "baseBranch": "origin/master",
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Motivation
As this project now is based on pnpm, let's switch to pnpm. 
pnpm allows to skip `run` keyword when initiating command.

## Summary
- Replaced `npm run` with `pnpm`.
- Fixed `watch` command in every package by concating build commands with `&`. I choose ampersand because it's almost cross-platform now: [Powershell 7+ supports it.](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-7.3#call-operator-) I've checked on Powershell 7.3.0.
- Deleted `watch` command from main `package.json`, because it floods memory.
- Deleted `baseBranch` property from turbo, as it does nothing.
- Set `preserveWatchOutput` in `tsconfig.json` because it does clearing output by default.
## Test plan
Let's run in CI.
