### PR TITLE
fix(babel): avoid using different babel versions

### DIFF
--- a/examples/gatsby/plugin/package.json
+++ b/examples/gatsby/plugin/package.json
@@ -33,8 +33,7 @@
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "pnpm develop",
     "serve": "gatsby serve",
-    "clean": "gatsby clean",
-    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1"
+    "clean": "gatsby clean"
   },
   "repository": {
     "type": "git",

--- a/packages/shaker/src/index.ts
+++ b/packages/shaker/src/index.ts
@@ -1,5 +1,4 @@
 import type { TransformOptions } from '@babel/core';
-import { transformSync } from '@babel/core';
 
 import { buildOptions, loadBabelOptions } from '@linaria/utils';
 import type { Evaluator } from '@linaria/utils';
@@ -48,7 +47,7 @@ const shaker: Evaluator = (filename, options, text, only, babel) => {
     buildOptions(options?.babelOptions, getShakerConfig(only))
   );
 
-  const transformed = transformSync(text, {
+  const transformed = babel.transformSync(text, {
     ...transformOptions,
     filename,
   });


### PR DESCRIPTION
## Motivation

Bug fix for #1061

## Summary

Shaker used `transformSync` from the wrong babel version