### PR TITLE
chore: add prettier-plugin-packagejson

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,0 @@
-{
-  "trailingComma": "es5",
-  "singleQuote": true
-}

--- a/examples/astro-solid/package.json
+++ b/examples/astro-solid/package.json
@@ -2,8 +2,13 @@
   "name": "astro-solid-example",
   "version": "0.0.1",
   "license": "MIT",
-  "main": "index.js",
+  "author": "Dmitriy Nikiforov",
   "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "build": "astro build",
+    "dev": "astro dev --force"
+  },
   "devDependencies": {
     "@astrojs/solid-js": "^1.2.3",
     "@babel/core": "^7.18.6",
@@ -14,10 +19,5 @@
     "solid-js": "^1.6.2",
     "vite": "^3.2.4",
     "vite-plugin-inspect": "^0.7.8"
-  },
-  "scripts": {
-    "dev": "astro dev --force",
-    "build": "astro build"
-  },
-  "author": "Dmitriy Nikiforov"
+  }
 }

--- a/examples/esbuild/package.json
+++ b/examples/esbuild/package.json
@@ -1,17 +1,17 @@
 {
-  "private": true,
   "name": "esbuild-example",
   "version": "0.0.0",
+  "private": true,
   "license": "MIT",
+  "author": "Anton Evzhakov",
+  "scripts": {
+    "build": "node build.js"
+  },
   "dependencies": {
     "linaria-website": "workspace:^"
   },
   "devDependencies": {
     "@linaria/esbuild": "workspace:^",
     "esbuild": "^0.14.48"
-  },
-  "scripts": {
-    "build": "node build.js"
-  },
-  "author": "Anton Evzhakov"
+  }
 }

--- a/examples/rollup/package.json
+++ b/examples/rollup/package.json
@@ -1,8 +1,12 @@
 {
-  "private": true,
   "name": "rollup-example",
   "version": "0.0.0",
+  "private": true,
   "license": "MIT",
+  "author": "Anton Evzhakov",
+  "scripts": {
+    "build": "rollup -c"
+  },
   "dependencies": {
     "linaria-website": "workspace:^"
   },
@@ -10,15 +14,11 @@
     "@babel/core": "^7.18.6",
     "@babel/preset-react": "^7.18.6",
     "@linaria/rollup": "workspace:^",
-    "@rollup/plugin-commonjs": "^22.0.1",
     "@rollup/plugin-babel": "^5.3.1",
+    "@rollup/plugin-commonjs": "^22.0.1",
     "@rollup/plugin-image": "^2.1.1",
     "@rollup/plugin-node-resolve": "^13.3.0",
     "rollup": "^2.76.0",
     "rollup-plugin-css-only": "^3.1.0"
-  },
-  "scripts": {
-    "build": "rollup -c"
-  },
-  "author": "Anton Evzhakov"
+  }
 }

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -1,10 +1,14 @@
 {
-  "private": true,
   "name": "vite-example",
   "version": "0.0.0",
+  "private": true,
   "license": "MIT",
-  "main": "index.js",
+  "author": "Anton Evzhakov",
   "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "build": "vite build"
+  },
   "dependencies": {
     "linaria-website": "workspace:^"
   },
@@ -14,9 +18,5 @@
     "@rollup/plugin-node-resolve": "^15.0.0",
     "@vitejs/plugin-react": "^2.1.0",
     "vite": "^3.1.8"
-  },
-  "scripts": {
-    "build": "vite build"
-  },
-  "author": "Anton Evzhakov"
+  }
 }

--- a/examples/webpack4/package.json
+++ b/examples/webpack4/package.json
@@ -1,8 +1,13 @@
 {
-  "private": true,
   "name": "webpack4-example",
   "version": "0.0.0",
+  "private": true,
   "license": "MIT",
+  "author": "Anton Evzhakov",
+  "scripts": {
+    "build": "cross-env NODE_ENV=production webpack",
+    "preview": "pnpm build && pnpm dlx http-server ."
+  },
   "dependencies": {
     "linaria-website": "workspace:^4.1.8"
   },
@@ -17,10 +22,5 @@
     "mini-css-extract-plugin": "^0.5.0",
     "webpack": "^4.46.0",
     "webpack-cli": "4.7.0"
-  },
-  "scripts": {
-    "build": "cross-env NODE_ENV=production webpack",
-    "preview": "pnpm build && pnpm dlx http-server ."
-  },
-  "author": "Anton Evzhakov"
+  }
 }

--- a/examples/webpack5/package.json
+++ b/examples/webpack5/package.json
@@ -1,9 +1,14 @@
 {
-  "private": true,
   "name": "webpack5-example",
   "version": "0.0.0",
+  "private": true,
   "license": "MIT",
+  "author": "Anton Evzhakov",
   "main": "index.js",
+  "scripts": {
+    "build": "cross-env NODE_ENV=production webpack",
+    "preview": "pnpm build && pnpm dlx http-server ."
+  },
   "dependencies": {
     "linaria-website": "workspace:^4.1.8"
   },
@@ -18,10 +23,5 @@
     "mini-css-extract-plugin": "^2.7.0",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.0"
-  },
-  "scripts": {
-    "build": "cross-env NODE_ENV=production webpack",
-    "preview": "pnpm build && pnpm dlx http-server ."
-  },
-  "author": "Anton Evzhakov"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,39 @@
 {
   "name": "umbrella",
   "version": "3.0.0-beta.19",
+  "private": true,
+  "homepage": "https://github.com/callstack/linaria#readme",
   "bugs": "https://github.com/callstack/linaria/issues",
+  "repository": "git@github.com:callstack/linaria.git",
+  "license": "MIT",
+  "workspaces": [
+    "./packages/*",
+    "./website"
+  ],
+  "scripts": {
+    "add-contributor": "all-contributors add",
+    "bootstrap": "pnpm install",
+    "check:all": "turbo run check:all --output-logs=new-only && pnpm lint && pnpm sp:check",
+    "clean": "del 'packages/*/{coverage,dist,esm,lib,types,tsconfig.tsbuildinfo}'",
+    "lint": "eslint --ext .js,.ts,.tsx .",
+    "prepare": "turbo run build --output-logs=new-only",
+    "release": "pnpm run prepare && pnpm changeset publish",
+    "sp:check": "syncpack",
+    "sp:fix": "syncpack format && syncpack fix-mismatches",
+    "sp:format": "syncpack format",
+    "sp:list": "syncpack list-mismatches",
+    "test": "turbo run test",
+    "test:coverage": "turbo run test -- -- --coverage",
+    "test:dts": "turbo run test:dts",
+    "typecheck": "turbo run typecheck",
+    "website": "pnpm --filter=linaria-website"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "pnpm check:all",
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+    }
+  },
   "dependencies": {
     "git-raw-commits": "^2.0.3"
   },
@@ -38,50 +70,19 @@
     "husky": "^1.3.1",
     "jest": "^28.1.0",
     "prettier": "^2.7.1",
+    "prettier-plugin-packagejson": "^2.3.0",
     "react": "^16.14.0",
     "syncpack": "^8.0.0",
     "tsup": "^6.3.0",
     "turbo": "^1.6.3",
     "typescript": "^4.7.4"
   },
-  "engines": {
-    "node": "^12.16.0 || >=13.7.0",
-    "pnpm": "^7.16.0"
-  },
-  "homepage": "https://github.com/callstack/linaria#readme",
-  "husky": {
-    "hooks": {
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-commit": "pnpm check:all"
-    }
-  },
-  "license": "MIT",
-  "private": true,
-  "repository": "git@github.com:callstack/linaria.git",
   "resolutions": {
     "@typescript-eslint/experimental-utils": "^4.28.0",
     "git-raw-commits": "^2.0.3"
   },
-  "scripts": {
-    "add-contributor": "all-contributors add",
-    "bootstrap": "pnpm install",
-    "check:all": "turbo run check:all --output-logs=new-only && pnpm lint && pnpm sp:check",
-    "clean": "del 'packages/*/{coverage,dist,esm,lib,types,tsconfig.tsbuildinfo}'",
-    "lint": "eslint --ext .js,.ts,.tsx .",
-    "prepare": "turbo run build --output-logs=new-only",
-    "release": "pnpm run prepare && pnpm changeset publish",
-    "sp:check": "syncpack",
-    "sp:fix": "syncpack format && syncpack fix-mismatches",
-    "sp:format": "syncpack format",
-    "sp:list": "syncpack list-mismatches",
-    "test": "turbo run test",
-    "test:coverage": "turbo run test -- -- --coverage",
-    "test:dts": "turbo run test:dts",
-    "typecheck": "turbo run typecheck",
-    "website": "pnpm --filter=linaria-website"
-  },
-  "workspaces": [
-    "./packages/*",
-    "./website"
-  ]
+  "engines": {
+    "node": "^12.16.0 || >=13.7.0",
+    "pnpm": "^7.16.0"
+  }
 }

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -1,8 +1,47 @@
 {
   "name": "@linaria/atomic",
-  "description": "Blazing fast zero-runtime CSS in JS library",
   "version": "4.2.2",
+  "description": "Blazing fast zero-runtime CSS in JS library",
+  "keywords": [
+    "css",
+    "css-in-js",
+    "linaria",
+    "react",
+    "styled-components"
+  ],
+  "homepage": "https://github.com/callstack/linaria#readme",
   "bugs": "https://github.com/callstack/linaria/issues",
+  "repository": "git@github.com:callstack/linaria.git",
+  "license": "MIT",
+  "sideEffects": false,
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./types/index.d.ts",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.js"
+    },
+    "./*": {
+      "types": "./types/*.d.ts",
+      "import": "./dist/*.mjs",
+      "default": "./dist/*.js"
+    }
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "types/index.d.ts",
+  "files": [
+    "dist/",
+    "processors/",
+    "types/"
+  ],
+  "scripts": {
+    "build": "pnpm build:dist && pnpm build:declarations",
+    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
+    "build:dist": "tsup --format cjs,esm",
+    "typecheck": "tsc --noEmit --composite false",
+    "watch": "pnpm build:dist --watch & pnpm build:declarations --watch"
+  },
   "dependencies": {
     "@linaria/core": "workspace:^",
     "@linaria/logger": "workspace:^",
@@ -20,53 +59,15 @@
   "engines": {
     "node": "^12.16.0 || >=13.7.0"
   },
-  "exports": {
-    "./package.json": "./package.json",
-    ".": {
-      "types": "./types/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
-    },
-    "./*": {
-      "types": "./types/*.d.ts",
-      "import": "./dist/*.mjs",
-      "default": "./dist/*.js"
-    }
+  "publishConfig": {
+    "access": "public"
   },
-  "files": [
-    "dist/",
-    "processors/",
-    "types/"
-  ],
-  "homepage": "https://github.com/callstack/linaria#readme",
-  "keywords": [
-    "css",
-    "css-in-js",
-    "linaria",
-    "react",
-    "styled-components"
-  ],
-  "license": "MIT",
   "linaria": {
     "tags": {
       "css": "./dist/processors/css.js",
       "styled": "./dist/processors/styled.js"
     }
   },
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": "git@github.com:callstack/linaria.git",
-  "scripts": {
-    "build": "pnpm build:dist && pnpm build:declarations",
-    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
-    "build:dist": "tsup --format cjs,esm",
-    "typecheck": "tsc --noEmit --composite false",
-    "watch": "pnpm build:dist --watch & pnpm build:declarations --watch"
-  },
-  "sideEffects": false,
   "tsup": {
     "entry": [
       "src/index.ts",
@@ -76,6 +77,5 @@
     "splitting": false,
     "sourcemap": true,
     "clean": true
-  },
-  "types": "types/index.d.ts"
+  }
 }

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -1,8 +1,37 @@
 {
   "name": "@linaria/babel-preset",
-  "description": "Blazing fast zero-runtime CSS in JS library",
   "version": "4.3.0",
+  "description": "Blazing fast zero-runtime CSS in JS library",
+  "keywords": [
+    "babel",
+    "babel-plugin",
+    "css",
+    "css-in-js",
+    "linaria",
+    "react",
+    "styled-components"
+  ],
+  "homepage": "https://github.com/callstack/linaria#readme",
   "bugs": "https://github.com/callstack/linaria/issues",
+  "repository": "git@github.com:callstack/linaria.git",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "module": "esm/index.js",
+  "types": "types",
+  "files": [
+    "types/",
+    "lib/",
+    "esm/"
+  ],
+  "scripts": {
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
+    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
+    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "test": "jest --config ./jest.config.js --rootDir src",
+    "typecheck": "tsc --noEmit --composite false",
+    "watch": "pnpm build:lib --watch & pnpm build:declarations --watch"
+  },
   "dependencies": {
     "@babel/core": "^7.18.9",
     "@babel/generator": "^7.18.9",
@@ -38,36 +67,7 @@
   "engines": {
     "node": "^12.16.0 || >=13.7.0"
   },
-  "files": [
-    "types/",
-    "lib/",
-    "esm/"
-  ],
-  "homepage": "https://github.com/callstack/linaria#readme",
-  "keywords": [
-    "babel",
-    "babel-plugin",
-    "css",
-    "css-in-js",
-    "linaria",
-    "react",
-    "styled-components"
-  ],
-  "license": "MIT",
-  "main": "lib/index.js",
-  "module": "esm/index.js",
   "publishConfig": {
     "access": "public"
-  },
-  "repository": "git@github.com:callstack/linaria.git",
-  "scripts": {
-    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
-    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
-    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "test": "jest --config ./jest.config.js --rootDir src",
-    "typecheck": "tsc --noEmit --composite false",
-    "watch": "pnpm build:lib --watch & pnpm build:declarations --watch"
-  },
-  "types": "types"
+  }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,11 +1,39 @@
 {
   "name": "@linaria/cli",
-  "description": "Blazing fast zero-runtime CSS in JS library",
   "version": "4.1.8",
+  "description": "Blazing fast zero-runtime CSS in JS library",
+  "keywords": [
+    "babel",
+    "babel-plugin",
+    "css",
+    "css-in-js",
+    "linaria",
+    "react",
+    "styled-components"
+  ],
+  "homepage": "https://github.com/callstack/linaria#readme",
+  "bugs": "https://github.com/callstack/linaria/issues",
+  "repository": "git@github.com:callstack/linaria.git",
+  "license": "MIT",
+  "main": "lib/linaria.js",
+  "module": "esm/linaria.js",
   "bin": {
     "linaria": "bin/linaria.js"
   },
-  "bugs": "https://github.com/callstack/linaria/issues",
+  "files": [
+    "bin/",
+    "types/",
+    "lib/",
+    "esm/"
+  ],
+  "scripts": {
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
+    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
+    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "typecheck": "tsc --noEmit --composite false",
+    "watch": "pnpm build --watch"
+  },
   "dependencies": {
     "@babel/core": "^7.18.9",
     "@linaria/babel-preset": "workspace:^",
@@ -24,35 +52,7 @@
   "engines": {
     "node": "^12.16.0 || >=13.7.0"
   },
-  "files": [
-    "bin/",
-    "types/",
-    "lib/",
-    "esm/"
-  ],
-  "homepage": "https://github.com/callstack/linaria#readme",
-  "keywords": [
-    "babel",
-    "babel-plugin",
-    "css",
-    "css-in-js",
-    "linaria",
-    "react",
-    "styled-components"
-  ],
-  "license": "MIT",
-  "main": "lib/linaria.js",
-  "module": "esm/linaria.js",
   "publishConfig": {
     "access": "public"
-  },
-  "repository": "git@github.com:callstack/linaria.git",
-  "scripts": {
-    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
-    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
-    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "typecheck": "tsc --noEmit --composite false",
-    "watch": "pnpm build --watch"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,8 +1,57 @@
 {
   "name": "@linaria/core",
-  "description": "Blazing fast zero-runtime CSS in JS library",
   "version": "4.2.2",
+  "description": "Blazing fast zero-runtime CSS in JS library",
+  "keywords": [
+    "css",
+    "css-in-js",
+    "linaria",
+    "react",
+    "styled-components"
+  ],
+  "homepage": "https://github.com/callstack/linaria#readme",
   "bugs": "https://github.com/callstack/linaria/issues",
+  "repository": "git@github.com:callstack/linaria.git",
+  "license": "MIT",
+  "sideEffects": false,
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./types/index.d.ts",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.js"
+    },
+    "./*": {
+      "types": "./types/*.d.ts",
+      "import": "./dist/*.mjs",
+      "default": "./dist/*.js"
+    }
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "processors/*": [
+        "./types/processors/*.d.ts"
+      ]
+    }
+  },
+  "files": [
+    "dist/",
+    "processors/",
+    "types/"
+  ],
+  "scripts": {
+    "build": "pnpm build:dist && pnpm build:declarations",
+    "build:corejs-test": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --ignore \"src/processors/**/*\"",
+    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
+    "build:dist": "tsup --format cjs,esm",
+    "test": "jest --config ../../jest.config.js --rootDir .",
+    "test:dts": "dtslint --localTs ../../node_modules/typescript/lib __dtslint__",
+    "typecheck": "tsc --noEmit --composite false",
+    "watch": "pnpm build:dist --watch & pnpm build:declarations --watch"
+  },
   "dependencies": {
     "@linaria/logger": "workspace:^",
     "@linaria/tags": "workspace:^",
@@ -18,55 +67,14 @@
   "engines": {
     "node": "^12.16.0 || >=13.7.0"
   },
-  "exports": {
-    "./package.json": "./package.json",
-    ".": {
-      "types": "./types/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
-    },
-    "./*": {
-      "types": "./types/*.d.ts",
-      "import": "./dist/*.mjs",
-      "default": "./dist/*.js"
-    }
+  "publishConfig": {
+    "access": "public"
   },
-  "files": [
-    "dist/",
-    "processors/",
-    "types/"
-  ],
-  "homepage": "https://github.com/callstack/linaria#readme",
-  "keywords": [
-    "css",
-    "css-in-js",
-    "linaria",
-    "react",
-    "styled-components"
-  ],
-  "license": "MIT",
   "linaria": {
     "tags": {
       "css": "./dist/processors/css.js"
     }
   },
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": "git@github.com:callstack/linaria.git",
-  "scripts": {
-    "build": "pnpm build:dist && pnpm build:declarations",
-    "build:corejs-test": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --ignore \"src/processors/**/*\"",
-    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
-    "build:dist": "tsup --format cjs,esm",
-    "test": "jest --config ../../jest.config.js --rootDir .",
-    "test:dts": "dtslint --localTs ../../node_modules/typescript/lib __dtslint__",
-    "typecheck": "tsc --noEmit --composite false",
-    "watch": "pnpm build:dist --watch & pnpm build:declarations --watch"
-  },
-  "sideEffects": false,
   "tsup": {
     "entry": [
       "src/index.ts",
@@ -75,13 +83,5 @@
     "splitting": false,
     "sourcemap": true,
     "clean": true
-  },
-  "types": "types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "processors/*": [
-        "./types/processors/*.d.ts"
-      ]
-    }
   }
 }

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -1,8 +1,40 @@
 {
   "name": "@linaria/esbuild",
-  "description": "Blazing fast zero-runtime CSS in JS library",
   "version": "4.2.2",
+  "description": "Blazing fast zero-runtime CSS in JS library",
+  "keywords": [
+    "babel",
+    "babel-plugin",
+    "css",
+    "css-in-js",
+    "esbuild",
+    "linaria",
+    "react",
+    "styled-components"
+  ],
+  "homepage": "https://github.com/callstack/linaria#readme",
   "bugs": "https://github.com/callstack/linaria/issues",
+  "repository": "git@github.com:callstack/linaria.git",
+  "license": "MIT",
+  "exports": {
+    "import": "./dist/index.mjs",
+    "require": "./dist/index.js",
+    "types": "./types/index.d.ts"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "types",
+  "files": [
+    "dist/",
+    "types/"
+  ],
+  "scripts": {
+    "build": "pnpm build:dist && pnpm build:declarations",
+    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
+    "build:dist": "tsup --format cjs,esm",
+    "typecheck": "tsc --noEmit --composite false",
+    "watch": "pnpm build:dist --watch & pnpm build:declarations --watch"
+  },
   "dependencies": {
     "@babel/core": "^7.18.9",
     "@linaria/babel-preset": "workspace:^",
@@ -15,39 +47,8 @@
   "engines": {
     "node": "^12.16.0 || >=13.7.0"
   },
-  "exports": {
-    "import": "./dist/index.mjs",
-    "require": "./dist/index.js",
-    "types": "./types/index.d.ts"
-  },
-  "files": [
-    "dist/",
-    "types/"
-  ],
-  "homepage": "https://github.com/callstack/linaria#readme",
-  "keywords": [
-    "babel",
-    "babel-plugin",
-    "css",
-    "css-in-js",
-    "esbuild",
-    "linaria",
-    "react",
-    "styled-components"
-  ],
-  "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
   "publishConfig": {
     "access": "public"
-  },
-  "repository": "git@github.com:callstack/linaria.git",
-  "scripts": {
-    "build": "pnpm build:dist && pnpm build:declarations",
-    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
-    "build:dist": "tsup --format cjs,esm",
-    "typecheck": "tsc --noEmit --composite false",
-    "watch": "pnpm build:dist --watch & pnpm build:declarations --watch"
   },
   "tsup": {
     "entry": [
@@ -56,6 +57,5 @@
     "splitting": false,
     "sourcemap": true,
     "clean": true
-  },
-  "types": "types"
+  }
 }

--- a/packages/extractor/package.json
+++ b/packages/extractor/package.json
@@ -1,17 +1,7 @@
 {
   "name": "@linaria/extractor",
-  "description": "Blazing fast zero-runtime CSS in JS library",
   "version": "4.0.0",
-  "bugs": "https://github.com/callstack/linaria/issues",
-  "engines": {
-    "node": "^12.16.0 || >=13.7.0"
-  },
-  "files": [
-    "types/",
-    "lib/",
-    "esm/"
-  ],
-  "homepage": "https://github.com/callstack/linaria#readme",
+  "description": "Blazing fast zero-runtime CSS in JS library",
   "keywords": [
     "babel",
     "babel-plugin",
@@ -21,13 +11,18 @@
     "react",
     "styled-components"
   ],
+  "homepage": "https://github.com/callstack/linaria#readme",
+  "bugs": "https://github.com/callstack/linaria/issues",
+  "repository": "git@github.com:callstack/linaria.git",
   "license": "MIT",
   "main": "lib/index.js",
   "module": "esm/index.js",
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": "git@github.com:callstack/linaria.git",
+  "types": "types",
+  "files": [
+    "types/",
+    "lib/",
+    "esm/"
+  ],
   "scripts": {
     "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
@@ -36,5 +31,10 @@
     "typecheck": "tsc --noEmit --composite false",
     "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
   },
-  "types": "types"
+  "engines": {
+    "node": "^12.16.0 || >=13.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/griffel/package.json
+++ b/packages/griffel/package.json
@@ -1,8 +1,36 @@
 {
   "name": "@linaria/griffel",
-  "description": "Blazing fast zero-runtime CSS in JS library",
   "version": "4.2.0",
+  "description": "Blazing fast zero-runtime CSS in JS library",
+  "keywords": [
+    "css",
+    "css-in-js",
+    "linaria",
+    "react",
+    "styled-components"
+  ],
+  "homepage": "https://github.com/callstack/linaria#readme",
   "bugs": "https://github.com/callstack/linaria/issues",
+  "repository": "git@github.com:callstack/linaria.git",
+  "license": "MIT",
+  "sideEffects": false,
+  "main": "lib/index.js",
+  "module": "esm/index.js",
+  "types": "types/index.d.ts",
+  "files": [
+    "esm/",
+    "lib/",
+    "processors/",
+    "types/"
+  ],
+  "scripts": {
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
+    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
+    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "typecheck": "tsc --noEmit --composite false",
+    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
+  },
   "dependencies": {
     "@griffel/core": "^1.5.0",
     "@linaria/logger": "workspace:^",
@@ -16,40 +44,12 @@
   "engines": {
     "node": "^12.16.0 || >=13.7.0"
   },
-  "files": [
-    "esm/",
-    "lib/",
-    "processors/",
-    "types/"
-  ],
-  "homepage": "https://github.com/callstack/linaria#readme",
-  "keywords": [
-    "css",
-    "css-in-js",
-    "linaria",
-    "react",
-    "styled-components"
-  ],
-  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "linaria": {
     "tags": {
       "makeStyles": "./lib/processors/makeStyles.js"
     }
-  },
-  "main": "lib/index.js",
-  "module": "esm/index.js",
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": "git@github.com:callstack/linaria.git",
-  "scripts": {
-    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
-    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
-    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "typecheck": "tsc --noEmit --composite false",
-    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
-  },
-  "sideEffects": false,
-  "types": "types/index.d.ts"
+  }
 }

--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -1,9 +1,29 @@
 {
   "name": "@linaria/babel-plugin-interop",
   "version": "4.0.0",
+  "homepage": "https://github.com/callstack/linaria/tree/master/packages/interop#readme",
+  "repository": "git@github.com:callstack/linaria.git",
+  "license": "MIT",
   "author": {
     "name": "Anton Evzhakov",
     "email": "anton@evz.name"
+  },
+  "main": "lib/index.js",
+  "module": "esm/index.js",
+  "types": "types",
+  "files": [
+    "types/",
+    "lib/",
+    "esm/"
+  ],
+  "scripts": {
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
+    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
+    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "test": "jest --config ../../jest.config.js --rootDir .",
+    "typecheck": "tsc --noEmit --composite false",
+    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
   },
   "devDependencies": {
     "@babel/core": "^7.18.9",
@@ -16,27 +36,7 @@
   "engines": {
     "node": "^12.16.0 || >=13.7.0"
   },
-  "files": [
-    "types/",
-    "lib/",
-    "esm/"
-  ],
-  "homepage": "https://github.com/callstack/linaria/tree/master/packages/interop#readme",
-  "license": "MIT",
-  "main": "lib/index.js",
-  "module": "esm/index.js",
   "publishConfig": {
     "access": "public"
-  },
-  "repository": "git@github.com:callstack/linaria.git",
-  "scripts": {
-    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
-    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
-    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "test": "jest --config ../../jest.config.js --rootDir .",
-    "typecheck": "tsc --noEmit --composite false",
-    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
-  },
-  "types": "types"
+  }
 }

--- a/packages/linaria/package.json
+++ b/packages/linaria/package.json
@@ -1,8 +1,43 @@
 {
   "name": "linaria",
-  "description": "Blazing fast zero-runtime CSS in JS library",
   "version": "4.1.8",
+  "description": "Blazing fast zero-runtime CSS in JS library",
+  "keywords": [
+    "babel",
+    "babel-plugin",
+    "css",
+    "css-in-js",
+    "linaria",
+    "react",
+    "styled-components"
+  ],
+  "homepage": "https://github.com/callstack/linaria#readme",
   "bugs": "https://github.com/callstack/linaria/issues",
+  "repository": "git@github.com:callstack/linaria.git",
+  "license": "MIT",
+  "main": "lib/core.js",
+  "module": "esm/core.js",
+  "types": "types/core.d.ts",
+  "files": [
+    "babel",
+    "evaluators",
+    "loader",
+    "react",
+    "rollup",
+    "server",
+    "stylelint-config",
+    "types/",
+    "lib/",
+    "esm/"
+  ],
+  "scripts": {
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
+    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
+    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "typecheck": "tsc --noEmit --composite false",
+    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
+  },
   "dependencies": {
     "@linaria/babel-preset": "workspace:^",
     "@linaria/core": "workspace:^",
@@ -17,48 +52,13 @@
   "engines": {
     "node": "^12.16.0 || >=13.7.0"
   },
-  "files": [
-    "babel",
-    "evaluators",
-    "loader",
-    "react",
-    "rollup",
-    "server",
-    "stylelint-config",
-    "types/",
-    "lib/",
-    "esm/"
-  ],
-  "homepage": "https://github.com/callstack/linaria#readme",
-  "keywords": [
-    "babel",
-    "babel-plugin",
-    "css",
-    "css-in-js",
-    "linaria",
-    "react",
-    "styled-components"
-  ],
-  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "linaria": {
     "tags": {
       "css": "@linaria/core/processors/css",
       "styled": "@linaria/react/processors/styled"
     }
-  },
-  "main": "lib/core.js",
-  "module": "esm/core.js",
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": "git@github.com:callstack/linaria.git",
-  "scripts": {
-    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
-    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
-    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "typecheck": "tsc --noEmit --composite false",
-    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
-  },
-  "types": "types/core.d.ts"
+  }
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,8 +1,34 @@
 {
   "name": "@linaria/logger",
-  "description": "Blazing fast zero-runtime CSS in JS library",
   "version": "4.0.0",
+  "description": "Blazing fast zero-runtime CSS in JS library",
+  "keywords": [
+    "css",
+    "css-in-js",
+    "linaria",
+    "react",
+    "styled-components"
+  ],
+  "homepage": "https://github.com/callstack/linaria#readme",
   "bugs": "https://github.com/callstack/linaria/issues",
+  "repository": "git@github.com:callstack/linaria.git",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "module": "esm/index.js",
+  "types": "types",
+  "files": [
+    "types/",
+    "lib/",
+    "esm/"
+  ],
+  "scripts": {
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
+    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
+    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "typecheck": "tsc --noEmit --composite false",
+    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
+  },
   "dependencies": {
     "debug": "^4.1.1",
     "picocolors": "^1.0.0"
@@ -14,33 +40,7 @@
   "engines": {
     "node": "^12.16.0 || >=13.7.0"
   },
-  "files": [
-    "types/",
-    "lib/",
-    "esm/"
-  ],
-  "homepage": "https://github.com/callstack/linaria#readme",
-  "keywords": [
-    "css",
-    "css-in-js",
-    "linaria",
-    "react",
-    "styled-components"
-  ],
-  "license": "MIT",
-  "main": "lib/index.js",
-  "module": "esm/index.js",
   "publishConfig": {
     "access": "public"
-  },
-  "repository": "git@github.com:callstack/linaria.git",
-  "scripts": {
-    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
-    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
-    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "typecheck": "tsc --noEmit --composite false",
-    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
-  },
-  "types": "types"
+  }
 }

--- a/packages/postcss-linaria/package.json
+++ b/packages/postcss-linaria/package.json
@@ -1,8 +1,36 @@
 {
   "name": "@linaria/postcss-linaria",
-  "description": "Blazing fast zero-runtime CSS in JS library",
   "version": "4.1.4",
+  "description": "Blazing fast zero-runtime CSS in JS library",
+  "keywords": [
+    "css",
+    "css-in-js",
+    "linaria",
+    "react",
+    "styled-components"
+  ],
+  "homepage": "https://github.com/callstack/linaria#readme",
   "bugs": "https://github.com/callstack/linaria/issues",
+  "repository": "git@github.com:callstack/linaria.git",
+  "license": "MIT",
+  "sideEffects": false,
+  "main": "lib/index.js",
+  "module": "esm/index.js",
+  "types": "types/index.d.ts",
+  "files": [
+    "esm/",
+    "lib/",
+    "processors/",
+    "types/"
+  ],
+  "scripts": {
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
+    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
+    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "typecheck": "tsc --noEmit --composite false",
+    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
+  },
   "dependencies": {
     "@babel/generator": "^7.18.9",
     "@babel/parser": "^7.18.13",
@@ -15,47 +43,19 @@
     "@types/babel__traverse": "^7.17.1",
     "postcss": "^8.3.11"
   },
+  "peerDependencies": {
+    "postcss": "^8.3.11"
+  },
   "engines": {
     "node": "^12.16.0 || >=13.7.0"
   },
-  "files": [
-    "esm/",
-    "lib/",
-    "processors/",
-    "types/"
-  ],
-  "homepage": "https://github.com/callstack/linaria#readme",
-  "keywords": [
-    "css",
-    "css-in-js",
-    "linaria",
-    "react",
-    "styled-components"
-  ],
-  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "linaria": {
     "tags": {
       "css": "./lib/processors/css.js",
       "styled": "./lib/processors/styled.js"
     }
-  },
-  "main": "lib/index.js",
-  "module": "esm/index.js",
-  "peerDependencies": {
-    "postcss": "^8.3.11"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": "git@github.com:callstack/linaria.git",
-  "scripts": {
-    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
-    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
-    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "typecheck": "tsc --noEmit --composite false",
-    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
-  },
-  "sideEffects": false,
-  "types": "types/index.d.ts"
+  }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,8 +1,57 @@
 {
   "name": "@linaria/react",
-  "description": "Blazing fast zero-runtime CSS in JS library",
   "version": "4.3.0",
+  "description": "Blazing fast zero-runtime CSS in JS library",
+  "keywords": [
+    "css",
+    "css-in-js",
+    "linaria",
+    "react",
+    "styled-components"
+  ],
+  "homepage": "https://github.com/callstack/linaria#readme",
   "bugs": "https://github.com/callstack/linaria/issues",
+  "repository": "git@github.com:callstack/linaria.git",
+  "license": "MIT",
+  "sideEffects": false,
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./types/index.d.ts",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.js"
+    },
+    "./*": {
+      "types": "./types/*.d.ts",
+      "import": "./dist/*.mjs",
+      "default": "./dist/*.js"
+    }
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "processors/*": [
+        "./types/processors/*.d.ts"
+      ]
+    }
+  },
+  "files": [
+    "dist/",
+    "processors/",
+    "types/"
+  ],
+  "scripts": {
+    "build": "pnpm build:dist && pnpm build:declarations",
+    "build:corejs-test": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --ignore \"src/processors/**/*\"",
+    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
+    "build:dist": "tsup --format cjs,esm",
+    "test": "jest --config ../../jest.config.js --rootDir .",
+    "test:dts": "dtslint --localTs ../../node_modules/typescript/lib __dtslint__",
+    "typecheck": "tsc --noEmit --composite false",
+    "watch": "pnpm build:dist --watch & pnpm build:declarations --watch"
+  },
   "dependencies": {
     "@emotion/is-prop-valid": "^1.2.0",
     "@linaria/core": "workspace:^",
@@ -19,61 +68,20 @@
     "react": "^16.14.0",
     "react-test-renderer": "^16.8.3"
   },
+  "peerDependencies": {
+    "react": ">=16"
+  },
   "engines": {
     "node": "^12.16.0 || >=13.7.0"
   },
-  "exports": {
-    "./package.json": "./package.json",
-    ".": {
-      "types": "./types/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
-    },
-    "./*": {
-      "types": "./types/*.d.ts",
-      "import": "./dist/*.mjs",
-      "default": "./dist/*.js"
-    }
+  "publishConfig": {
+    "access": "public"
   },
-  "files": [
-    "dist/",
-    "processors/",
-    "types/"
-  ],
-  "homepage": "https://github.com/callstack/linaria#readme",
-  "keywords": [
-    "css",
-    "css-in-js",
-    "linaria",
-    "react",
-    "styled-components"
-  ],
-  "license": "MIT",
   "linaria": {
     "tags": {
       "styled": "./dist/processors/styled.js"
     }
   },
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
-  "peerDependencies": {
-    "react": ">=16"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": "git@github.com:callstack/linaria.git",
-  "scripts": {
-    "build": "pnpm build:dist && pnpm build:declarations",
-    "build:corejs-test": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --ignore \"src/processors/**/*\"",
-    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
-    "build:dist": "tsup --format cjs,esm",
-    "test": "jest --config ../../jest.config.js --rootDir .",
-    "test:dts": "dtslint --localTs ../../node_modules/typescript/lib __dtslint__",
-    "typecheck": "tsc --noEmit --composite false",
-    "watch": "pnpm build:dist --watch & pnpm build:declarations --watch"
-  },
-  "sideEffects": false,
   "tsup": {
     "entry": [
       "src/index.ts",
@@ -82,13 +90,5 @@
     "splitting": false,
     "sourcemap": true,
     "clean": true
-  },
-  "types": "types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "processors/*": [
-        "./types/processors/*.d.ts"
-      ]
-    }
   }
 }

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -1,8 +1,41 @@
 {
   "name": "@linaria/rollup",
-  "description": "Blazing fast zero-runtime CSS in JS library",
   "version": "4.2.2",
+  "description": "Blazing fast zero-runtime CSS in JS library",
+  "keywords": [
+    "babel",
+    "babel-plugin",
+    "css",
+    "css-in-js",
+    "linaria",
+    "react",
+    "rollup",
+    "rollup-plugin",
+    "styled-components"
+  ],
+  "homepage": "https://github.com/callstack/linaria#readme",
   "bugs": "https://github.com/callstack/linaria/issues",
+  "repository": "git@github.com:callstack/linaria.git",
+  "license": "MIT",
+  "exports": {
+    "import": "./dist/index.mjs",
+    "require": "./dist/index.js",
+    "types": "./types/index.d.ts"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "types/index.d.ts",
+  "files": [
+    "dist/",
+    "types/"
+  ],
+  "scripts": {
+    "build": "pnpm build:dist && pnpm build:declarations",
+    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
+    "build:dist": "tsup --format cjs,esm",
+    "typecheck": "tsc --noEmit --composite false",
+    "watch": "pnpm build:dist --watch & pnpm build:declarations --watch"
+  },
   "dependencies": {
     "@linaria/babel-preset": "workspace:^",
     "@linaria/logger": "workspace:^",
@@ -16,40 +49,8 @@
   "engines": {
     "node": "^12.16.0 || >=13.7.0"
   },
-  "exports": {
-    "import": "./dist/index.mjs",
-    "require": "./dist/index.js",
-    "types": "./types/index.d.ts"
-  },
-  "files": [
-    "dist/",
-    "types/"
-  ],
-  "homepage": "https://github.com/callstack/linaria#readme",
-  "keywords": [
-    "babel",
-    "babel-plugin",
-    "css",
-    "css-in-js",
-    "linaria",
-    "react",
-    "rollup",
-    "rollup-plugin",
-    "styled-components"
-  ],
-  "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
   "publishConfig": {
     "access": "public"
-  },
-  "repository": "git@github.com:callstack/linaria.git",
-  "scripts": {
-    "build": "pnpm build:dist && pnpm build:declarations",
-    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
-    "build:dist": "tsup --format cjs,esm",
-    "typecheck": "tsc --noEmit --composite false",
-    "watch": "pnpm build:dist --watch & pnpm build:declarations --watch"
   },
   "tsup": {
     "entry": [
@@ -58,6 +59,5 @@
     "splitting": false,
     "sourcemap": true,
     "clean": true
-  },
-  "types": "types/index.d.ts"
+  }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,8 +1,34 @@
 {
   "name": "@linaria/server",
-  "description": "Blazing fast zero-runtime CSS in JS library",
   "version": "4.0.0",
+  "description": "Blazing fast zero-runtime CSS in JS library",
+  "keywords": [
+    "css",
+    "css-in-js",
+    "linaria",
+    "react",
+    "styled-components"
+  ],
+  "homepage": "https://github.com/callstack/linaria#readme",
   "bugs": "https://github.com/callstack/linaria/issues",
+  "repository": "git@github.com:callstack/linaria.git",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "module": "esm/index.js",
+  "types": "types",
+  "files": [
+    "types/",
+    "lib/",
+    "esm/"
+  ],
+  "scripts": {
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
+    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
+    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "typecheck": "tsc --noEmit --composite false",
+    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
+  },
   "dependencies": {
     "postcss": "^8.3.11"
   },
@@ -14,33 +40,7 @@
   "engines": {
     "node": "^12.16.0 || >=13.7.0"
   },
-  "files": [
-    "types/",
-    "lib/",
-    "esm/"
-  ],
-  "homepage": "https://github.com/callstack/linaria#readme",
-  "keywords": [
-    "css",
-    "css-in-js",
-    "linaria",
-    "react",
-    "styled-components"
-  ],
-  "license": "MIT",
-  "main": "lib/index.js",
-  "module": "esm/index.js",
   "publishConfig": {
     "access": "public"
-  },
-  "repository": "git@github.com:callstack/linaria.git",
-  "scripts": {
-    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
-    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
-    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "typecheck": "tsc --noEmit --composite false",
-    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
-  },
-  "types": "types"
+  }
 }

--- a/packages/shaker/package.json
+++ b/packages/shaker/package.json
@@ -1,8 +1,37 @@
 {
   "name": "@linaria/shaker",
-  "description": "Blazing fast zero-runtime CSS in JS library",
   "version": "4.2.4",
+  "description": "Blazing fast zero-runtime CSS in JS library",
+  "keywords": [
+    "babel",
+    "babel-plugin",
+    "css",
+    "css-in-js",
+    "linaria",
+    "react",
+    "styled-components"
+  ],
+  "homepage": "https://github.com/callstack/linaria#readme",
   "bugs": "https://github.com/callstack/linaria/issues",
+  "repository": "git@github.com:callstack/linaria.git",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "module": "esm/index.js",
+  "types": "types",
+  "files": [
+    "types/",
+    "lib/",
+    "esm/"
+  ],
+  "scripts": {
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
+    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
+    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "test": "jest --config ./jest.config.js --rootDir src",
+    "typecheck": "tsc --noEmit --composite false",
+    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
+  },
   "dependencies": {
     "@babel/core": "^7.18.9",
     "@babel/generator": "^7.18.9",
@@ -31,36 +60,7 @@
   "engines": {
     "node": "^12.16.0 || >=13.7.0"
   },
-  "files": [
-    "types/",
-    "lib/",
-    "esm/"
-  ],
-  "homepage": "https://github.com/callstack/linaria#readme",
-  "keywords": [
-    "babel",
-    "babel-plugin",
-    "css",
-    "css-in-js",
-    "linaria",
-    "react",
-    "styled-components"
-  ],
-  "license": "MIT",
-  "main": "lib/index.js",
-  "module": "esm/index.js",
   "publishConfig": {
     "access": "public"
-  },
-  "repository": "git@github.com:callstack/linaria.git",
-  "scripts": {
-    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
-    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
-    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "test": "jest --config ./jest.config.js --rootDir src",
-    "typecheck": "tsc --noEmit --composite false",
-    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
-  },
-  "types": "types"
+  }
 }

--- a/packages/stylelint-config-standard-linaria/package.json
+++ b/packages/stylelint-config-standard-linaria/package.json
@@ -1,23 +1,7 @@
 {
   "name": "@linaria/stylelint-config-standard-linaria",
-  "description": "Blazing fast zero-runtime CSS in JS library",
   "version": "4.1.4",
-  "bugs": "https://github.com/callstack/linaria/issues",
-  "dependencies": {
-    "@linaria/postcss-linaria": "workspace:^",
-    "stylelint": "^14.11.0",
-    "stylelint-config-standard": "^28.0.0"
-  },
-  "engines": {
-    "node": "^12.16.0 || >=13.7.0"
-  },
-  "files": [
-    "esm/",
-    "lib/",
-    "processors/",
-    "types/"
-  ],
-  "homepage": "https://github.com/callstack/linaria#readme",
+  "description": "Blazing fast zero-runtime CSS in JS library",
   "keywords": [
     "css",
     "css-in-js",
@@ -25,19 +9,20 @@
     "react",
     "styled-components"
   ],
+  "homepage": "https://github.com/callstack/linaria#readme",
+  "bugs": "https://github.com/callstack/linaria/issues",
+  "repository": "git@github.com:callstack/linaria.git",
   "license": "MIT",
-  "linaria": {
-    "tags": {
-      "css": "./lib/processors/css.js",
-      "styled": "./lib/processors/styled.js"
-    }
-  },
+  "sideEffects": false,
   "main": "lib/index.js",
   "module": "esm/index.js",
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": "git@github.com:callstack/linaria.git",
+  "types": "types/index.d.ts",
+  "files": [
+    "esm/",
+    "lib/",
+    "processors/",
+    "types/"
+  ],
   "scripts": {
     "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
@@ -46,6 +31,21 @@
     "typecheck": "tsc --noEmit --composite false",
     "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
   },
-  "sideEffects": false,
-  "types": "types/index.d.ts"
+  "dependencies": {
+    "@linaria/postcss-linaria": "workspace:^",
+    "stylelint": "^14.11.0",
+    "stylelint-config-standard": "^28.0.0"
+  },
+  "engines": {
+    "node": "^12.16.0 || >=13.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "linaria": {
+    "tags": {
+      "css": "./lib/processors/css.js",
+      "styled": "./lib/processors/styled.js"
+    }
+  }
 }

--- a/packages/stylelint/package.json
+++ b/packages/stylelint/package.json
@@ -1,8 +1,34 @@
 {
   "name": "@linaria/stylelint",
-  "description": "Blazing fast zero-runtime CSS in JS library",
   "version": "4.1.8",
+  "description": "Blazing fast zero-runtime CSS in JS library",
+  "keywords": [
+    "css",
+    "css-in-js",
+    "linaria",
+    "react",
+    "styled-components"
+  ],
+  "homepage": "https://github.com/callstack/linaria#readme",
   "bugs": "https://github.com/callstack/linaria/issues",
+  "repository": "git@github.com:callstack/linaria.git",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "module": "esm/index.js",
+  "types": "types",
+  "files": [
+    "types/",
+    "lib/",
+    "esm/"
+  ],
+  "scripts": {
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
+    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
+    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "typecheck": "tsc --noEmit --composite false",
+    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
+  },
   "dependencies": {
     "@linaria/babel-preset": "workspace:^",
     "@linaria/utils": "workspace:^",
@@ -14,33 +40,7 @@
   "engines": {
     "node": "^12.16.0 || >=13.7.0"
   },
-  "files": [
-    "types/",
-    "lib/",
-    "esm/"
-  ],
-  "homepage": "https://github.com/callstack/linaria#readme",
-  "keywords": [
-    "css",
-    "css-in-js",
-    "linaria",
-    "react",
-    "styled-components"
-  ],
-  "license": "MIT",
-  "main": "lib/index.js",
-  "module": "esm/index.js",
   "publishConfig": {
     "access": "public"
-  },
-  "repository": "git@github.com:callstack/linaria.git",
-  "scripts": {
-    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
-    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
-    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "typecheck": "tsc --noEmit --composite false",
-    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
-  },
-  "types": "types"
+  }
 }

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -1,8 +1,35 @@
 {
   "name": "@linaria/tags",
-  "description": "Blazing fast zero-runtime CSS in JS library",
   "version": "4.2.0",
+  "description": "Blazing fast zero-runtime CSS in JS library",
+  "keywords": [
+    "css",
+    "css-in-js",
+    "linaria",
+    "react",
+    "styled-components"
+  ],
+  "homepage": "https://github.com/callstack/linaria#readme",
   "bugs": "https://github.com/callstack/linaria/issues",
+  "repository": "git@github.com:callstack/linaria.git",
+  "license": "MIT",
+  "sideEffects": false,
+  "main": "lib/index.js",
+  "module": "esm/index.js",
+  "types": "types/index.d.ts",
+  "files": [
+    "types/",
+    "lib/",
+    "esm/"
+  ],
+  "scripts": {
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
+    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
+    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "typecheck": "tsc --noEmit --composite false",
+    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
+  },
   "dependencies": {
     "@babel/generator": "^7.18.9",
     "@linaria/logger": "workspace:^",
@@ -19,34 +46,7 @@
   "engines": {
     "node": "^12.16.0 || >=13.7.0"
   },
-  "files": [
-    "types/",
-    "lib/",
-    "esm/"
-  ],
-  "homepage": "https://github.com/callstack/linaria#readme",
-  "keywords": [
-    "css",
-    "css-in-js",
-    "linaria",
-    "react",
-    "styled-components"
-  ],
-  "license": "MIT",
-  "main": "lib/index.js",
-  "module": "esm/index.js",
   "publishConfig": {
     "access": "public"
-  },
-  "repository": "git@github.com:callstack/linaria.git",
-  "scripts": {
-    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
-    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
-    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "typecheck": "tsc --noEmit --composite false",
-    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
-  },
-  "sideEffects": false,
-  "types": "types/index.d.ts"
+  }
 }

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -1,8 +1,25 @@
 {
   "name": "@linaria/testkit",
-  "description": "Blazing fast zero-runtime CSS in JS library",
   "version": "4.2.0",
+  "private": true,
+  "description": "Blazing fast zero-runtime CSS in JS library",
+  "keywords": [
+    "babel",
+    "babel-plugin",
+    "css",
+    "css-in-js",
+    "linaria",
+    "react",
+    "styled-components"
+  ],
+  "homepage": "https://github.com/callstack/linaria#readme",
   "bugs": "https://github.com/callstack/linaria/issues",
+  "repository": "git@github.com:callstack/linaria.git",
+  "license": "MIT",
+  "scripts": {
+    "test": "jest --config ./jest.config.js --rootDir .",
+    "typecheck": "tsc --noEmit --composite false"
+  },
   "dependencies": {
     "@babel/core": "^7.18.9",
     "@babel/generator": "^7.18.9",
@@ -42,24 +59,7 @@
   "engines": {
     "node": "^12.16.0 || >=13.7.0"
   },
-  "homepage": "https://github.com/callstack/linaria#readme",
-  "keywords": [
-    "babel",
-    "babel-plugin",
-    "css",
-    "css-in-js",
-    "linaria",
-    "react",
-    "styled-components"
-  ],
-  "license": "MIT",
-  "private": true,
   "publishConfig": {
     "access": "public"
-  },
-  "repository": "git@github.com:callstack/linaria.git",
-  "scripts": {
-    "test": "jest --config ./jest.config.js --rootDir .",
-    "typecheck": "tsc --noEmit --composite false"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,8 +1,35 @@
 {
   "name": "@linaria/utils",
-  "description": "Blazing fast zero-runtime CSS in JS library",
   "version": "4.2.4",
+  "description": "Blazing fast zero-runtime CSS in JS library",
+  "keywords": [
+    "css",
+    "css-in-js",
+    "linaria",
+    "react",
+    "styled-components"
+  ],
+  "homepage": "https://github.com/callstack/linaria#readme",
   "bugs": "https://github.com/callstack/linaria/issues",
+  "repository": "git@github.com:callstack/linaria.git",
+  "license": "MIT",
+  "sideEffects": false,
+  "main": "lib/index.js",
+  "module": "esm/index.js",
+  "types": "types/index.d.ts",
+  "files": [
+    "types/",
+    "lib/",
+    "esm/"
+  ],
+  "scripts": {
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
+    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
+    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "typecheck": "tsc --noEmit --composite false",
+    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
+  },
   "dependencies": {
     "@babel/core": "^7.18.9",
     "@babel/plugin-proposal-export-namespace-from": ">=7",
@@ -21,34 +48,7 @@
   "engines": {
     "node": "^12.16.0 || >=13.7.0"
   },
-  "files": [
-    "types/",
-    "lib/",
-    "esm/"
-  ],
-  "homepage": "https://github.com/callstack/linaria#readme",
-  "keywords": [
-    "css",
-    "css-in-js",
-    "linaria",
-    "react",
-    "styled-components"
-  ],
-  "license": "MIT",
-  "main": "lib/index.js",
-  "module": "esm/index.js",
   "publishConfig": {
     "access": "public"
-  },
-  "repository": "git@github.com:callstack/linaria.git",
-  "scripts": {
-    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
-    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
-    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "typecheck": "tsc --noEmit --composite false",
-    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
-  },
-  "sideEffects": false,
-  "types": "types/index.d.ts"
+  }
 }

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,31 +1,7 @@
 {
   "name": "@linaria/vite",
-  "description": "Blazing fast zero-runtime CSS in JS library",
   "version": "4.2.2",
-  "bugs": "https://github.com/callstack/linaria/issues",
-  "dependencies": {
-    "@linaria/babel-preset": "workspace:^",
-    "@linaria/logger": "workspace:^",
-    "@linaria/utils": "workspace:^",
-    "@rollup/pluginutils": "^4.1.0"
-  },
-  "devDependencies": {
-    "@types/node": "^17.0.39",
-    "vite": "^3.1.8"
-  },
-  "engines": {
-    "node": "^12.16.0 || >=13.7.0"
-  },
-  "exports": {
-    "import": "./dist/index.mjs",
-    "require": "./dist/index.js",
-    "types": "./types/index.d.ts"
-  },
-  "files": [
-    "dist/",
-    "types/"
-  ],
-  "homepage": "https://github.com/callstack/linaria#readme",
+  "description": "Blazing fast zero-runtime CSS in JS library",
   "keywords": [
     "babel",
     "babel-plugin",
@@ -37,22 +13,47 @@
     "vite",
     "vite-plugin"
   ],
+  "homepage": "https://github.com/callstack/linaria#readme",
+  "bugs": "https://github.com/callstack/linaria/issues",
+  "repository": "git@github.com:callstack/linaria.git",
   "license": "MIT",
+  "exports": {
+    "import": "./dist/index.mjs",
+    "require": "./dist/index.js",
+    "types": "./types/index.d.ts"
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
-  "peerDependencies": {
-    "vite": "^3.1.8"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": "git@github.com:callstack/linaria.git",
+  "types": "types/index.d.ts",
+  "files": [
+    "dist/",
+    "types/"
+  ],
   "scripts": {
     "build": "npm run build:dist && npm run build:declarations",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
     "build:dist": "tsup --format cjs,esm",
     "typecheck": "tsc --noEmit --composite false",
     "watch": "npm run build --watch"
+  },
+  "dependencies": {
+    "@linaria/babel-preset": "workspace:^",
+    "@linaria/logger": "workspace:^",
+    "@linaria/utils": "workspace:^",
+    "@rollup/pluginutils": "^4.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.39",
+    "vite": "^3.1.8"
+  },
+  "peerDependencies": {
+    "vite": "^3.1.8"
+  },
+  "engines": {
+    "node": "^12.16.0 || >=13.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "tsup": {
     "entry": [
@@ -61,6 +62,5 @@
     "splitting": false,
     "sourcemap": true,
     "clean": true
-  },
-  "types": "types/index.d.ts"
+  }
 }

--- a/packages/webpack-loader/package.json
+++ b/packages/webpack-loader/package.json
@@ -1,21 +1,7 @@
 {
   "name": "@linaria/webpack-loader",
-  "description": "Blazing fast zero-runtime CSS in JS library",
   "version": "4.1.8",
-  "bugs": "https://github.com/callstack/linaria/issues",
-  "dependencies": {
-    "@linaria/webpack4-loader": "workspace:^",
-    "@linaria/webpack5-loader": "workspace:^"
-  },
-  "engines": {
-    "node": "^12.16.0 || >=13.7.0"
-  },
-  "files": [
-    "types/",
-    "lib/",
-    "esm/"
-  ],
-  "homepage": "https://github.com/callstack/linaria#readme",
+  "description": "Blazing fast zero-runtime CSS in JS library",
   "keywords": [
     "babel",
     "babel-plugin",
@@ -25,13 +11,18 @@
     "react",
     "styled-components"
   ],
+  "homepage": "https://github.com/callstack/linaria#readme",
+  "bugs": "https://github.com/callstack/linaria/issues",
+  "repository": "git@github.com:callstack/linaria.git",
   "license": "MIT",
   "main": "lib/index.js",
   "module": "esm/index.js",
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": "git@github.com:callstack/linaria.git",
+  "types": "types/index.d.ts",
+  "files": [
+    "types/",
+    "lib/",
+    "esm/"
+  ],
   "scripts": {
     "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
@@ -40,5 +31,14 @@
     "typecheck": "tsc --noEmit --composite false",
     "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
   },
-  "types": "types/index.d.ts"
+  "dependencies": {
+    "@linaria/webpack4-loader": "workspace:^",
+    "@linaria/webpack5-loader": "workspace:^"
+  },
+  "engines": {
+    "node": "^12.16.0 || >=13.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/webpack4-loader/package.json
+++ b/packages/webpack4-loader/package.json
@@ -1,8 +1,36 @@
 {
   "name": "@linaria/webpack4-loader",
-  "description": "Blazing fast zero-runtime CSS in JS library",
   "version": "4.1.8",
+  "description": "Blazing fast zero-runtime CSS in JS library",
+  "keywords": [
+    "babel",
+    "babel-plugin",
+    "css",
+    "css-in-js",
+    "linaria",
+    "react",
+    "styled-components"
+  ],
+  "homepage": "https://github.com/callstack/linaria#readme",
   "bugs": "https://github.com/callstack/linaria/issues",
+  "repository": "git@github.com:callstack/linaria.git",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "module": "esm/index.js",
+  "types": "types",
+  "files": [
+    "types/",
+    "lib/",
+    "esm/"
+  ],
+  "scripts": {
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
+    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
+    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "typecheck": "tsc --noEmit --composite false",
+    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & --watch & pnpm build:declarations --watch"
+  },
   "dependencies": {
     "@linaria/babel-preset": "workspace:^",
     "@linaria/logger": "workspace:^",
@@ -18,41 +46,13 @@
     "@types/webpack": "^4.41.33",
     "source-map": "^0.7.3"
   },
-  "engines": {
-    "node": "^12.16.0 || >=13.7.0"
-  },
-  "files": [
-    "types/",
-    "lib/",
-    "esm/"
-  ],
-  "homepage": "https://github.com/callstack/linaria#readme",
-  "keywords": [
-    "babel",
-    "babel-plugin",
-    "css",
-    "css-in-js",
-    "linaria",
-    "react",
-    "styled-components"
-  ],
-  "license": "MIT",
-  "main": "lib/index.js",
-  "module": "esm/index.js",
   "peerDependencies": {
     "webpack": ">=4.0.0 <5.0.0"
   },
+  "engines": {
+    "node": "^12.16.0 || >=13.7.0"
+  },
   "publishConfig": {
     "access": "public"
-  },
-  "repository": "git@github.com:callstack/linaria.git",
-  "scripts": {
-    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
-    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
-    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "typecheck": "tsc --noEmit --composite false",
-    "watch": "pnpm build:lib --watch & pnpm build:esm --watch & --watch & pnpm build:declarations --watch"
-  },
-  "types": "types"
+  }
 }

--- a/packages/webpack5-loader/package.json
+++ b/packages/webpack5-loader/package.json
@@ -1,8 +1,36 @@
 {
   "name": "@linaria/webpack5-loader",
-  "description": "Blazing fast zero-runtime CSS in JS library",
   "version": "4.1.8",
+  "description": "Blazing fast zero-runtime CSS in JS library",
+  "keywords": [
+    "babel",
+    "babel-plugin",
+    "css",
+    "css-in-js",
+    "linaria",
+    "react",
+    "styled-components"
+  ],
+  "homepage": "https://github.com/callstack/linaria#readme",
   "bugs": "https://github.com/callstack/linaria/issues",
+  "repository": "git@github.com:callstack/linaria.git",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "module": "esm/index.js",
+  "types": "types",
+  "files": [
+    "types/",
+    "lib/",
+    "esm/"
+  ],
+  "scripts": {
+    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
+    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
+    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "typecheck": "tsc --noEmit --composite false",
+    "watch": "pnpm build --watch"
+  },
   "dependencies": {
     "@linaria/babel-preset": "workspace:^",
     "@linaria/logger": "workspace:^",
@@ -16,41 +44,13 @@
     "source-map": "^0.7.3",
     "webpack": "^5.6.0"
   },
-  "engines": {
-    "node": "^12.16.0 || >=13.7.0"
-  },
-  "files": [
-    "types/",
-    "lib/",
-    "esm/"
-  ],
-  "homepage": "https://github.com/callstack/linaria#readme",
-  "keywords": [
-    "babel",
-    "babel-plugin",
-    "css",
-    "css-in-js",
-    "linaria",
-    "react",
-    "styled-components"
-  ],
-  "license": "MIT",
-  "main": "lib/index.js",
-  "module": "esm/index.js",
   "peerDependencies": {
     "webpack": "^5.0.0"
   },
+  "engines": {
+    "node": "^12.16.0 || >=13.7.0"
+  },
   "publishConfig": {
     "access": "public"
-  },
-  "repository": "git@github.com:callstack/linaria.git",
-  "scripts": {
-    "build": "pnpm build:lib && pnpm build:esm && pnpm build:declarations",
-    "build:declarations": "tsc --emitDeclarationOnly --outDir types",
-    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
-    "typecheck": "tsc --noEmit --composite false",
-    "watch": "pnpm build --watch"
-  },
-  "types": "types"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,7 @@ importers:
       husky: ^1.3.1
       jest: ^28.1.0
       prettier: ^2.7.1
+      prettier-plugin-packagejson: ^2.3.0
       react: ^16.14.0
       syncpack: ^8.0.0
       tsup: ^6.3.0
@@ -81,6 +82,7 @@ importers:
       husky: 1.3.1
       jest: 28.1.0
       prettier: 2.7.1
+      prettier-plugin-packagejson: 2.3.0_prettier@2.7.1
       react: 16.14.0
       syncpack: 8.0.0
       tsup: 6.3.0_typescript@4.7.4
@@ -3982,7 +3984,7 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 3.0.5
-      '@types/node': 17.0.39
+      '@types/node': 18.11.9
     dev: true
 
   /@types/graceful-fs/4.1.5:
@@ -8312,6 +8314,10 @@ packages:
       assert-plus: 1.0.0
     dev: true
 
+  /git-hooks-list/1.0.3:
+    resolution: {integrity: sha512-Y7wLWcrLUXwk2noSka166byGCvhMtDRpgHdzCno1UQv/n/Hegp++a2xBWJL1lJarnKD3SWaljD+0z1ztqxuKyQ==}
+    dev: true
+
   /git-raw-commits/2.0.11:
     resolution: {integrity: sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==}
     engines: {node: '>=10'}
@@ -8430,6 +8436,20 @@ packages:
 
   /globalyzer/0.1.0:
     resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
+    dev: true
+
+  /globby/10.0.0:
+    resolution: {integrity: sha512-3LifW9M4joGZasyYPz2A1U74zbC/45fvpXUvO/9KbSa+VV0aGZarWkfdgKyR9sExNP0t0x0ss/UMJpNpcaTspw==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@types/glob': 7.2.0
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.2.11
+      glob: 7.2.3
+      ignore: 5.2.0
+      merge2: 1.4.1
+      slash: 3.0.0
     dev: true
 
   /globby/11.1.0:
@@ -9262,6 +9282,11 @@ packages:
   /is-plain-obj/1.1.0:
     resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
     engines: {node: '>=0.10.0'}
+
+  /is-plain-obj/2.1.0:
+    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
+    engines: {node: '>=8'}
+    dev: true
 
   /is-plain-obj/3.0.0:
     resolution: {integrity: sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==}
@@ -12115,6 +12140,18 @@ packages:
       synckit: 0.8.4
     dev: true
 
+  /prettier-plugin-packagejson/2.3.0_prettier@2.7.1:
+    resolution: {integrity: sha512-2SAPMMk1UDkqsB7DifWKcwCm6VC52JXMrzLHfbcQHJRWhRCj9zziOy+s+2XOyPBeyqFqS+A/1IKzOrxKFTo6pw==}
+    peerDependencies:
+      prettier: '>= 1.16.0'
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+    dependencies:
+      prettier: 2.7.1
+      sort-package-json: 1.57.0
+    dev: true
+
   /prettier/1.19.1:
     resolution: {integrity: sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==}
     engines: {node: '>=4'}
@@ -13239,6 +13276,22 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-plain-obj: 1.1.0
+    dev: true
+
+  /sort-object-keys/1.1.3:
+    resolution: {integrity: sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==}
+    dev: true
+
+  /sort-package-json/1.57.0:
+    resolution: {integrity: sha512-FYsjYn2dHTRb41wqnv+uEqCUvBpK3jZcTp9rbz2qDTmel7Pmdtf+i2rLaaPMRZeSVM60V3Se31GyWFpmKs4Q5Q==}
+    hasBin: true
+    dependencies:
+      detect-indent: 6.1.0
+      detect-newline: 3.1.0
+      git-hooks-list: 1.0.3
+      globby: 10.0.0
+      is-plain-obj: 2.1.0
+      sort-object-keys: 1.1.3
     dev: true
 
   /source-map-js/1.0.2:

--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -1,0 +1,6 @@
+/** @type {import('prettier').Config} */
+module.exports = {
+  trailingComma: 'es5',
+  singleQuote: true,
+  plugins: [require.resolve('prettier-plugin-packagejson')],
+};

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,26 @@
 {
   "name": "linaria-website",
-  "description": "Linaria website",
   "version": "4.1.8",
+  "private": true,
+  "description": "Linaria website",
+  "exports": {
+    ".": "./src/index.jsx",
+    "./*": "./src/*.jsx"
+  },
+  "main": "./src/index.jsx",
+  "scripts": {
+    "prebuild": "pnpm clean",
+    "build": "pnpm build:client && pnpm build:server",
+    "build:client": "cross-env NODE_ENV=production webpack",
+    "build:server": "cross-env NODE_ENV=production BABEL_ENV=server babel src --out-dir build",
+    "clean": "pnpm clean:client && pnpm clean:server",
+    "clean:client": "del dist",
+    "clean:server": "del build",
+    "lint:css": "stylelint src/**/*.jsx",
+    "server": "node build/server",
+    "prestart": "pnpm -w prepare",
+    "start": "webpack serve"
+  },
   "dependencies": {
     "@babel/runtime": "^7.18.3",
     "@linaria/atomic": "workspace:^",
@@ -39,24 +58,5 @@
     "webpack": "^5.6.0",
     "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.9.1"
-  },
-  "exports": {
-    ".": "./src/index.jsx",
-    "./*": "./src/*.jsx"
-  },
-  "main": "./src/index.jsx",
-  "private": true,
-  "scripts": {
-    "build": "pnpm build:client && pnpm build:server",
-    "build:client": "cross-env NODE_ENV=production webpack",
-    "build:server": "cross-env NODE_ENV=production BABEL_ENV=server babel src --out-dir build",
-    "clean": "pnpm clean:client && pnpm clean:server",
-    "clean:client": "del dist",
-    "clean:server": "del build",
-    "lint:css": "stylelint src/**/*.jsx",
-    "prebuild": "pnpm clean",
-    "prestart": "pnpm -w prepare",
-    "server": "node build/server",
-    "start": "webpack serve"
   }
 }


### PR DESCRIPTION
## Motivation
It's hard to manage `package.json` files as they are not formatted.

## Summary
I added plugin `prettier-plugin-packagejson`, changed prettier config because of prettier issues with pnpm: https://github.com/prettier/prettier/issues/8056
Then formatted with `pnpm exec prettier --config ./prettier.config.cjs ./*/*/package.json -w`