### PR TITLE
fix(esbuild,rollup): remove esbuild and rollup from dependencies (fixes #1139)

### DIFF
--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -6,11 +6,14 @@
   "dependencies": {
     "@babel/core": "^7.20.2",
     "@linaria/babel-preset": "workspace:^",
-    "@linaria/utils": "workspace:^",
-    "esbuild": "^0.12.5"
+    "@linaria/utils": "workspace:^"
   },
   "devDependencies": {
-    "@types/node": "^17.0.39"
+    "@types/node": "^17.0.39",
+    "esbuild": "^0.12.5"
+  },
+  "peerDependencies": {
+    "esbuild": ">=0.12.0"
   },
   "engines": {
     "node": "^12.16.0 || >=13.7.0"

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -13,6 +13,9 @@
   "devDependencies": {
     "rollup": "1.20.0||^2.0.0"
   },
+  "peerDependencies": {
+    "rollup": "1.20.0||^2.0.0"
+  },
   "engines": {
     "node": "^12.16.0 || >=13.7.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,9 +334,9 @@ importers:
       '@babel/core': 7.20.2
       '@linaria/babel-preset': link:../babel
       '@linaria/utils': link:../utils
-      esbuild: 0.12.29
     devDependencies:
       '@types/node': 17.0.39
+      esbuild: 0.12.29
 
   packages/extractor:
     specifiers: {}
@@ -2547,22 +2547,22 @@ packages:
       postcss: 8.4.16
       postcss-selector-parser: 6.0.10
 
-  /@definitelytyped/header-parser/0.0.140:
-    resolution: {integrity: sha512-bh5odviRpF3zHO9sz8OkxMIN8yqiZQSKzdgNLHLNtAEbme2p42fAzT1tEBkjmUHAJ/zntnBFyn7N/iCTcp5nmw==}
+  /@definitelytyped/header-parser/0.0.141:
+    resolution: {integrity: sha512-u7f/NnXJJMML86BBGwLaQwhxfvuEogJdRTUA8g2vOZ9UhGzAyLSX3njTp7lni7C7PGYp2/vV2B+YLBwujQzJ8Q==}
     dependencies:
-      '@definitelytyped/typescript-versions': 0.0.140
+      '@definitelytyped/typescript-versions': 0.0.141
       '@types/parsimmon': 1.10.6
       parsimmon: 1.18.1
     dev: true
 
-  /@definitelytyped/typescript-versions/0.0.140:
-    resolution: {integrity: sha512-kWzD/k7IywjnVx8/RgCgBD0vZjzuyktrZ/JzwSBpaKZgq7RJZYlkGFhYaZNiRPfhz3A10k3KI/ILK9gcRZ7pkA==}
+  /@definitelytyped/typescript-versions/0.0.141:
+    resolution: {integrity: sha512-RHONSp0eGUccKcoiDJF25DVAUk6pNS79ie0/1T0fn/cDTrzhX14eo6Zcz7O9emqAI496pvsS7IhYctoFrZ/xzw==}
     dev: true
 
-  /@definitelytyped/utils/0.0.140:
-    resolution: {integrity: sha512-uqcZu8jeA+Ul05jxOvs7Sf0Bw2yL7P0YEGGxckmhL/DDx/7VJqE7ZnEGBY2lVgLEwqwQIXeoG7IUWDjBNCnntw==}
+  /@definitelytyped/utils/0.0.141:
+    resolution: {integrity: sha512-4DneI5xY0KDSF0vNWiSwmDpxVR9E32oQPWFjv0PdEgGaZT1VS8E/LxSHVjwn2+MK3uuk4XK41S/R9IFvddu9Gw==}
     dependencies:
-      '@definitelytyped/typescript-versions': 0.0.140
+      '@definitelytyped/typescript-versions': 0.0.141
       '@qiwi/npm-registry-client': 8.9.1
       '@types/node': 14.18.33
       charm: 1.0.2
@@ -5971,7 +5971,7 @@ packages:
     peerDependencies:
       typescript: '*'
     dependencies:
-      '@definitelytyped/header-parser': 0.0.140
+      '@definitelytyped/header-parser': 0.0.141
       command-exists: 1.2.9
       rimraf: 3.0.2
       semver: 6.3.0
@@ -5987,9 +5987,9 @@ packages:
     peerDependencies:
       typescript: '>= 3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.7.0-dev || >= 3.8.0-dev || >= 3.9.0-dev || >= 4.0.0-dev'
     dependencies:
-      '@definitelytyped/header-parser': 0.0.140
-      '@definitelytyped/typescript-versions': 0.0.140
-      '@definitelytyped/utils': 0.0.140
+      '@definitelytyped/header-parser': 0.0.141
+      '@definitelytyped/typescript-versions': 0.0.141
+      '@definitelytyped/utils': 0.0.141
       dts-critic: 3.3.11_typescript@4.7.4
       fs-extra: 6.0.1
       json-stable-stringify: 1.0.1
@@ -6737,7 +6737,7 @@ packages:
     resolution: {integrity: sha512-w/XuoBCSwepyiZtIRsKsetiLDUVGPVw1E/R3VTFSecIy8UR7Cq3SOtwKHJMFoVqqVG36aGkzh4e8BvpO1Fdc7g==}
     hasBin: true
     requiresBuild: true
-    dev: false
+    dev: true
 
   /esbuild/0.14.48:
     resolution: {integrity: sha512-w6N1Yn5MtqK2U1/WZTX9ZqUVb8IOLZkZ5AdHkT6x3cHDMVsYWC7WPdiLmx19w3i4Rwzy5LqsEMtVihG3e4rFzA==}


### PR DESCRIPTION
## Motivation

See #1139

## Summary

`esbuild` and `rollup` have been moved from `dependencies` to `devDependencies` and `peerDependencies`.

