### PR TITLE
fix(pnpm): add lockfile = true to .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+lockfile = true


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->

When I cloned the project and installed it with pnpm, I got:

```
WARN  A pnpm-lock.yaml file exists. The current configuration prohibits to read or write a lockfile
```

I'm not familiar with pnpm, but I finally figure out it's due to the `lockfile` setting on my computer.
 
## Summary

<!--
Explain how your implementation works and your thoughts behind the solution.
It will help maintainers to review your PR.
You can skip it if PR is trivial.
-->

pnpm should respect the `pnpm-lock.yaml` file in the project whether lockfile is true or not out of the project scope.

## Test plan

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->

```sh
$ npm config set lockfile false
$ git clone https://github.com/callstack/linaria.git
$ cd linaria && pnpm install
```
