### PR TITLE
fix(syncpack): use same esbuild version

### DIFF
--- a/examples/esbuild/package.json
+++ b/examples/esbuild/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@linaria/esbuild": "workspace:^",
-    "esbuild": "^0.14.48"
+    "esbuild": "^0.15.16"
   },
   "scripts": {
     "build": "node build.js"

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@types/node": "^17.0.39",
-    "esbuild": "^0.12.5"
+    "esbuild": "^0.15.16"
   },
   "peerDependencies": {
     "esbuild": ">=0.12.0"

--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -41,7 +41,6 @@ export default function linaria({
           ? path.dirname(importer)
           : path.join(process.cwd(), path.dirname(importer));
 
-        // @ts-expect-error
         const result = await build.resolve(token, {
           resolveDir: context,
         });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,13 +112,13 @@ importers:
   examples/esbuild:
     specifiers:
       '@linaria/esbuild': workspace:^
-      esbuild: ^0.14.48
+      esbuild: ^0.15.16
       linaria-website: workspace:^
     dependencies:
       linaria-website: link:../../website
     devDependencies:
       '@linaria/esbuild': link:../../packages/esbuild
-      esbuild: 0.14.48
+      esbuild: 0.15.16
 
   examples/rollup:
     specifiers:
@@ -329,14 +329,14 @@ importers:
       '@linaria/babel-preset': workspace:^
       '@linaria/utils': workspace:^
       '@types/node': ^17.0.39
-      esbuild: ^0.12.5
+      esbuild: ^0.15.16
     dependencies:
       '@babel/core': 7.20.2
       '@linaria/babel-preset': link:../babel
       '@linaria/utils': link:../utils
     devDependencies:
       '@types/node': 17.0.39
-      esbuild: 0.12.29
+      esbuild: 0.15.16
 
   packages/extractor:
     specifiers: {}
@@ -5003,13 +5003,13 @@ packages:
     resolution: {integrity: sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==}
     dev: true
 
-  /bundle-require/3.1.0_esbuild@0.15.12:
+  /bundle-require/3.1.0_esbuild@0.15.16:
     resolution: {integrity: sha512-IIXtAO7fKcwPHNPt9kY/WNVJqy7NDy6YqJvv6ENH0TOZoJ+yjpEsn1w40WKZbR2ibfu5g1rfgJTvmFHpm5aOMA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       esbuild: '>=0.13'
     dependencies:
-      esbuild: 0.15.12
+      esbuild: 0.15.16
       load-tsconfig: 0.2.3
     dev: true
 
@@ -6910,12 +6910,6 @@ packages:
     os: [win32]
     requiresBuild: true
     optional: true
-
-  /esbuild/0.12.29:
-    resolution: {integrity: sha512-w/XuoBCSwepyiZtIRsKsetiLDUVGPVw1E/R3VTFSecIy8UR7Cq3SOtwKHJMFoVqqVG36aGkzh4e8BvpO1Fdc7g==}
-    hasBin: true
-    requiresBuild: true
-    dev: true
 
   /esbuild/0.14.48:
     resolution: {integrity: sha512-w6N1Yn5MtqK2U1/WZTX9ZqUVb8IOLZkZ5AdHkT6x3cHDMVsYWC7WPdiLmx19w3i4Rwzy5LqsEMtVihG3e4rFzA==}
@@ -13870,11 +13864,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      bundle-require: 3.1.0_esbuild@0.15.12
+      bundle-require: 3.1.0_esbuild@0.15.16
       cac: 6.7.14
       chokidar: 3.5.3
       debug: 4.3.4
-      esbuild: 0.15.12
+      esbuild: 0.15.16
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->

When committing without `--no-verify`, syncpack run failed due to `✕ esbuild ^0.12.5, ^0.15.16`:

```
> umbrella@3.0.0-beta.19 sp:check /Users/chentsulin/oss/linaria
> syncpack

- @babel/cli ^7.19.3
- @babel/core ^7.20.2
- @babel/eslint-parser ^7.19.1
- @babel/generator ^7.20.4
- @babel/helper-module-imports ^7.18.6
- @babel/parser ^7.20.3
- @babel/plugin-proposal-class-properties ^7.18.6
- @babel/plugin-proposal-export-namespace-from ^7.18.9
- @babel/plugin-syntax-dynamic-import ^7.8.3
- @babel/plugin-syntax-jsx ^7.18.6
- @babel/plugin-syntax-typescript ^7.20.0
- @babel/plugin-transform-modules-commonjs ^7.19.6
- @babel/plugin-transform-runtime ^7.19.6
- @babel/plugin-transform-template-literals ^7.18.9
- @babel/preset-env ^7.20.2
- @babel/preset-react ^7.18.6
- @babel/preset-typescript ^7.18.6
- @babel/runtime ^7.20.1
- @babel/template ^7.18.10
- @babel/traverse ^7.20.1
- @babel/types ^7.20.2
- @changesets/cli ^2.22.0
- @commitlint/config-conventional ^8.3.4
- @emotion/is-prop-valid ^1.2.0
- @griffel/core ^1.5.0
- @linaria/atomic workspace:^
- @linaria/babel-preset workspace:^
- @linaria/core workspace:^
- @linaria/extractor workspace:^
- @linaria/griffel workspace:^
- @linaria/logger workspace:^
- @linaria/postcss-linaria workspace:^
- @linaria/react workspace:^
- @linaria/rollup workspace:^
- @linaria/server workspace:^
- @linaria/shaker workspace:^
- @linaria/stylelint workspace:^
- @linaria/tags workspace:^
- @linaria/utils workspace:^
- @linaria/vite workspace:^
- @linaria/webpack4-loader workspace:^
- @linaria/webpack5-loader workspace:^
- @rollup/pluginutils ^4.1.0
- @swc/core ^1.3.20
- @types/babel__core ^7.1.19
- @types/babel__generator ^7.6.4
- @types/babel__template ^7.4.1
- @types/babel__traverse ^7.17.1
- @types/cosmiconfig ^5.0.3
- @types/debug ^4.1.5
- @types/dedent ^0.7.0
- @types/enhanced-resolve ^3.0.6
- @types/glob ^7.2.0
- @types/jest ^28.1.0
- @types/loader-utils ^1.1.3
- @types/mkdirp ^0.5.2
- @types/node ^17.0.39
- @types/normalize-path ^3.0.0
- @types/react >=16
- @types/webpack ^4.41.33
- @types/yargs ^17.0.10
- @typescript-eslint/eslint-plugin ^5.30.7
- @typescript-eslint/experimental-utils ^4.28.0
- @typescript-eslint/parser ^5.30.7
- all-contributors-cli ^6.20.0
- babel-jest ^28.1.0
- babel-loader ^8.2.5
- babel-merge ^3.0.0
- babel-plugin-file-loader ^1.1.1
- babel-plugin-istanbul ^6.1.1
- babel-plugin-module-resolver ^4.1.0
- babel-plugin-transform-react-remove-prop-types ^0.4.24
- codecov ^3.2.0
- commitlint ^8.3.5
- cosmiconfig ^5.1.0
- cross-env ^7.0.3
- css-hot-loader ^1.4.4
- css-loader ^6.7.1
- debug ^4.1.1
- dedent ^0.7.0
- del-cli ^1.1.0
- dtslint ^4.2.1
- enhanced-resolve ^5.3.1
✕ esbuild ^0.12.5, ^0.15.16
- escape-html ^1.0.3
- eslint ^8.16.0
- eslint-config-airbnb ^19.0.4
- eslint-config-airbnb-typescript ^17.0.0
- eslint-config-prettier ^8.5.0
- eslint-plugin-import ^2.26.0
- eslint-plugin-jsx-a11y ^6.5.1
- eslint-plugin-prettier ^4.0.0
- eslint-plugin-react ^7.30.0
- eslint-plugin-react-hooks ^4.5.0
- find-up ^5.0.0
- git-raw-commits ^2.0.3
- glob ^7.1.3
- husky ^1.3.1
- ignore-styles ^5.0.1
- jest ^28.1.0
- known-css-properties ^0.24.0
- koa ^2.7.0
- koa-compress ^3.0.0
- koa-router ^7.4.0
- koa-send ^5.0.0
- linaria workspace:^
- loader-utils ^1.2.3
- mini-css-extract-plugin ^2.6.0
- mkdirp ^0.5.1
- normalize-path ^3.0.0
- picocolors ^1.0.0
- postcss ^8.3.11
- prettier ^2.7.1
- react ^16.14.0
- react-dom ^16.14.0
- react-html-attributes ^1.4.6
- react-test-renderer ^16.8.3
- rollup 1.20.0||^2.0.0
- source-map ^0.7.3
- strip-ansi ^5.2.0
- stylelint ^14.11.0
- stylelint-config-recommended ^3.0.0
- stylelint-config-standard ^28.0.0
- stylis ^3.5.4
- syncpack ^8.0.0
- ts-invariant ^0.10.3
- ts-jest ^28.0.4
- tsup ^6.3.0
- turbo ^1.6.3
- typescript ^4.7.4
- url ^0.11.0
- vite ^3.1.8
- webpack ^5.6.0
- webpack-cli ^4.9.2
- webpack-dev-server ^4.9.1
- yargs ^17.5.0
= Version Group 1 ===============================================================
- @types/enhanced-resolve ^3.0.6
- enhanced-resolve ^4.1.0
 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Command failed with exit code 1.
```

## Summary

<!--
Explain how your implementation works and your thoughts behind the solution.
It will help maintainers to review your PR.
You can skip it if PR is trivial.
-->

Use same esbuild to fix the issue.

## Test plan

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->

```sh
$ git commit 
```
