### PR TITLE
Make it possible to configure ESBuild filter

### DIFF
--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -22,6 +22,7 @@ type EsbuildPluginOptions = {
 const nodeModulesRegex = /^(?:.*[\\/])?node_modules(?:[\\/].*)?$/;
 
 export default function linaria({
+  filter = /\.(js|jsx|ts|tsx)$/,
   sourceMap,
   preprocessor,
   esbuildOptions,
@@ -67,7 +68,7 @@ export default function linaria({
         };
       });
 
-      build.onLoad({ filter: /\.(js|jsx|ts|tsx)$/ }, async (args) => {
+      build.onLoad({ filter }, async (args) => {
         const rawCode = fs.readFileSync(args.path, 'utf8');
         const { ext, name: filename } = path.parse(args.path);
         const loader = ext.replace(/^\./, '') as Loader;


### PR DESCRIPTION
## Motivation

Currently the `@linaria/esbuild` plugins transforms all .js / .jsx / .ts / .tsx files that ESBuild can find. But for performance and pure functional reasons, it might be necessary to reduce that set of files to a bare minimum pattern. For example, at Framer we strictly only want to transform files that end with `….styles.ts`. We had our own custom ESBuild plugin, but in an attempt to switch to this plugin I ran into this as a blocker, and created this PR.

## Summary

The plugin can now be configured like this, to only transform a subset of the source files:

```typescript
build({
    // …
    plugins: [linaria({ filter: /\.styles\.ts$/ })],
    // …
})
```

## Test plan

To verify this works, just use the example config above and verify that only styles within the matching files (e.g. `Something.styles.ts`) get transformed.
