### PR TITLE
fix(vite): enforce: 'post'

### DIFF
--- a/.changeset/sixty-peaches-rush.md
+++ b/.changeset/sixty-peaches-rush.md
@@ -1,0 +1,5 @@
+---
+'@linaria/vite': patch
+---
+
+Vite should replace import aliases so resolve functions in bundlers should be able to correctly resolve imports.

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -49,6 +49,7 @@ export default function linaria({
 
   return {
     name: 'linaria',
+    enforce: 'post',
     configResolved(resolvedConfig: ResolvedConfig) {
       config = resolvedConfig;
     },


### PR DESCRIPTION
Vite should replace import aliases so `resolve` functions in bundlers should be able to correctly resolve imports.

