### PR TITLE
feat: option to remove `var()` wrapper around css variables

### DIFF
--- a/.changeset/three-bikes-lay.md
+++ b/.changeset/three-bikes-lay.md
@@ -1,0 +1,7 @@
+---
+'@linaria/tags': minor
+'@linaria/testkit': minor
+'@linaria/utils': minor
+---
+
+Add option to remove var() wrapper around css variables

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ### OS Junk ###
 .DS_Store
 *~
+.history
 
 ### Node ###
 # Logs

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -26,6 +26,96 @@ module.exports = {
 
   Enabling this will add a display name to generated class names, e.g. `.Title_abcdef` instead of `.abcdef'. It is disabled by default to generate smaller CSS files.
 
+- `variableNameConfig: "var" | "dashes" | "raw"` (default: `var`):
+
+  Configures how the variable will be formatted in final CSS.
+
+  ### Possible values
+
+  #### `var`
+  Use full css variable structure. This is default behavior.
+
+  ```js
+  import { styled } from "@linaria/react";
+
+  export const MyComponent = styled.div`
+    color: ${(props) => props.color};
+  `;
+  ```
+
+  In CSS you will see full variable declaration
+
+  ```css
+  .MyComponent_m1cus5as {
+    color: var(--m1cus5as-0);
+  }
+  ```
+
+  #### `dashes`
+  Removes `var()` around the variable name. It is useful when you want to control the variable on your own. For example you can set default value for CSS variable.
+
+  ```js
+  import { styled } from "@linaria/react";
+
+  export const Theme = styled.div`
+    --font-color: red;
+  `;
+
+  export const MyComponent = styled.div`
+    // Returning empty string is mandatory
+    // Otherwise you will have "undefined" in css variable value
+    color: var(${(props) => props.color ?? ""}, var(--font-color));
+  `;
+
+  function App() {
+    return (
+      <Theme>
+        <MyComponent>Text with red color</MyComponent>
+        <MyComponent color="blue">Text with blue color</MyComponent>
+      </Theme>
+    );
+  }
+  ```
+
+  In CSS you will see generated variable name and your default value.
+
+  ```css
+  .Theme_t1cus5as {
+    --font-color: red;
+  }
+
+  .MyComponent_mc195ga {
+    color: var(--mc195ga-0, var(--font-color));
+  }
+  ```
+
+  #### `raw`
+  Use only variable name without dashes and `var()` wrapper.
+
+  ```js
+  import { styled } from "@linaria/react";
+
+  export const MyComponent = styled.div`
+    color: ${(props) => props.color};
+  `;
+  ```
+
+  In CSS you will see just the variable name. This is not valid value for css property.
+
+  ```css
+  .MyComponent_mc195ga {
+    color: mc195ga-0;
+  }
+  ```
+
+  You will have to make it valid:
+
+  ```js
+  export const MyComponent = styled.div`
+    color: var(--${(props) => props.color});
+  `;
+  ```
+
 - `classNameSlug: string | ((hash: string, title: string, args: ClassNameSlugVars) => string)` (default: `default`):
 
   Using this will provide an interface to customize the output of the CSS class name. Example:

--- a/packages/tags/src/TaggedTemplateProcessor.ts
+++ b/packages/tags/src/TaggedTemplateProcessor.ts
@@ -34,7 +34,12 @@ export default abstract class TaggedTemplateProcessor extends BaseProcessor {
       throw new Error('Tag is already built');
     }
 
-    const artifact = templateProcessor(this, this.#template, values);
+    const artifact = templateProcessor(
+      this,
+      this.#template,
+      values,
+      this.options.variableNameConfig
+    );
     if (artifact) {
       this.artifacts.push(['css', artifact]);
     }

--- a/packages/tags/src/utils/getVariableName.ts
+++ b/packages/tags/src/utils/getVariableName.ts
@@ -1,0 +1,16 @@
+import type { IOptions } from './types';
+
+export function getVariableName(
+  varId: string,
+  rawVariableName: IOptions['variableNameConfig'] | undefined
+) {
+  switch (rawVariableName) {
+    case 'raw':
+      return varId;
+    case 'dashes':
+      return `--${varId}`;
+    case 'var':
+    default:
+      return `var(--${varId})`;
+  }
+}

--- a/packages/tags/src/utils/types.ts
+++ b/packages/tags/src/utils/types.ts
@@ -5,6 +5,7 @@ import type { ClassNameFn, VariableNameFn } from '@linaria/utils';
 export interface IOptions {
   classNameSlug?: string | ClassNameFn;
   displayName: boolean;
+  variableNameConfig?: 'var' | 'dashes' | 'raw';
   variableNameSlug?: string | VariableNameFn;
 }
 

--- a/packages/testkit/src/__snapshots__/babel.test.ts.snap
+++ b/packages/testkit/src/__snapshots__/babel.test.ts.snap
@@ -1053,6 +1053,43 @@ Dependencies: NA
 
 `;
 
+exports[`strategy shaker handles dashes in variableNameConfig 1`] = `
+"import { styled as atomicStyled } from '@linaria/atomic';
+import { styled } from '@linaria/react';
+const _exp = /*#__PURE__*/() => props => props.size;
+export const Title = /*#__PURE__*/styled('h1')({
+  name: \\"Title\\",
+  class: \\"Title_t13jq05\\",
+  propsAsIs: false,
+  vars: {
+    \\"t13jq05-0\\": [_exp(), \\"px\\"]
+  }
+});
+const _exp2 = /*#__PURE__*/() => props => props.size;
+export const Body = /*#__PURE__*/atomicStyled('h1')({
+  name: \\"Body\\",
+  class: \\"atm_c8_trva6l Body_b1vhermz\\",
+  propsAsIs: false,
+  vars: {
+    \\"1qqvhyq\\": [_exp2(), \\"px\\"]
+  },
+  atomic: true
+});"
+`;
+
+exports[`strategy shaker handles dashes in variableNameConfig 2`] = `
+
+CSS:
+
+.Title_t13jq05 {
+  font-size: --t13jq05-0;
+}
+.atm_c8_trva6l.atm_c8_trva6l{font-size:--1qqvhyq;}
+
+Dependencies: NA
+
+`;
+
 exports[`strategy shaker handles escapes properly 1`] = `
 "import { styled } from '@linaria/react';
 export const Block = /*#__PURE__*/styled('div')({
@@ -1286,6 +1323,80 @@ CSS:
 
 .stringKey_s13jq05 {}
 ._2__1vhermz {}
+
+Dependencies: NA
+
+`;
+
+exports[`strategy shaker handles raw in variableNameConfig 1`] = `
+"import { styled as atomicStyled } from '@linaria/atomic';
+import { styled } from '@linaria/react';
+const _exp = /*#__PURE__*/() => props => props.size;
+export const Title = /*#__PURE__*/styled('h1')({
+  name: \\"Title\\",
+  class: \\"Title_t13jq05\\",
+  propsAsIs: false,
+  vars: {
+    \\"t13jq05-0\\": [_exp(), \\"px\\"]
+  }
+});
+const _exp2 = /*#__PURE__*/() => props => props.size;
+export const Body = /*#__PURE__*/atomicStyled('h1')({
+  name: \\"Body\\",
+  class: \\"atm_c8_1s69o7d Body_b1vhermz\\",
+  propsAsIs: false,
+  vars: {
+    \\"1qqvhyq\\": [_exp2(), \\"px\\"]
+  },
+  atomic: true
+});"
+`;
+
+exports[`strategy shaker handles raw in variableNameConfig 2`] = `
+
+CSS:
+
+.Title_t13jq05 {
+  font-size: t13jq05-0;
+}
+.atm_c8_1s69o7d.atm_c8_1s69o7d{font-size:1qqvhyq;}
+
+Dependencies: NA
+
+`;
+
+exports[`strategy shaker handles val in variableNameConfig 1`] = `
+"import { styled as atomicStyled } from '@linaria/atomic';
+import { styled } from '@linaria/react';
+const _exp = /*#__PURE__*/() => props => props.size;
+export const Title = /*#__PURE__*/styled('h1')({
+  name: \\"Title\\",
+  class: \\"Title_t13jq05\\",
+  propsAsIs: false,
+  vars: {
+    \\"t13jq05-0\\": [_exp(), \\"px\\"]
+  }
+});
+const _exp2 = /*#__PURE__*/() => props => props.size;
+export const Body = /*#__PURE__*/atomicStyled('h1')({
+  name: \\"Body\\",
+  class: \\"atm_c8_1g7eom2 Body_b1vhermz\\",
+  propsAsIs: false,
+  vars: {
+    \\"1qqvhyq\\": [_exp2(), \\"px\\"]
+  },
+  atomic: true
+});"
+`;
+
+exports[`strategy shaker handles val in variableNameConfig 2`] = `
+
+CSS:
+
+.Title_t13jq05 {
+  font-size: var(--t13jq05-0);
+}
+.atm_c8_1g7eom2.atm_c8_1g7eom2{font-size:var(--1qqvhyq);}
 
 Dependencies: NA
 

--- a/packages/testkit/src/babel.test.ts
+++ b/packages/testkit/src/babel.test.ts
@@ -297,6 +297,84 @@ describe('strategy shaker', () => {
     expect(metadata).toMatchSnapshot();
   });
 
+  it('handles val in variableNameConfig', async () => {
+    const { code, metadata } = await transform(
+      dedent`
+    import { styled as atomicStyled } from '@linaria/atomic';
+    import { styled } from '@linaria/react';
+
+    export const Title = styled('h1')\`
+      font-size: ${'${props => props.size}px'};
+    \`;
+
+    export const Body = atomicStyled('h1')\`
+      font-size: ${'${props => props.size}px'};
+    \`;
+`,
+      [
+        evaluator,
+        {
+          variableNameConfig: 'var',
+        },
+      ]
+    );
+
+    expect(code).toMatchSnapshot();
+    expect(metadata).toMatchSnapshot();
+  });
+
+  it('handles dashes in variableNameConfig', async () => {
+    const { code, metadata } = await transform(
+      dedent`
+    import { styled as atomicStyled } from '@linaria/atomic';
+    import { styled } from '@linaria/react';
+
+    export const Title = styled('h1')\`
+      font-size: ${'${props => props.size}px'};
+    \`;
+
+    export const Body = atomicStyled('h1')\`
+      font-size: ${'${props => props.size}px'};
+    \`;
+`,
+      [
+        evaluator,
+        {
+          variableNameConfig: 'dashes',
+        },
+      ]
+    );
+
+    expect(code).toMatchSnapshot();
+    expect(metadata).toMatchSnapshot();
+  });
+
+  it('handles raw in variableNameConfig', async () => {
+    const { code, metadata } = await transform(
+      dedent`
+    import { styled as atomicStyled } from '@linaria/atomic';
+    import { styled } from '@linaria/react';
+
+    export const Title = styled('h1')\`
+      font-size: ${'${props => props.size}px'};
+    \`;
+
+    export const Body = atomicStyled('h1')\`
+      font-size: ${'${props => props.size}px'};
+    \`;
+`,
+      [
+        evaluator,
+        {
+          variableNameConfig: 'raw',
+        },
+      ]
+    );
+
+    expect(code).toMatchSnapshot();
+    expect(metadata).toMatchSnapshot();
+  });
+
   it('transpiles styled template literal with function and tag', async () => {
     const { code, metadata } = await transform(
       dedent`

--- a/packages/utils/src/options/types.ts
+++ b/packages/utils/src/options/types.ts
@@ -43,5 +43,6 @@ export type StrictOptions = {
   ignore?: RegExp;
   rules: EvalRule[];
   tagResolver?: (source: string, tag: string) => string | null;
+  variableNameConfig?: 'var' | 'dashes' | 'raw';
   variableNameSlug?: string | VariableNameFn;
 };


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation
Linaria generates `var()` with one argument - the variable itself. However, css variables can accept default value:
``` 
var( <custom-property-name> , <declaration-value>? ) 
```
Since there is no way to set default value for linaria's variable we limit functionality of css variables.

Using the variable names without `var()` wrapper will allow you to use it as-is. For example, it is useful for theming: (this example will work when `variableNameConfig` is `dashes` )
```
import { styled } from "@linaria/react";

export const Theme = styled.div`
  --font-color: red;
`;

export const MyComponent = styled.div`
  color: var(${(props) => props.color ?? ""}, var(--font-color));
`;

function App() {
  return (
    <Theme>
      <MyComponent>Text with red color</MyComponent>
      <MyComponent color="blue">Text with blue color</MyComponent>
    </Theme>
  );
}
```
Here we set default variable in the root theme component `Theme`. Inside `MyComponent` we can use the linaria css variable name as-is and hence create our own `var` wrapper. So if we do not pass `color` prop css will take fallback value which is `red`. If we pass `color` props then it will be used

<img width="200" alt="image" src="https://user-images.githubusercontent.com/3620639/208174944-fceaed26-81ec-4d11-9c93-12191c6ea0bf.png">

<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->

## Summary

<!--
Explain how your implementation works and your thoughts behind the solution.
It will help maintainers to review your PR.
You can skip it if PR is trivial.
-->

In order to make it work i had to add new option `variableNameConfig` where you can control the variable formatting. The possible values are `var`, `dashes` and `raw`. 
- `var` is default and current behavior of linaria, each variable name is wrapped by `var`, i.e. `var(--mc195ga-0)`. 
- `dashes` will emit only valid css variable name, i.e. `--mc195ga-0`. 
- `raw` will emit only the variable name without `--`, i.e. `mc195ga-0`.  I added `raw` option just in case, i do not see a use case for that.

To make the idea of default css variable value work we have to check for `undefined`:

```
color: var(${(props) => props.color ?? ""}, var(--font-color));
```
Otherwise there will be `undefined` value for linaria style css variable and fallback will not work.
There is discussion about that https://github.com/callstack/linaria/issues/1072

This config affects whole linaria behavior, so in fact it is all or nothing, either you use `var` wrapper or use `dashes` in your application. However, probably you can configure webpack to have two linaria loaders one for `var` and another one for `dashes` using `test/include/exclude/.etc` features of your bundler. 

## Test plan

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->
In order to make this feature you need to add the `variableNameConfig` options into webpack config.
```
{
  loader: "@linaria/webpack-loader",
  options: {
    displayName: true,
    variableNameConfig: "dashes",
  },
},
```