### PR TITLE
Avoid crashing build on empty css``

### DIFF
--- a/.changeset/new-seas-drive.md
+++ b/.changeset/new-seas-drive.md
@@ -1,0 +1,5 @@
+---
+'@linaria/atomic': patch
+---
+
+Do not crash when no styles are extracted.

--- a/packages/atomic/src/processors/css.ts
+++ b/packages/atomic/src/processors/css.ts
@@ -10,7 +10,7 @@ export default class AtomicCssProcessor extends CssProcessor {
   #classes: string | undefined;
 
   private get classes(): string {
-    if (this.#classes) {
+    if (typeof this.#classes !== 'undefined') {
       return this.#classes;
     }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

It's possible that no atomic styles are extracted from a css`` block. Regardless of whether this is a bug or not, we shouldn't crash the babel plugin/the build. 

## Summary

To avoid this, check for undefined instead of truthiness, since empty string is falsy. 

## Test plan

tested locally with an empty css`` and this stops the crashing
