### PR TITLE
Update @linaria/rollup to be @linaria/vite

### DIFF
--- a/docs/BUNDLERS_INTEGRATION.md
+++ b/docs/BUNDLERS_INTEGRATION.md
@@ -313,7 +313,7 @@ export default {
 
 ### Vite
 
-Since Vite supports Rollup plugin, you can use `@linaria/vite`. Vite handles CSS by itself, you don't need a css plugin.
+~~Since Vite supports Rollup plugin~~ Since Vite provides more features and flexibility, Linaria has a separate plugin for it `@linaria/vite`. Vite handles CSS by itself, you don't need a css plugin.
 
 ```sh
 yarn add --dev @linaria/vite

--- a/docs/BUNDLERS_INTEGRATION.md
+++ b/docs/BUNDLERS_INTEGRATION.md
@@ -313,17 +313,17 @@ export default {
 
 ### Vite
 
-Since Vite supports Rollup plugin, you can use `@linaria/rollup`. Vite handles CSS by itself, you don't need a css plugin.
+Since Vite supports Rollup plugin, you can use `@linaria/vite`. Vite handles CSS by itself, you don't need a css plugin.
 
 ```sh
-yarn add --dev @linaria/rollup
+yarn add --dev @linaria/vite
 ```
 
 Then add them to your `vite.config.js`:
 
 ```js
 import { defineConfig } from 'vite';
-import linaria from '@linaria/rollup';
+import linaria from '@linaria/vite';
 
 export default defineConfig(() => ({
   // ...
@@ -335,7 +335,7 @@ If you are using language features that requires a babel transform (such as type
 
 ```js
 import { defineConfig } from 'vite';
-import linaria from '@linaria/rollup';
+import linaria from '@linaria/vite';
 
 // example to support typescript syntax:
 export default defineConfig(() => ({


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

When using `@linaria/rollup` with vite, it does not work, however using `@linaria/vite` works like a charm!
