### PR TITLE
fix(tags): use appropriate import/request for ESM/CommonJS

### DIFF
--- a/.changeset/calm-keys-jog.md
+++ b/.changeset/calm-keys-jog.md
@@ -1,0 +1,7 @@
+---
+'@linaria/babel-preset': patch
+'@linaria/tags': patch
+'@linaria/utils': patch
+---
+
+Update tags processor to insert appropriate import/request for ESM/CommonJS.

--- a/packages/babel/src/helper-module-imports.d.ts
+++ b/packages/babel/src/helper-module-imports.d.ts
@@ -1,11 +1,92 @@
 declare module '@babel/helper-module-imports' {
   import type { NodePath } from '@babel/traverse';
-  import type { Identifier } from '@babel/types';
+  import type * as t from '@babel/types';
+
+  type ImportOptions = {
+    /**
+     * The module being referenced.
+     */
+    importedSource: string | null;
+    /**
+     * The type of module being imported:
+     *
+     *  * 'es6'      - An ES6 module.
+     *  * 'commonjs' - A CommonJS module. (Default)
+     */
+    importedType: 'es6' | 'commonjs';
+    /**
+     * The type of interop behavior for namespace/default/named when loading
+     * CommonJS modules.
+     *
+     * ## 'babel' (Default)
+     *
+     * Load using Babel's interop.
+     *
+     * If '.__esModule' is true, treat as 'compiled', else:
+     *
+     * * Namespace: A copy of the module.exports with .default
+     *     populated by the module.exports object.
+     * * Default: The module.exports value.
+     * * Named: The .named property of module.exports.
+     *
+     * The 'ensureLiveReference' has no effect on the liveness of these.
+     *
+     * ## 'compiled'
+     *
+     * Assume the module is ES6 compiled to CommonJS. Useful to avoid injecting
+     * interop logic if you are confident that the module is a certain format.
+     *
+     * * Namespace: The root module.exports object.
+     * * Default: The .default property of the namespace.
+     * * Named: The .named property of the namespace.
+     *
+     * Will return erroneous results if the imported module is _not_ compiled
+     * from ES6 with Babel.
+     *
+     * ## 'uncompiled'
+     *
+     * Assume the module is _not_ ES6 compiled to CommonJS. Used a simplified
+     * access pattern that doesn't require additional function calls.
+     *
+     * Will return erroneous results if the imported module _is_ compiled
+     * from ES6 with Babel.
+     *
+     * * Namespace: The module.exports object.
+     * * Default: The module.exports object.
+     * * Named: The .named property of module.exports.
+     */
+    importedInterop: 'babel' | 'node' | 'compiled' | 'uncompiled';
+    /**
+     * The type of CommonJS interop included in the environment that will be
+     * loading the output code.
+     *
+     *  * 'babel' - CommonJS modules load with Babel's interop. (Default)
+     *  * 'node'  - CommonJS modules load with Node's interop.
+     *
+     * See descriptions in 'importedInterop' for more details.
+     */
+    importingInterop: 'babel' | 'node';
+    /**
+     * Define whether the import should be loaded before or after the existing imports.
+     * "after" is only allowed inside ECMAScript modules, since it's not possible to
+     * reliably pick the location _after_ require() calls but _before_ other code in CJS.
+     */
+    importPosition: 'before' | 'after';
+
+    nameHint?: string;
+    blockHoist?: number;
+  };
+
+  function addDefault(
+    path: NodePath,
+    importedSource: string,
+    opts?: Partial<ImportOptions>
+  ): t.Identifier;
 
   function addNamed(
     path: NodePath,
     name: string,
     importedSource: string,
-    opts?: { nameHint: string }
-  ): Identifier;
+    opts?: Partial<ImportOptions>
+  ): t.Identifier;
 }

--- a/packages/babel/src/utils/getTagProcessor.ts
+++ b/packages/babel/src/utils/getTagProcessor.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'fs';
 import { basename, dirname, join } from 'path';
 
 import { types as t } from '@babel/core';
-import { addNamed } from '@babel/helper-module-imports';
+import { addDefault, addNamed } from '@babel/helper-module-imports';
 import type { NodePath } from '@babel/traverse';
 import type {
   Expression,
@@ -327,10 +327,16 @@ function getBuilderForIdentifier(
     });
   };
 
+  const importedType = imports.some((i) => i.type === 'esm')
+    ? 'es6'
+    : 'commonjs';
+
   const astService = {
     ...t,
-    addNamedImport: (name: string, importedSource: string) =>
-      addNamed(path, name, importedSource),
+    addDefaultImport: (importedSource: string, nameHint?: string) =>
+      addDefault(path, importedSource, { importedType, nameHint }),
+    addNamedImport: (name: string, importedSource: string, nameHint?: string) =>
+      addNamed(path, name, importedSource, { importedType, nameHint }),
   };
 
   return (...args: BuilderArgs) =>

--- a/packages/tags/src/BaseProcessor.ts
+++ b/packages/tags/src/BaseProcessor.ts
@@ -51,7 +51,12 @@ export default abstract class BaseProcessor {
   public constructor(
     params: Params,
     protected readonly astService: typeof t & {
-      addNamedImport: (name: string, source: string) => Identifier;
+      addDefaultImport: (source: string, nameHint?: string) => Identifier;
+      addNamedImport: (
+        name: string,
+        source: string,
+        nameHint?: string
+      ) => Identifier;
     },
     public readonly location: SourceLocation | null,
     protected readonly replacer: (


### PR DESCRIPTION
## Summary

This PR fixes the issue where the `addDefaultImport` and `addNamedImport` methods in processors always inserted ESM imports, even when the processed file used CommonJS. The updated code now correctly inserts the appropriate import for each file format.