### PR TITLE
fix: exports.hasOwnProperty is not a function

### DIFF
--- a/packages/babel/src/module.ts
+++ b/packages/babel/src/module.ts
@@ -184,7 +184,14 @@ class Module {
 
           return values;
         }
-        const value = this.#lazyValues.get(key)?.();
+        let value: unknown;
+        if (this.#lazyValues.has(key)) {
+          value = this.#lazyValues.get(key)?.();
+        } else {
+          // Support Object.prototype methods on `exports`
+          // e.g `exports.hasOwnProperty`
+          value = Reflect.get(target, key);
+        }
         this.debug('evaluated', 'get %s: %o', key, value);
         return value;
       },

--- a/packages/testkit/src/module.test.ts
+++ b/packages/testkit/src/module.test.ts
@@ -139,6 +139,16 @@ it('has access to the global object', () => {
   ).not.toThrow();
 });
 
+it('has access to Object prototype methods on `exports`', () => {
+  const mod = new Module(getFileName(), options);
+
+  expect(() =>
+    mod.evaluate(dedent`
+    exports.hasOwnProperty('keyss');
+  `)
+  ).not.toThrow();
+});
+
 it("doesn't have access to the process object", () => {
   const mod = new Module(getFileName(), options);
 


### PR DESCRIPTION
The Proxy for `this.#exports` did not forward unknown properties to the underlying Object instance.

<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

Fixes issues like https://github.com/callstack/linaria/issues/1140

## Summary

Ensure that the Proxy for this.#exports forwards unknown properties to the underlying Object instance.

## Test plan

Added a unit test.