### PR TITLE
fix: preeval emits invalid code

### DIFF
--- a/packages/babel/src/plugins/preeval.ts
+++ b/packages/babel/src/plugins/preeval.ts
@@ -146,7 +146,7 @@ export default function preeval(
                 p.find(
                   (parentPath) =>
                     parentPath.isUnaryExpression({ operator: 'typeof' }) ||
-                    p.parentPath.isTSTypeQuery()
+                    parentPath.isTSTypeQuery()
                 )
               ) {
                 // Ignore `typeof window` expressions

--- a/packages/babel/src/plugins/preeval.ts
+++ b/packages/babel/src/plugins/preeval.ts
@@ -157,7 +157,7 @@ export default function preeval(
                 // ignore class property decls
                 return;
               }
-              if (p.parentPath.isMemberExpression()) {
+              if (p.parentPath.isMemberExpression() && p.key === 'property') {
                 // ignore e.g this.fetch()
                 // window.fetch will be handled by the windowScoped block below
                 return;

--- a/packages/babel/src/plugins/preeval.ts
+++ b/packages/babel/src/plugins/preeval.ts
@@ -137,12 +137,29 @@ export default function preeval(
             removeWithRelated([p]);
           },
           Identifier(p, state) {
+            if (p.find((parent) => parent.isTSTypeReference())) {
+              // don't mess with TS type references
+              return;
+            }
             if (isBrowserGlobal(p)) {
               if (
-                p.parentPath.isUnaryExpression({ operator: 'typeof' }) ||
-                p.parentPath.isTSTypeQuery()
+                p.find(
+                  (parentPath) =>
+                    parentPath.isUnaryExpression({ operator: 'typeof' }) ||
+                    p.parentPath.isTSTypeQuery()
+                )
               ) {
                 // Ignore `typeof window` expressions
+                return;
+              }
+
+              if (p.parentPath.isClassProperty()) {
+                // ignore class property decls
+                return;
+              }
+              if (p.parentPath.isMemberExpression()) {
+                // ignore e.g this.fetch()
+                // window.fetch will be handled by the windowScoped block below
                 return;
               }
 

--- a/packages/testkit/src/__snapshots__/preeval.test.ts.snap
+++ b/packages/testkit/src/__snapshots__/preeval.test.ts.snap
@@ -15,6 +15,17 @@ exports[`preeval should keep getGlobal but remove window-related code 1`] = `
 }"
 `;
 
+exports[`preeval should keep object members that look like window globals 1`] = `
+"class Test {
+  fetch: typeof global.fetch;
+  constructor(options) {
+    this.fetch = options.fetch;
+  }
+}"
+`;
+
+exports[`preeval should keep type parameters that look like window globals 1`] = `"type FooType = Generic<Foo>;"`;
+
 exports[`preeval should not remove "location" in types only because it looks like a global variable 1`] = `
 "interface IProps {
   fn: (location: string) => void;

--- a/packages/testkit/src/preeval.test.ts
+++ b/packages/testkit/src/preeval.test.ts
@@ -83,4 +83,24 @@ describe('preeval', () => {
 
     expect(code).toMatchSnapshot();
   });
+  it('should keep object members that look like window globals', () => {
+    const { code } = run`
+      class Test {
+        fetch: typeof global.fetch;
+        constructor(options) {
+          this.fetch = options.fetch;
+        }
+      }
+    `;
+
+    expect(code).toMatchSnapshot();
+  });
+  it('should keep type parameters that look like window globals', () => {
+    const { code } = run`
+      const blah = window.Foo;
+      type FooType = Generic<Foo>;
+    `;
+
+    expect(code).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
Fix some instances where preeval emits invalid code.


## Motivation
Avoid breaking builds due to buggy preeval logic. 

## Summary
Unfortunately, babel seems to record identifiers as globals even when they're accessed via TS type references, e.g:

```
class Foo {
  fetch: typeof global.fetch;
}
```

will result in `scope.hasGlobal('fetch')` returning true. preeval will end up deleting the class property, and then the entire class. The same applies if `fetch` is accessed in a member expression, e.g
```
class Foo {
  fetch: typeof global.fetch;
  constructor(options) {
    this.fetch = options.fetch;
  }
}
```

The key is the `typeof global.fetch` messes up Babel's scope tracking, which makes subsequent `isGlobal/isBrowserGlobal` return false positives. 

A similar problem occurs with TS type references - accessing `window.foo` or `global.foo` will break the scope tracking, resulting in TS type references that look like globals getting deleted. See the unit test for an example. 

## Test plan
Added unit tests

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->
