### PR TITLE
fix: workaround for weirdly packaged cjs modules

### DIFF
--- a/.changeset/shiny-owls-visit.md
+++ b/.changeset/shiny-owls-visit.md
@@ -1,0 +1,7 @@
+---
+'@linaria/shaker': patch
+'@linaria/testkit': patch
+'@linaria/utils': patch
+---
+
+Workaround for weirdly packaged cjs modules.

--- a/packages/shaker/src/plugins/shaker-plugin.ts
+++ b/packages/shaker/src/plugins/shaker-plugin.ts
@@ -197,7 +197,20 @@ export default function shakerPlugin(
 
         return;
       }
-
+      // Hackaround for packages which include a 'default' export without specifying __esModule; such packages cannot be
+      // shaken as they will break interopRequireDefault babel helper
+      // See example in shaker-plugin.test.ts
+      // Real-world example was found in preact/compat npm package
+      if (
+        onlyExports.includes('default') &&
+        exports.find(({ exported }) => exported === 'default') &&
+        !collected.isEsModule
+      ) {
+        this.imports = collected.imports;
+        this.exports = exports;
+        this.reexports = collected.reexports;
+        return;
+      }
       if (!onlyExports.includes('*')) {
         const aliveExports = new Set<IExport | IReexport>();
         const importNames = collected.imports.map(({ imported }) => imported);

--- a/packages/testkit/src/module.test.ts
+++ b/packages/testkit/src/module.test.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+
 import dedent from 'dedent';
 
 import { Module, TransformCacheCollection } from '@linaria/babel-preset';

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -43,7 +43,7 @@ export default function linaria({
   // <dependency id, targets>
   const targets: { id: string; dependencies: string[] }[] = [];
   const cache = new TransformCacheCollection();
-  const { codeCache, resolveCache, evalCache } = cache;
+  const { codeCache, evalCache } = cache;
   return {
     name: 'linaria',
     enforce: 'post',


### PR DESCRIPTION
## Motivation
We found a weird bug when shaker attempted to operate on preact/compat. Note that it's probably a bug that shaker is even processing this file, since it means we didn't strip the import in an earlier stage, but I'm not sure what's going on there. 

I think the issue is demonstrated pretty clearly in the unit test, but the gist is that certain libraries might be packaged in a way where they have a `default` export, but no `__esModule: true` export. This will break babel's interopRequireDefault helper, which wraps its argument if it doesn't detect `__esModule: true`, resulting in an object like `{ default: { default: someExport } }`. 

In the case of preact/compat, this is fine, because all of the exports are *also* defined directly on `module.exports`. resulting in `{ default: { default: someExport, someExport } }`. So even if interopRequireDefault produces a broken result, `interopRequireDefault(...).default.someExport` still exists.

Thee trouble comes when shaker deletes `someExport` because it was not in `onlyExports`, leaving only the default export; now, interopRequireDefault produces `{ default: { default: someExport } }` and `interopRequireDefault(...).default.someExport` will be undefined.


<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->

## Summary
I added detection of __esModule to collectImportAndExports. Now, if we detect that `default` is in `onlyExports`, *and* the module is not an esModule, we'll skip the shaker process as it will be unsafe. 

## Test plan

Added a unit test.
