### PR TITLE
fix: handle object patterns in exports

### DIFF
--- a/.changeset/bright-coats-vanish.md
+++ b/.changeset/bright-coats-vanish.md
@@ -1,0 +1,5 @@
+---
+'@linaria/shaker': patch
+---
+
+Handle object patterns in exports.

--- a/packages/shaker/src/plugins/__tests__/shaker-plugin.test.ts
+++ b/packages/shaker/src/plugins/__tests__/shaker-plugin.test.ts
@@ -196,4 +196,19 @@ describe('shaker', () => {
     expect(code).toMatchSnapshot();
     expect(metadata.imports.size).toBe(0);
   });
+  it('should handle object patterns in exports', () => {
+    const { code } = keep(['Alive'])`
+      import foo from "foo";
+
+      export const { Alive, Dead } = foo();
+    `;
+
+    expect(code).toMatchInlineSnapshot(`
+      "import foo from \\"foo\\";
+      export const {
+        Alive,
+        Dead
+      } = foo();"
+    `);
+  });
 });

--- a/packages/shaker/src/plugins/shaker-plugin.ts
+++ b/packages/shaker/src/plugins/shaker-plugin.ts
@@ -209,6 +209,14 @@ export default function shakerPlugin(
             importNames.includes((exp.local.node as NodeWithName).name || '')
           ) {
             aliveExports.add(exp);
+          } else if (
+            [...aliveExports].some((liveExp) => liveExp.local === exp.local)
+          ) {
+            // It's possible to export multiple values from a single variable initializer, e.g
+            // export const { foo, bar } = baz();
+            // We need to treat all of them as used if any of them are used, since otherwise
+            // we'll attempt to delete the baz() call
+            aliveExports.add(exp);
           }
         });
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

shaker did not handle object pattern exports like `export const { foo, bar } = baz()`

## Summary

The way that shaker associates exports seems to assume that the RHS of an export const assignment corresponds to exactly one export name. But this isn't true, as in the example above - `baz()`'s return will be destructured to multiple exported values. Due to this assumption, if one of the exports is not in `onlyExports`, the entire statement will be deleted. 

## Test plan

Added a unit test
