### PR TITLE
fix: lookup referencedIdentifiers after tree mutations

### DIFF
--- a/packages/utils/src/scopeHelpers.ts
+++ b/packages/utils/src/scopeHelpers.ts
@@ -368,7 +368,6 @@ function removeWithRelated(paths: NodePath[]) {
 
   const affectedPaths = actions.map(getPathFromAction);
 
-  let referencedIdentifiers = findIdentifiers(affectedPaths, 'referenced');
   const referencesOfBinding = findIdentifiers(affectedPaths, 'binding')
     .map((i) => (i.node && getScope(i).getBinding(i.node.name)) ?? null)
     .filter(isNotNull)
@@ -390,6 +389,7 @@ function removeWithRelated(paths: NodePath[]) {
   });
 
   removeWithRelated(referencesOfBinding);
+  let referencedIdentifiers = findIdentifiers(affectedPaths, 'referenced');
 
   referencedIdentifiers.sort((a, b) =>
     a.node?.name.localeCompare(b.node?.name)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation
https://github.com/callstack/linaria/issues/1112

This `localeCompare` error is very strange as identifiers should always have a name property. I did some debugging and found that the referencedIdentifiers array had paths pointing to random nodes like StringLiterals. I suspect the issue is that we look up the paths prior to mutating the AST, and the mutations end up leaving the paths pointing to invalid data. 

## Summary

Given that we don't actually use referencedIdentifiers until after the mutations are finished, I think a fix could be to just move this variable to after the mutations.


## Test plan

I don't have a good way of unit testing this change, but it did fix the localeCompare errors in our build. 