### PR TITLE
fix: handle .cjs & .mjs extensions

### DIFF
--- a/.changeset/wicked-poets-begin.md
+++ b/.changeset/wicked-poets-begin.md
@@ -1,0 +1,6 @@
+---
+"@linaria/babel-preset": patch
+"@linaria/testkit": patch
+---
+
+fix: handle .cjs & .mjs extensions

--- a/packages/babel/src/transform-stages/helpers/loadLinariaOptions.ts
+++ b/packages/babel/src/transform-stages/helpers/loadLinariaOptions.ts
@@ -30,7 +30,7 @@ export default function loadLinariaOptions(
   const options = {
     displayName: false,
     evaluate: true,
-    extensions: ['.json', '.js', '.jsx', '.ts', '.tsx'],
+    extensions: ['.cjs', '.json', '.js', '.jsx', '.mjs', '.ts', '.tsx'],
     rules: rules ?? [
       {
         action: require.resolve('@linaria/shaker'),

--- a/packages/babel/src/utils/processTemplateExpression.ts
+++ b/packages/babel/src/utils/processTemplateExpression.ts
@@ -17,6 +17,7 @@ const processTemplateExpression = (
   >,
   emit: (processor: BaseProcessor) => void
 ) => {
+  if (p.parentPath.isExportSpecifier()) return;
   if (processed.has(p.node)) return;
 
   const tagProcessor = getTagProcessor(p, fileContext, options);

--- a/packages/testkit/src/__fixtures__/sample-script.cjs
+++ b/packages/testkit/src/__fixtures__/sample-script.cjs
@@ -1,0 +1,1 @@
+module.exports = 42;

--- a/packages/testkit/src/module.test.ts
+++ b/packages/testkit/src/module.test.ts
@@ -1,20 +1,10 @@
+import dedent from 'dedent';
 import path from 'path';
 
-import * as babel from '@babel/core';
-import dedent from 'dedent';
-
 import { Module, TransformCacheCollection } from '@linaria/babel-preset';
-import type { Evaluator, StrictOptions } from '@linaria/utils';
+import type { StrictOptions } from '@linaria/utils';
 
 beforeEach(() => Module.invalidate());
-
-const evaluator: Evaluator = (filename, options, text) => {
-  const { code } = babel.transformSync(text, {
-    filename,
-    presets: ['@babel/preset-env'],
-  })!;
-  return [code!, null];
-};
 
 function getFileName() {
   return path.resolve(__dirname, './__fixtures__/test.js');
@@ -23,16 +13,8 @@ function getFileName() {
 const options: StrictOptions = {
   displayName: false,
   evaluate: true,
-  extensions: ['.js', '.jsx', '.ts', '.tsx'],
-  rules: [
-    {
-      action: evaluator,
-    },
-    {
-      test: /\/node_modules\//,
-      action: 'ignore',
-    },
-  ],
+  extensions: ['.cjs', '.js', '.jsx', '.ts', '.tsx'],
+  rules: [],
   babelOptions: {},
 };
 
@@ -49,7 +31,7 @@ it('creates module for JS files', () => {
   expect(mod.filename).toBe(filename);
 });
 
-it('requires JS files', () => {
+it('requires .js files', () => {
   const mod = new Module(getFileName(), options);
 
   mod.evaluate(dedent`
@@ -61,7 +43,19 @@ it('requires JS files', () => {
   expect(mod.exports).toBe('The answer is 42');
 });
 
-it('requires JSON files', () => {
+it('requires .cjs files', () => {
+  const mod = new Module(getFileName(), options);
+
+  mod.evaluate(dedent`
+    const answer = require('./sample-script.cjs');
+
+    module.exports = 'The answer is ' + answer;
+  `);
+
+  expect(mod.exports).toBe('The answer is 42');
+});
+
+it('requires .json files', () => {
   const mod = new Module(getFileName(), options);
 
   mod.evaluate(dedent`

--- a/packages/testkit/src/module.test.ts
+++ b/packages/testkit/src/module.test.ts
@@ -1,5 +1,5 @@
-import dedent from 'dedent';
 import path from 'path';
+import dedent from 'dedent';
 
 import { Module, TransformCacheCollection } from '@linaria/babel-preset';
 import type { StrictOptions } from '@linaria/utils';


### PR DESCRIPTION
## Motivation

Fixes #1177.

## Summary

This PR adds `.cjs` & `.mjs` to the list of default ones, so Linaria will handle them and load them properly.

### Before

```
  linaria:module:00001 [eval-cache] ❌ module:00002 is going to be initialized +0ms
  linaria:module:00002 [init] /private/var/folders/v4/l_41mr81261dpdvcdldkgdbh0000gn/T/nextjs-98284-78vGr91L2kUL/node_modules/@griffel/react/colors.cjs +1s
  linaria:module:00002 [evaluated] the whole exports was overridden with '/private/var/folders/v4/l_41mr81261dpdvcdldkgdbh0000gn/T/nextjs-98284-78vGr91L2kUL/node_modules/@griffel/react/colors.cjs' +0ms
```

### After

```
  linaria:module:00001 [require] @griffel/react/colors.cjs -> /private/var/folders/v4/l_41mr81261dpdvcdldkgdbh0000gn/T/nextjs-98284-78vGr91L2kUL/node_modules/@griffel/react/colors.cjs +0ms
  linaria:module:00001 [eval-cache] ❌ module:00002 is going to be initialized +0ms
  linaria:module:00002 [init] /private/var/folders/v4/l_41mr81261dpdvcdldkgdbh0000gn/T/nextjs-98284-78vGr91L2kUL/node_modules/@griffel/react/colors.cjs +1s
  linaria:module:00002 [code-cache] ✅ +0ms
  linaria:module:00002 [evaluate:fragment-01] 
  linaria:module:00002 	module.exports = {
  linaria:module:00002 	  red: 'pink',
  linaria:module:00002 	} +1ms
  linaria:module:00002 [evaluated] the whole exports was overridden with { red: 'pink' } +0ms
```

## Test plan

I didn't find a proper place to test it, it seems that `module.test.ts` is nearest, so I modified it.