### PR TITLE
fix: keep side effects from modules

### DIFF
--- a/.changeset/weak-walls-behave.md
+++ b/.changeset/weak-walls-behave.md
@@ -1,0 +1,5 @@
+---
+'@linaria/shaker': patch
+---
+
+fix: keep side effects from modules

--- a/packages/shaker/src/plugins/__tests__/__snapshots__/shaker-plugin.test.ts.snap
+++ b/packages/shaker/src/plugins/__tests__/__snapshots__/shaker-plugin.test.ts.snap
@@ -15,6 +15,11 @@ exports.defaultValue = Math.random() * _foo;
 exports.foo = _foo;"
 `;
 
+exports[`shaker should keep side-effects from modules 1`] = `
+"import 'regenerator-runtime/runtime.js';
+export const a = 1;"
+`;
+
 exports[`shaker should process array patterns 1`] = `
 "const [,, c] = array;
 export { c };"
@@ -50,6 +55,8 @@ exports.Kind = _Kind;"
 `;
 
 exports[`shaker should remove all references of \`a\` 1`] = `"exports.b = 10;"`;
+
+exports[`shaker should remove asset imports 1`] = `"export const a = 1;"`;
 
 exports[`shaker should remove related code 1`] = `
 "const a = 1;

--- a/packages/shaker/src/plugins/__tests__/shaker-plugin.test.ts
+++ b/packages/shaker/src/plugins/__tests__/shaker-plugin.test.ts
@@ -309,4 +309,26 @@ describe('shaker', () => {
       exports.default = defaultExports;"
     `);
   });
+
+  it('should remove asset imports', () => {
+    const { code, metadata } = keep(['a'])`
+      import './asset.css';
+
+      export const a = 1;
+    `;
+
+    expect(code).toMatchSnapshot();
+    expect(metadata.imports.size).toBe(0);
+  });
+
+  it('should keep side-effects from modules', () => {
+    const { code, metadata } = keep(['a'])`
+      import 'regenerator-runtime/runtime.js';
+
+      export const a = 1;
+    `;
+
+    expect(code).toMatchSnapshot();
+    expect(metadata.imports.size).toBe(1);
+  });
 });

--- a/packages/shaker/src/plugins/__tests__/utils/shouldKeepSideEffect.test.ts
+++ b/packages/shaker/src/plugins/__tests__/utils/shouldKeepSideEffect.test.ts
@@ -1,0 +1,23 @@
+import shouldKeepSideEffect from '../../utils/shouldKeepSideEffect';
+
+describe('shouldKeepSideEffect', () => {
+  it('allows modules', () => {
+    expect(shouldKeepSideEffect('@babel/runtime')).toBeTruthy();
+    expect(shouldKeepSideEffect('regenerator-runtime')).toBeTruthy();
+
+    expect(shouldKeepSideEffect('./side-effect')).toBeTruthy();
+  });
+
+  it('allows extensions', () => {
+    expect(shouldKeepSideEffect('./side-effect.js')).toBeTruthy();
+    expect(shouldKeepSideEffect('./side-effect.cjs')).toBeTruthy();
+    expect(shouldKeepSideEffect('./side-effect.mjs')).toBeTruthy();
+
+    expect(shouldKeepSideEffect('regenerator-runtime/runtime.js')).toBeTruthy();
+  });
+
+  it('skips assets', () => {
+    expect(shouldKeepSideEffect('./asset.css')).toBeFalsy();
+    expect(shouldKeepSideEffect('./asset.scss')).toBeFalsy();
+  });
+});

--- a/packages/shaker/src/plugins/shaker-plugin.ts
+++ b/packages/shaker/src/plugins/shaker-plugin.ts
@@ -22,6 +22,8 @@ import {
   mutate,
 } from '@linaria/utils';
 
+import shouldKeepSideEffect from './utils/shouldKeepSideEffect';
+
 type Core = typeof core;
 
 export interface IShakerOptions {
@@ -276,8 +278,12 @@ export default function shakerPlugin(
           .map((exp) => exp.local);
 
         if (!keepSideEffects && sideEffectImports.length > 0) {
-          // Remove all imports that don't import something explicitly
-          sideEffectImports.forEach((i) => forDeleting.push(i.local));
+          // Remove all imports that don't import something explicitly and should not be kept
+          sideEffectImports.forEach((i) => {
+            if (!shouldKeepSideEffect(i.source)) {
+              forDeleting.push(i.local);
+            }
+          });
         }
 
         const deleted = new Set<NodePath>();

--- a/packages/shaker/src/plugins/utils/shouldKeepSideEffect.ts
+++ b/packages/shaker/src/plugins/utils/shouldKeepSideEffect.ts
@@ -1,0 +1,8 @@
+const EXT_REGEX = /\.[0-9a-z]+$/;
+const ALLOWED_EXTENSIONS = ['.js', '.cjs', '.mjs'];
+
+export default function shouldKeepSideEffect(importPath: string) {
+  const [ext] = importPath.match(EXT_REGEX) || [''];
+
+  return ext === '' || ALLOWED_EXTENSIONS.includes(ext);
+}


### PR DESCRIPTION
## Motivation

Fixes #1189.

## Summary

Generally there two kinds of side-effects:
- asset imports (`import './foo.css')
- real code ('import './foo')

We want to keep only imports that contain code. Implemented `shouldKeepSideEffect()` to check if an import should stay.

```js
shouldKeepSideEffect('regenerator-runtime') // true
shouldKeepSideEffect('./asset.css') // false
```

The tricky part is that `shouldKeepSideEffect('object.values')` is `false` 💥 However, we can't do much at this step: to be sure we need to resolve imports 🙃

## Test plan

New tests have been added.
