### PR TITLE
fix(babel): update cosmiconfig so linaria.config.cjs works

### DIFF
--- a/.changeset/metal-hounds-push.md
+++ b/.changeset/metal-hounds-push.md
@@ -1,0 +1,5 @@
+---
+'@linaria/babel-preset': patch
+---
+
+fix(babel): update cosmiconfig so linaria.config.cjs works

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -44,7 +44,7 @@
     "@linaria/shaker": "workspace:^",
     "@linaria/tags": "workspace:^",
     "@linaria/utils": "workspace:^",
-    "cosmiconfig": "^5.1.0",
+    "cosmiconfig": "^8.0.0",
     "find-up": "^5.0.0",
     "source-map": "^0.7.3",
     "stylis": "^3.5.4"

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -55,7 +55,6 @@
     "@types/babel__helper-module-imports": "^7.18.0",
     "@types/babel__template": "^7.4.1",
     "@types/babel__traverse": "^7.17.1",
-    "@types/cosmiconfig": "^5.0.3",
     "@types/dedent": "^0.7.0",
     "@types/jest": "^28.1.0",
     "@types/node": "^17.0.39",

--- a/packages/babel/src/transform-stages/helpers/loadLinariaOptions.ts
+++ b/packages/babel/src/transform-stages/helpers/loadLinariaOptions.ts
@@ -1,4 +1,4 @@
-import cosmiconfig from 'cosmiconfig';
+import { cosmiconfigSync } from 'cosmiconfig';
 
 import type { StrictOptions } from '@linaria/utils';
 
@@ -9,7 +9,7 @@ export type PluginOptions = StrictOptions & {
   stage?: Stage;
 };
 
-const explorer = cosmiconfig('linaria');
+const explorerSync = cosmiconfigSync('linaria');
 
 const cache = new WeakMap<Partial<PluginOptions>, StrictOptions>();
 
@@ -24,8 +24,8 @@ export default function loadLinariaOptions(
 
   const result =
     configFile !== undefined
-      ? explorer.loadSync(configFile)
-      : explorer.searchSync();
+      ? explorerSync.load(configFile)
+      : explorerSync.search();
 
   const options = {
     displayName: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,7 +259,6 @@ importers:
       '@types/babel__helper-module-imports': ^7.18.0
       '@types/babel__template': ^7.4.1
       '@types/babel__traverse': ^7.17.1
-      '@types/cosmiconfig': ^5.0.3
       '@types/dedent': ^0.7.0
       '@types/jest': ^28.1.0
       '@types/node': ^17.0.39
@@ -294,7 +293,6 @@ importers:
       '@types/babel__helper-module-imports': 7.18.0
       '@types/babel__template': 7.4.1
       '@types/babel__traverse': 7.17.1
-      '@types/cosmiconfig': 5.0.3
       '@types/dedent': 0.7.0
       '@types/jest': 28.1.0
       '@types/node': 17.0.39
@@ -3637,12 +3635,6 @@ packages:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
       '@types/node': 18.11.9
-    dev: true
-
-  /@types/cosmiconfig/5.0.3:
-    resolution: {integrity: sha512-HgTGG7X5y9pLl3pixeo2XtDEFD8rq2EuH+S4mK6teCnAwWMucQl6v1D43hI4Uw1VJh6nu59lxLkqXHRl4uwThA==}
-    dependencies:
-      '@types/node': 17.0.39
     dev: true
 
   /@types/debug/4.1.7:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       vite-plugin-solid: 2.4.0_solid-js@1.6.2+vite@3.2.4
       vite-plugin-ssr: 0.4.54_vite@3.2.4
 
+  examples/vpssr-linaria-solid/dist/server:
+    specifiers: {}
+
   examples/webpack5:
     specifiers:
       '@babel/core': ^7.20.2
@@ -260,7 +263,7 @@ importers:
       '@types/dedent': ^0.7.0
       '@types/jest': ^28.1.0
       '@types/node': ^17.0.39
-      cosmiconfig: ^5.1.0
+      cosmiconfig: ^8.0.0
       dedent: ^0.7.0
       find-up: ^5.0.0
       jest: ^28.1.0
@@ -281,7 +284,7 @@ importers:
       '@linaria/shaker': link:../shaker
       '@linaria/tags': link:../tags
       '@linaria/utils': link:../utils
-      cosmiconfig: 5.2.1
+      cosmiconfig: 8.0.0
       find-up: 5.0.0
       source-map: 0.7.3
       stylis: 3.5.4
@@ -4610,10 +4613,10 @@ packages:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
     dependencies:
       sprintf-js: 1.0.3
+    dev: true
 
   /argparse/2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
-    dev: true
 
   /argv/0.0.2:
     resolution: {integrity: sha512-dEamhpPEwRUBpLNHeuCm/v+g0anFByHahxodVO/BbAarHVBBg2MccCwf9K+o1Pof+2btdnkJelYVUWjW/VrATw==}
@@ -5343,16 +5346,19 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       callsites: 2.0.0
+    dev: true
 
   /caller-path/2.0.0:
     resolution: {integrity: sha512-MCL3sf6nCSXOwCTzvPKhN18TU7AHTvdtam8DAogxcrJ8Rjfbbg7Lgng64H9Iy+vUV6VGFClN/TyxBkAebLRR4A==}
     engines: {node: '>=4'}
     dependencies:
       caller-callsite: 2.0.0
+    dev: true
 
   /callsites/2.0.0:
     resolution: {integrity: sha512-ksWePWBloaWPxJYQ8TL0JHvtci6G5QTKwQ95RcWAa/lzoAKuAOflGdAK92hpHXjkwb8zLxoLNUoNYZgVsaJzvQ==}
     engines: {node: '>=4'}
+    dev: true
 
   /callsites/3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -5869,6 +5875,7 @@ packages:
       is-directory: 0.3.1
       js-yaml: 3.14.1
       parse-json: 4.0.0
+    dev: true
 
   /cosmiconfig/7.0.1:
     resolution: {integrity: sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==}
@@ -5879,6 +5886,16 @@ packages:
       parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.2
+
+  /cosmiconfig/8.0.0:
+    resolution: {integrity: sha512-da1EafcpH6b/TD8vDRaWV7xFINlHlF6zKsGwS1TsuVJTZRkquaS5HTMq7uq6h31619QjbsYl21gVDOm32KM1vQ==}
+    engines: {node: '>=14'}
+    dependencies:
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      parse-json: 5.2.0
+      path-type: 4.0.0
+    dev: false
 
   /create-error-class/3.0.2:
     resolution: {integrity: sha512-gYTKKexFO3kh200H1Nit76sRwRtOY32vQd3jpAQKpLtZqyNsSQNfI4N7o3eP2wUjV35pTWKRYqFUDBvUha/Pkw==}
@@ -7432,6 +7449,7 @@ packages:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+    dev: true
 
   /esquery/1.4.0:
     resolution: {integrity: sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==}
@@ -8670,6 +8688,7 @@ packages:
     dependencies:
       caller-path: 2.0.0
       resolve-from: 3.0.0
+    dev: true
 
   /import-fresh/3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
@@ -8895,6 +8914,7 @@ packages:
   /is-directory/0.3.1:
     resolution: {integrity: sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /is-docker/2.2.1:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
@@ -9807,13 +9827,13 @@ packages:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
+    dev: true
 
   /js-yaml/4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
     dependencies:
       argparse: 2.0.1
-    dev: true
 
   /jsbn/0.1.1:
     resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
@@ -9839,6 +9859,7 @@ packages:
 
   /json-parse-better-errors/1.0.2:
     resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
+    dev: true
 
   /json-parse-even-better-errors/2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
@@ -11500,6 +11521,7 @@ packages:
     dependencies:
       error-ex: 1.3.2
       json-parse-better-errors: 1.0.2
+    dev: true
 
   /parse-json/5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
@@ -12492,6 +12514,7 @@ packages:
   /resolve-from/3.0.0:
     resolution: {integrity: sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==}
     engines: {node: '>=4'}
+    dev: true
 
   /resolve-from/4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -13139,6 +13162,7 @@ packages:
 
   /sprintf-js/1.0.3:
     resolution: {integrity: sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=}
+    dev: true
 
   /sprintf-js/1.1.2:
     resolution: {integrity: sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==}


### PR DESCRIPTION
## Motivation

New vite projects (made with `pnpm create vite`, for example) have `"type": "module"` in `package.json`. That causes loading `linaria.config.js` to fail because of CJS/ESM mismatch.

## Summary

Upgrade cosmiconfig to 8.x. The support for `.cjs` was added in 7.0.0 but no reason to hold back from version 8.

## Test plan

I updated the code for the breaking changes in cosmiconfig 6.x, see https://github.com/davidtheclark/cosmiconfig/blob/main/CHANGELOG.md#600

I don't think we need any new tests in linaria, it's probably sufficient that the existing tests continue to pass. Anything specific for `.cjs` would just reduplicate what cosmiconfig tests upstream.
