### PR TITLE
fix(babel): do not parse json as js

### DIFF
--- a/.changeset/unlucky-worms-complain.md
+++ b/.changeset/unlucky-worms-complain.md
@@ -1,0 +1,5 @@
+---
+'@linaria/babel-preset': patch
+---
+
+Avoid parsing json as js

--- a/packages/babel/src/transform-stages/1-prepare-for-eval.ts
+++ b/packages/babel/src/transform-stages/1-prepare-for-eval.ts
@@ -122,7 +122,7 @@ function prepareCode(
     originalCode
   );
 
-  if (action === 'ignore') {
+  if (action === 'ignore' || filename.endsWith('.json')) {
     log('stage-1:ignore', '');
     fileCache.set('*', {
       code: originalCode,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation
#1182 

<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->

## Summary
Added a check to prepare-for-eval that will ignore json files. Another option would be to 
add the `.json` extension to the default regex for ignored files in [loadLinariaOptions](https://github.com/callstack/linaria/blob/master/packages/babel/src/transform-stages/helpers/loadLinariaOptions.ts#L40) but I'm not sure if that gets overridden by custom rules and I'm not sure we'd want that.

This isn't ready for merge yet because I've encountered a new error that I was hoping I could get some help with. See the read me in this [repo](https://github.com/kcover/babel-playground-app) I made to reproduce the issue.

<!--
Explain how your implementation works and your thoughts behind the solution.
It will help maintainers to review your PR.
You can skip it if PR is trivial.
-->

## Test plan
Use the repo I linked above to reproduce the issue, then use `yarn link` to utilize this branch in that project and verify that the json parsing error no longer occurs.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->
