### PR TITLE
Normalize import path in the Vite plugin to fix Vite builds on Windows

### DIFF
--- a/.changeset/tender-guests-kick.md
+++ b/.changeset/tender-guests-kick.md
@@ -1,0 +1,5 @@
+---
+"@linaria/vite": patch
+---
+
+Normalize import path in the Vite plugin to fix Vite builds on Windows

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -146,7 +146,7 @@ export default function linaria({
 
       const slug = slugify(cssText);
 
-      const cssFilename = `${id.replace(/\.[jt]sx?$/, '')}_${slug}.css`;
+      const cssFilename = path.normalize(`${id.replace(/\.[jt]sx?$/, '')}_${slug}.css`);
       const cssId = `/${path.posix.relative(config.root, cssFilename)}`;
 
       if (sourceMap && result.cssSourceMapText) {

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -147,7 +147,7 @@ export default function linaria({
       const slug = slugify(cssText);
 
       const cssFilename = path.normalize(`${id.replace(/\.[jt]sx?$/, '')}_${slug}.css`);
-      const cssId = `/${path.posix.relative(config.root, cssFilename)}`;
+      const cssId = `/${path.relative(config.root, cssFilename)}`;
 
       if (sourceMap && result.cssSourceMapText) {
         const map = Buffer.from(result.cssSourceMapText).toString('base64');

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -151,7 +151,7 @@ export default function linaria({
       );
       const cssRelativePath = path
         .relative(config.root, cssFilename)
-        .replaceAll(path.win32.sep, path.posix.sep);
+        .replace(/\\/g, path.posix.sep);
       const cssId = `/${cssRelativePath}`;
 
       if (sourceMap && result.cssSourceMapText) {

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -146,8 +146,13 @@ export default function linaria({
 
       const slug = slugify(cssText);
 
-      const cssFilename = path.normalize(`${id.replace(/\.[jt]sx?$/, '')}_${slug}.css`);
-      const cssId = `/${path.relative(config.root, cssFilename)}`;
+      const cssFilename = path.normalize(
+        `${id.replace(/\.[jt]sx?$/, '')}_${slug}.css`
+      );
+      const cssRelativePath = path
+        .relative(config.root, cssFilename)
+        .replaceAll(path.win32.sep, path.posix.sep);
+      const cssId = `/${cssRelativePath}`;
 
       if (sourceMap && result.cssSourceMapText) {
         const map = Buffer.from(result.cssSourceMapText).toString('base64');


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->
https://github.com/vitejs/vite/issues/11035#issuecomment-1416057700

## Summary

<!--
Explain how your implementation works and your thoughts behind the solution.
It will help maintainers to review your PR.
You can skip it if PR is trivial.
-->
It seems like Vite cannot resolve absolute paths on windows when the separator is `/` instead of `\`, so I tried normalizing the filename path output, and it works!

## Test plan

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->
`npm run build` (`vite`) or `npm run build` (`vite build`) in this repo on a Windows machine: https://github.com/nstepien/vite-bug