### PR TITLE
fix(vite): broken imports from some third-party libs

### DIFF
--- a/.changeset/bright-files-beg.md
+++ b/.changeset/bright-files-beg.md
@@ -1,0 +1,6 @@
+---
+'@linaria/babel-preset': patch
+'@linaria/vite': patch
+---
+
+A workaround for an issue with Vite and imports from some third-party libs.


### PR DESCRIPTION
## Motivation

Vite in dev mode converts CJS libraries to ESM. In some unclear cases, it causes a situation when all exports from such modules are exported as an object under `default`.

## Summary

This PR introduces a workaround that checks if an undefined import is presented in the `default` import. If so, the value from `default` will be returned.

However, the reason for such behaviour requires future investigation.