### PR TITLE
fix(babel): circular deps cause infinite loops (fixes #1202)

### DIFF
--- a/.changeset/purple-meals-deliver.md
+++ b/.changeset/purple-meals-deliver.md
@@ -1,0 +1,5 @@
+---
+'@linaria/babel-preset': patch
+---
+
+Another fix for infinite loops. Fixes #1202

--- a/packages/babel/src/transform-stages/1-prepare-for-eval.ts
+++ b/packages/babel/src/transform-stages/1-prepare-for-eval.ts
@@ -365,7 +365,10 @@ export default async function prepareForEval(
     if (cached) {
       if (isEqual(cached.only, mergedOnly)) {
         log('stage-1', '%s is already processed', name);
-        imports = cached.imports;
+        if (!resolveStack.includes(nextItem.name)) {
+          imports = cached.imports;
+        }
+
         result = cached.result;
       } else {
         log(


### PR DESCRIPTION
## Motivation

See #1202 

## Summary

This PR introduces a circuit breaker for cases when an imported dependency was already processed and presented in a resolve stack.