### PR TITLE
fix(rollup): don't parse external libraries

### DIFF
--- a/.changeset/metal-carrots-fix.md
+++ b/.changeset/metal-carrots-fix.md
@@ -1,5 +1,6 @@
 ---
 '@linaria/rollup': patch
+'@linaria/vite': patch
 ---
 
-Ignore external libraries when bundling with rollup
+Fallback resolver for external libraries when bundling with Rollup or Vite.

--- a/.changeset/metal-carrots-fix.md
+++ b/.changeset/metal-carrots-fix.md
@@ -1,0 +1,5 @@
+---
+'@linaria/rollup': patch
+---
+
+Ignore external libraries when bundling with rollup

--- a/packages/rollup/src/index.ts
+++ b/packages/rollup/src/index.ts
@@ -18,7 +18,7 @@ import type {
   Result,
 } from '@linaria/babel-preset';
 import { createCustomDebug } from '@linaria/logger';
-import { getFileIdx } from '@linaria/utils';
+import { getFileIdx, syncResolve } from '@linaria/utils';
 import type { Plugin as VitePlugin } from '@linaria/vite';
 import vitePlugin from '@linaria/vite';
 
@@ -60,16 +60,22 @@ export default function linaria({
 
       log('rollup-init', id);
 
-      const asyncResolve = async (what: string, importer: string) => {
+      const asyncResolve = async (
+        what: string,
+        importer: string,
+        stack: string[]
+      ) => {
         const resolved = await this.resolve(what, importer);
         if (resolved) {
-          log('resolve', "✅ '%s'@'%s -> %O\n%s", what, importer, resolved);
-
           if (resolved.external) {
-            // ignore external modules, they don't need to be processed
-            // because external modules shouldn't contain any CSS in JS
-            return null;
+            // If module is marked as external, Rollup will not resolve it,
+            // so we need to resolve it ourselves with default resolver
+            const resolvedId = syncResolve(what, importer, stack);
+            log('resolve', "✅ '%s'@'%s -> %O\n%s", what, importer, resolved);
+            return resolvedId;
           }
+
+          log('resolve', "✅ '%s'@'%s -> %O\n%s", what, importer, resolved);
 
           // Vite adds param like `?v=667939b3` to cached modules
           const resolvedId = resolved.id.split('?')[0];

--- a/packages/rollup/src/index.ts
+++ b/packages/rollup/src/index.ts
@@ -64,6 +64,13 @@ export default function linaria({
         const resolved = await this.resolve(what, importer);
         if (resolved) {
           log('resolve', "✅ '%s'@'%s -> %O\n%s", what, importer, resolved);
+
+          if (resolved.external) {
+            // ignore external modules, they don't need to be processed
+            // because external modules shouldn't contain any CSS in JS
+            return null;
+          }
+
           // Vite adds param like `?v=667939b3` to cached modules
           const resolvedId = resolved.id.split('?')[0];
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation
Linaria fails to transform code that contains external imports when used in rollup alongside certain plugins like node-resolve. See [this bug reproduction repo](https://github.com/kcover/linaria-rollup-resolve-repro) for an example.


<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->

## Summary
The linaria rollup plugin as it exists expects any external imports to be resolved as 'null', and passes that along to the babel plugin, which knows to ignore such imports. It doesn't expect an object indicating an external dependency to be returned (See [the rollup resolveId hook docs](https://rollupjs.org/plugin-development/#resolveid) to see when this might occur). When that happens, the linaria plugin returns the `id` property of the object, which is often just the name of the import (e.g. 'react'). The babel-preset's transform function expects this to be a path to the import so it can read it in, but we don't need to do this in the case of an external dependency. This PR adds a check to handle that case where the rollup plugin receives an object indicating an external dependency.

<!--
Explain how your implementation works and your thoughts behind the solution.
It will help maintainers to review your PR.
You can skip it if PR is trivial.
-->

## Test plan
I'd love to set up an automated test for this but that would be a lot of effort on my own, given how unfamiliar I am with this project. I don't see any tests already set up for the rollup plugin or I would've added some tests in there. If I can get some help/direction I'd be happy to get some automated tests started. 

In the mean time, you can pull down [the reproduction repo](https://github.com/kcover/linaria-rollup-resolve-repro) and this PR, and use yarn link to try out this change. If you have trouble using yarn link reach out to me and I can help you out.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->
