### PR TITLE
fix(atomic): add react as an optional peerDependency

### DIFF
--- a/.changeset/polite-chairs-float.md
+++ b/.changeset/polite-chairs-float.md
@@ -1,0 +1,5 @@
+---
+'@linaria/atomic': patch
+---
+
+add react as an optional peerDependency due to dependency on @atomic/react

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -62,6 +62,14 @@
   "devDependencies": {
     "@babel/types": "^7.20.2"
   },
+  "peerDependencies": {
+    "react": ">=16"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": "^12.16.0 || >=13.7.0"
   },


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation
When using the latest version of yarn, you get the following warning about the missing peerDependency passthrough from `@linaria/react` => `@linaria/atomic`. I marked it as optional, since it appears that you would only need react if using the `styled` export.

<img width="711" alt="Screenshot 2023-02-18 at 11 11 03 AM" src="https://user-images.githubusercontent.com/8534796/219876205-3ba1a6b2-6f1a-48d9-9bd4-6053c83c2d7f.png">

<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->

## Summary

<!--
Explain how your implementation works and your thoughts behind the solution.
It will help maintainers to review your PR.
You can skip it if PR is trivial.
-->

## Test plan

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->
Setting the following in my local yarnrc.yml resolves the warning
```yml
packageExtensions:
  '@linaria/atomic@*':
    peerDependencies:
      react: '>=16'
    peerDependenciesMeta:
      react:
        optional: true
```