### PR TITLE
loadLinariaOptions: fix node_modules regexp for Windows

### DIFF
--- a/packages/babel/src/transform-stages/helpers/loadLinariaOptions.ts
+++ b/packages/babel/src/transform-stages/helpers/loadLinariaOptions.ts
@@ -12,9 +12,11 @@ export type PluginOptions = StrictOptions & {
 const explorerSync = cosmiconfigSync('linaria');
 
 const cache = new WeakMap<Partial<PluginOptions>, StrictOptions>();
+const defaultOverrides = {};
+const nodeModulesRegExp = /[\\/]node_modules[\\/]/;
 
 export default function loadLinariaOptions(
-  overrides: Partial<PluginOptions> = {}
+  overrides: Partial<PluginOptions> = defaultOverrides
 ): StrictOptions {
   if (cache.has(overrides)) {
     return cache.get(overrides)!;
@@ -37,13 +39,13 @@ export default function loadLinariaOptions(
       },
       {
         // The old `ignore` option is used as a default value for `ignore` rule.
-        test: ignore ?? /[\\/]node_modules[\\/]/,
+        test: ignore ?? nodeModulesRegExp,
         action: 'ignore',
       },
       {
         // Do not ignore ES-modules
         test: (filename, code) => {
-          if (!/\/node_modules\//.test(filename)) {
+          if (!nodeModulesRegExp.test(filename)) {
             return false;
           }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->
Windows compatibily.

## Summary

<!--
Explain how your implementation works and your thoughts behind the solution.
It will help maintainers to review your PR.
You can skip it if PR is trivial.
-->
One regexp used forward slashes only, while filenames have blackslashes on Windows.

## Test plan

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->
Ran locally.