### PR TITLE
docs: add Vite to Bundlers table of contents

### DIFF
--- a/docs/BUNDLERS_INTEGRATION.md
+++ b/docs/BUNDLERS_INTEGRATION.md
@@ -5,6 +5,7 @@
 - [webpack](#webpack)
 - [esbuild](#esbuild)
 - [Rollup](#Rollup)
+- [Vite](#Vite)
 - [Svelte](#Svelte)
 
 ## Pre-requisites


### PR DESCRIPTION
Vite is present on the page but the link was missing in the "Jump to" list.