### PR TITLE
fix(atomic,core,react): simplify Jest configuration

### DIFF
--- a/.changeset/proud-boats-study.md
+++ b/.changeset/proud-boats-study.md
@@ -1,0 +1,7 @@
+---
+'@linaria/atomic': patch
+'@linaria/core': patch
+'@linaria/react': patch
+---
+
+Usages of `styled` and `css` in Jest no longer trigger the "Using the … tag in runtime is not supported" exception.

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -60,7 +60,8 @@
     "ts-invariant": "^0.10.3"
   },
   "devDependencies": {
-    "@babel/types": "^7.20.2"
+    "@babel/types": "^7.20.2",
+    "@types/node": "^17.0.39"
   },
   "peerDependencies": {
     "react": ">=16"

--- a/packages/atomic/src/css.ts
+++ b/packages/atomic/src/css.ts
@@ -7,7 +7,14 @@ type CSS = (
   ...exprs: Array<string | number | CSSProperties>
 ) => LinariaClassName;
 
+let idx = 0;
+
 export const css: CSS = () => {
+  if (process.env.NODE_ENV === 'test') {
+    // eslint-disable-next-line no-plusplus
+    return `mocked-atomic-css-${idx++}` as LinariaClassName;
+  }
+
   throw new Error(
     'Using the "css" tag in runtime is not supported. Make sure you have set up the Babel plugin correctly.'
   );

--- a/packages/atomic/tsconfig.json
+++ b/packages/atomic/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": { "paths": {}, "rootDir": "src/" },
+  "compilerOptions": {
+    "paths": {},
+    "rootDir": "src/",
+    "types": ["node"]
+  },
   "references": [{ "path": "../core" }, { "path": "../logger" }, { "path": "../react" }, { "path": "../utils" }]
 }

--- a/packages/core/src/css.ts
+++ b/packages/core/src/css.ts
@@ -8,7 +8,14 @@ type CSS = (
   ...exprs: Array<string | number | CSSProperties | StyledMeta>
 ) => LinariaClassName;
 
+let idx = 0;
+
 const css: CSS = () => {
+  if (process.env.NODE_ENV === 'test') {
+    // eslint-disable-next-line no-plusplus
+    return `mocked-css-${idx++}` as LinariaClassName;
+  }
+
   throw new Error(
     'Using the "css" tag in runtime is not supported. Make sure you have set up the Babel plugin correctly.'
   );

--- a/packages/react/__tests__/__snapshots__/styled.test.tsx.snap
+++ b/packages/react/__tests__/__snapshots__/styled.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`applies CSS variables in style prop 1`] = `
 <div
-  className="abcdefg"
+  className="mocked-styled-2 abcdefg"
   size={24}
   style={
     Object {
@@ -24,7 +24,7 @@ exports[`does not filter attributes for components 1`] = `
 
 exports[`does not filter attributes for kebab cased custom elements 1`] = `
 <my-element
-  className="abcdefg"
+  className="mocked-styled-14 abcdefg"
   unknownAttribute="voila"
 >
   This is a test
@@ -33,7 +33,7 @@ exports[`does not filter attributes for kebab cased custom elements 1`] = `
 
 exports[`does not filter attributes for unknown tag 1`] = `
 <definitelyunknowntag
-  className="abcdefg"
+  className="mocked-styled-16 abcdefg"
   hoverClass="voila"
 >
   This is a test
@@ -42,7 +42,7 @@ exports[`does not filter attributes for unknown tag 1`] = `
 
 exports[`does not filter attributes for upper camel cased custom elements 1`] = `
 <View
-  className="abcdefg"
+  className="mocked-styled-15 abcdefg"
   hoverClass="voila"
 >
   This is a test
@@ -51,7 +51,7 @@ exports[`does not filter attributes for upper camel cased custom elements 1`] = 
 
 exports[`filters unknown html attributes for HTML tag 1`] = `
 <div
-  className="abcdefg"
+  className="mocked-styled-13 abcdefg"
 >
   This is a test
 </div>
@@ -59,7 +59,7 @@ exports[`filters unknown html attributes for HTML tag 1`] = `
 
 exports[`forwards as prop when wrapping another styled component 1`] = `
 <a
-  className="hijklmn abcdefg"
+  className="mocked-styled-12 abcdefg hijklmn abcdefg"
 >
   This is a test
 </a>
@@ -67,7 +67,7 @@ exports[`forwards as prop when wrapping another styled component 1`] = `
 
 exports[`handles wrapping another styled component 1`] = `
 <div
-  className="hijklmn abcdefg"
+  className="mocked-styled-10 abcdefg hijklmn abcdefg"
 >
   This is a test
 </div>
@@ -75,7 +75,7 @@ exports[`handles wrapping another styled component 1`] = `
 
 exports[`merges CSS variables with custom style prop 1`] = `
 <div
-  className="abcdefg"
+  className="mocked-styled-3 abcdefg"
   style={
     Object {
       "--foo": "tomato",
@@ -97,7 +97,7 @@ exports[`provides linaria component className for composition as last item in pr
 
 exports[`renders component with display name and class name 1`] = `
 <div
-  className="abcdefg"
+  className="mocked-styled-1 abcdefg"
 >
   This is a test
 </div>
@@ -105,7 +105,7 @@ exports[`renders component with display name and class name 1`] = `
 
 exports[`renders tag with display name and class name 1`] = `
 <h1
-  className="abcdefg"
+  className="mocked-styled-0 abcdefg"
 >
   This is a test
 </h1>
@@ -113,7 +113,7 @@ exports[`renders tag with display name and class name 1`] = `
 
 exports[`replaces custom component with as prop for primitive 1`] = `
 <a
-  className="abcdefg"
+  className="mocked-styled-7 abcdefg"
   id="test"
 >
   This is a test
@@ -122,7 +122,7 @@ exports[`replaces custom component with as prop for primitive 1`] = `
 
 exports[`replaces primitive with as prop for custom component 1`] = `
 <div
-  className="abcdefg"
+  className="mocked-styled-8 abcdefg"
   foo="bar"
   id="test"
   style={
@@ -137,7 +137,7 @@ exports[`replaces primitive with as prop for custom component 1`] = `
 
 exports[`replaces simple component with as prop 1`] = `
 <a
-  className="abcdefg"
+  className="mocked-styled-6 abcdefg"
   id="test"
 >
   This is a test

--- a/packages/react/__tests__/styled.test.tsx
+++ b/packages/react/__tests__/styled.test.tsx
@@ -273,6 +273,10 @@ it('provides linaria component className for composition as last item in props.c
 });
 
 it('throws when using as tag for template literal', () => {
+  // styled uses process.env.NODE_ENV to determine if it's running in a test environment
+  const nodeEnv = process.env.NODE_ENV;
+  delete process.env.NODE_ENV;
+
   expect(
     () =>
       styled('div')`
@@ -286,6 +290,8 @@ it('throws when using as tag for template literal', () => {
         color: blue;
       `
   ).toThrow('Using the "styled" tag in runtime is not supported');
+
+  process.env.NODE_ENV = nodeEnv;
 });
 
 it('can get rest keys from object', () => {

--- a/packages/react/src/styled.ts
+++ b/packages/react/src/styled.ts
@@ -105,6 +105,8 @@ interface IProps {
   [props: string]: unknown;
 }
 
+let idx = 0;
+
 // Components with props are not allowed
 function styled(
   componentWithStyle: () => any
@@ -132,8 +134,17 @@ function styled(
   component: 'The target component should have a className prop'
 ): never;
 function styled(tag: any): any {
+  // eslint-disable-next-line no-plusplus
+  let mockedClass = `mocked-styled-${idx++}`;
+  if (tag?.__linaria?.className) {
+    mockedClass += ` ${tag.__linaria.className}`;
+  }
+
   return (options: Options) => {
-    if (process.env.NODE_ENV !== 'production') {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test'
+    ) {
       if (Array.isArray(options)) {
         // We received a strings array since it's used as a tag
         throw new Error(
@@ -143,7 +154,7 @@ function styled(tag: any): any {
     }
 
     const render = (props: any, ref: any) => {
-      const { as: component = tag, class: className } = props;
+      const { as: component = tag, class: className = mockedClass } = props;
       const shouldKeepProps =
         options.propsAsIs === undefined
           ? !(
@@ -213,7 +224,7 @@ function styled(tag: any): any {
 
     // These properties will be read by the babel plugin for interpolation
     (Result as any).__linaria = {
-      className: options.class,
+      className: options.class ?? mockedClass,
       extends: tag,
     };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,7 @@ importers:
       '@linaria/react': workspace:^
       '@linaria/tags': workspace:^
       '@linaria/utils': workspace:^
+      '@types/node': ^17.0.39
       known-css-properties: ^0.24.0
       postcss: ^8.3.11
       stylis: ^3.5.4
@@ -240,6 +241,7 @@ importers:
       ts-invariant: 0.10.3
     devDependencies:
       '@babel/types': 7.20.2
+      '@types/node': 17.0.39
 
   packages/babel:
     specifiers:
@@ -2600,22 +2602,22 @@ packages:
       postcss: 8.4.16
       postcss-selector-parser: 6.0.10
 
-  /@definitelytyped/header-parser/0.0.144:
-    resolution: {integrity: sha512-uDgZcuDI6NCsz6uo28w6l7JKuDg7IrzeroMp/+OxfWyrTdnPFZdaHGzQlyzJXx4upkvJ1fWvYYRwhP36khqG+A==}
+  /@definitelytyped/header-parser/0.0.159:
+    resolution: {integrity: sha512-y+zr9ahjiFz7BLW1HeMWrx7xNxfBTDU0loJqzRh9WPHVdSrMsk+JQBSlubed/EZ1hgFZ6m93FRzBRCGIj8kBYg==}
     dependencies:
-      '@definitelytyped/typescript-versions': 0.0.144
+      '@definitelytyped/typescript-versions': 0.0.159
       '@types/parsimmon': 1.10.6
       parsimmon: 1.18.1
     dev: true
 
-  /@definitelytyped/typescript-versions/0.0.144:
-    resolution: {integrity: sha512-fDaG9Wf2CvBprEMZCacifOopQCKKDlCINfKHeI0sEtJlQDIpRoQeOHdMqe7Jm2J8HJeK6mrzVF3Q9oCr/Go0hw==}
+  /@definitelytyped/typescript-versions/0.0.159:
+    resolution: {integrity: sha512-9TWRPpOo3CWYUyS3QCu8goJbAhS3qAE/LWFc+Qy6Wb8vsUAwMTioCtPPsYyqrPDbatXvPFrOr182hE1OFvEFSA==}
     dev: true
 
-  /@definitelytyped/utils/0.0.144:
-    resolution: {integrity: sha512-yB8XEF4O4gItnLz1MFcZtzNKXqWU4nE4Z3wfnZHcQWaJyZCjf/oONTt1Lw98bTjQsaRBDmcE9q8iFwpLYUuEVQ==}
+  /@definitelytyped/utils/0.0.159:
+    resolution: {integrity: sha512-zm+Gsw39sD2EANlJmmNXgtpIzXO3QmBq5nZx6Y95RD/s2AypDaBw0eauO1wWji6I45tJOAgPZEvfmjjaxfoyhA==}
     dependencies:
-      '@definitelytyped/typescript-versions': 0.0.144
+      '@definitelytyped/typescript-versions': 0.0.159
       '@qiwi/npm-registry-client': 8.9.1
       '@types/node': 14.18.33
       charm: 1.0.2
@@ -3727,7 +3729,7 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 3.0.5
-      '@types/node': 17.0.39
+      '@types/node': 18.11.9
     dev: true
 
   /@types/graceful-fs/4.1.5:
@@ -3826,7 +3828,7 @@ packages:
   /@types/mkdirp/0.5.2:
     resolution: {integrity: sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==}
     dependencies:
-      '@types/node': 17.0.39
+      '@types/node': 18.11.9
     dev: true
 
   /@types/ms/0.7.31:
@@ -6290,7 +6292,7 @@ packages:
     peerDependencies:
       typescript: '*'
     dependencies:
-      '@definitelytyped/header-parser': 0.0.144
+      '@definitelytyped/header-parser': 0.0.159
       command-exists: 1.2.9
       rimraf: 3.0.2
       semver: 6.3.0
@@ -6306,9 +6308,9 @@ packages:
     peerDependencies:
       typescript: '>= 3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.7.0-dev || >= 3.8.0-dev || >= 3.9.0-dev || >= 4.0.0-dev'
     dependencies:
-      '@definitelytyped/header-parser': 0.0.144
-      '@definitelytyped/typescript-versions': 0.0.144
-      '@definitelytyped/utils': 0.0.144
+      '@definitelytyped/header-parser': 0.0.159
+      '@definitelytyped/typescript-versions': 0.0.159
+      '@definitelytyped/utils': 0.0.159
       dts-critic: 3.3.11_typescript@4.7.4
       fs-extra: 6.0.1
       json-stable-stringify: 1.0.1
@@ -13681,7 +13683,7 @@ packages:
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
       terser: 5.14.0
-      webpack: 5.73.0_webpack-cli@4.9.2
+      webpack: 5.73.0
     dev: true
 
   /terser-webpack-plugin/5.3.6_webpack@5.75.0:


### PR DESCRIPTION
## Motivation

Prior to this pull request, using Jest with Linaria required the inclusion of a Babel plugin to extract styles and generate class names.

## Summary

This pull request eliminates the need to include the @linaria/babel-preset when using Jest. All calls to styled and css will now be replaced with runtime versions that generate sequential class names. This simplification reduces the risk of configuration issues and streamlines the process of integrating Jest with Linaria.
