### PR TITLE
fix(tags): typeScript < 4.7 compatibility (fixes #1227)

### DIFF
--- a/.changeset/clean-berries-decide.md
+++ b/.changeset/clean-berries-decide.md
@@ -1,0 +1,5 @@
+---
+'@linaria/tags': patch
+---
+
+Fix TypeScript < 4.7 compatibility (fixes #1227)

--- a/packages/tags/src/utils/validateParams.ts
+++ b/packages/tags/src/utils/validateParams.ts
@@ -7,22 +7,34 @@ export type ParamConstraints =
   | [...ParamConstraint[]]
   | [...ParamConstraint[], '...'];
 
-type GetParamByName<T> = T extends '*'
-  ? Param
-  : T extends (infer TNames extends ParamName)[]
-  ? Extract<Param, readonly [TNames, ...unknown[]]>
-  : T extends ParamName
-  ? Extract<Param, readonly [T, ...unknown[]]>
-  : never;
+// ParamMapping maps each ParamName to its corresponding Param type.
+type ParamMapping = {
+  [K in ParamName]: Extract<Param, readonly [K, ...unknown[]]>; // For each ParamName K, extract the corresponding Param type.
+};
 
+// GetParamByName returns the Param type based on the input type T.
+type GetParamByName<T> = T extends '*'
+  ? Param // If T is '*', return Param type.
+  : T extends keyof ParamMapping // If T is a key in ParamMapping (i.e., a ParamName).
+  ? ParamMapping[T] // Return the corresponding Param type from ParamMapping.
+  : T extends Array<infer TNames> // If T is an array of names.
+  ? TNames extends ParamName // If TNames is a ParamName.
+    ? Extract<Param, readonly [TNames, ...unknown[]]> // Return the corresponding Param type.
+    : never // If TNames is not a ParamName, return never.
+  : never; // If T is none of the above, return never.
+
+// MapParams iteratively maps the input ParamConstraints to their corresponding Param types.
 export type MapParams<
   TNames extends ParamConstraints,
   TRes extends Param[] = []
-> = TNames extends [infer THead, ...infer TTail extends ParamConstraints]
-  ? THead extends '...'
-    ? [...TRes, ...Params]
-    : MapParams<TTail, [...TRes, GetParamByName<THead>]>
-  : TRes;
+> = TNames extends [infer THead, ...infer TTail] // If TNames is a non-empty tuple.
+  ? THead extends '...' // If the first element in the tuple is '...'.
+    ? [...TRes, ...Params] // Append all Params to the result tuple.
+    : MapParams<
+        Extract<TTail, ParamConstraints>, // Extract the remaining ParamConstraints.
+        [...TRes, GetParamByName<Extract<THead, ParamName | '*' | ParamName[]>>] // Append the mapped Param to the result tuple and recurse.
+      >
+  : TRes; // If TNames is an empty tuple, return the result tuple.
 
 export function isValidParams<T extends ParamConstraints>(
   params: Params,


### PR DESCRIPTION
## Motivation

See #1227 

## Summary

`isValidParams` has been rewritten without extends constraints.