### PR TITLE
fix(shaker): improve strategy for namespace imports and side effects

### DIFF
--- a/.changeset/thick-ads-beam.md
+++ b/.changeset/thick-ads-beam.md
@@ -1,0 +1,8 @@
+---
+'@linaria/react': patch
+'@linaria/shaker': patch
+'@linaria/tags': patch
+'@linaria/utils': patch
+---
+
+Enhance @linaria/shaker strategy: better search in namespace imports, add support for side effect imports, fix file skipping.

--- a/packages/react/src/styled.ts
+++ b/packages/react/src/styled.ts
@@ -224,7 +224,7 @@ function styled(tag: any): any {
 
     // These properties will be read by the babel plugin for interpolation
     (Result as any).__linaria = {
-      className: options.class ?? mockedClass,
+      className: options.class || mockedClass,
       extends: tag,
     };
 

--- a/packages/shaker/src/plugins/__tests__/__snapshots__/shaker-plugin.test.ts.snap
+++ b/packages/shaker/src/plugins/__tests__/__snapshots__/shaker-plugin.test.ts.snap
@@ -2,11 +2,31 @@
 
 exports[`shaker should delete import 1`] = `"export const Alive = \\"\\";"`;
 
+exports[`shaker should handle __importDefault 1`] = `
+"var __importDefault = this && this.__importDefault || function (mod) {
+  return mod && mod.__esModule ? mod : {
+    default: mod
+  };
+};
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+var Input_1 = require('./Input');
+Object.defineProperty(exports, 'Input', {
+  enumerable: true,
+  get: function () {
+    return __importDefault(Input_1).default;
+  }
+});"
+`;
+
 exports[`shaker should keep assigment even if export is marked for removing 1`] = `
 "let _a;
 exports.a = _a = {};
 exports.b = _a;"
 `;
+
+exports[`shaker should keep only side-effects 1`] = `"import 'regenerator-runtime/runtime.js';"`;
 
 exports[`shaker should keep referenced exports 1`] = `
 "var _foo;
@@ -69,6 +89,11 @@ exports[`shaker should respect implicit references 1`] = `
 "let _a;
 exports.a = _a = {};
 exports.b = _a;"
+`;
+
+exports[`shaker should shake if __linariaPreval required but not exported 1`] = `
+"import 'regenerator-runtime/runtime.js';
+export { Input } from \\"./Input\\";"
 `;
 
 exports[`shaker should throw out unused referenced exports 1`] = `"exports.defaultValue = 20;"`;

--- a/packages/shaker/src/plugins/shaker-plugin.ts
+++ b/packages/shaker/src/plugins/shaker-plugin.ts
@@ -150,6 +150,7 @@ export default function shakerPlugin(
       const log = createCustomDebug('shaker', getFileIdx(this.filename));
 
       log('start', `${this.filename}, onlyExports: ${onlyExports.join(',')}`);
+      const onlyExportsSet = new Set(onlyExports);
 
       const collected = collectExportsAndImports(file.path);
       const sideEffectImports = collected.imports.filter(sideEffectImport);
@@ -171,6 +172,9 @@ export default function shakerPlugin(
         collected.exports
       );
 
+      const findExport = (name: string) =>
+        exports.find((i) => i.exported === name);
+
       collected.exports.forEach(({ local }) => {
         if (local.isAssignmentExpression()) {
           const left = local.get('left');
@@ -182,13 +186,16 @@ export default function shakerPlugin(
         }
       });
 
-      if (
-        onlyExports.length === 1 &&
-        onlyExports[0] === '__linariaPreval' &&
-        !exports.find((i) => i.exported === '__linariaPreval')
-      ) {
-        // Fast-lane: if only __linariaPreval is requested, and it's not exported,
-        // we can just shake out the whole file
+      const hasLinariaPreval = findExport('__linariaPreval') !== undefined;
+      const hasDefault = findExport('default') !== undefined;
+
+      // If __linariaPreval is not exported, we can remove it from onlyExports
+      if (onlyExportsSet.has('__linariaPreval') && !hasLinariaPreval) {
+        onlyExportsSet.delete('__linariaPreval');
+      }
+
+      if (onlyExportsSet.size === 0) {
+        // Fast-lane: if there are no exports to keep, we can just shake out the whole file
         this.imports = [];
         this.exports = [];
         this.reexports = [];
@@ -199,13 +206,17 @@ export default function shakerPlugin(
 
         return;
       }
+
+      const importedAsSideEffect = onlyExportsSet.has('side-effect');
+      onlyExportsSet.delete('side-effect');
+
       // Hackaround for packages which include a 'default' export without specifying __esModule; such packages cannot be
       // shaken as they will break interopRequireDefault babel helper
       // See example in shaker-plugin.test.ts
       // Real-world example was found in preact/compat npm package
       if (
-        onlyExports.includes('default') &&
-        exports.find(({ exported }) => exported === 'default') &&
+        onlyExportsSet.has('default') &&
+        hasDefault &&
         !collected.isEsModule
       ) {
         this.imports = collected.imports;
@@ -213,12 +224,13 @@ export default function shakerPlugin(
         this.reexports = collected.reexports;
         return;
       }
-      if (!onlyExports.includes('*')) {
+
+      if (!onlyExportsSet.has('*')) {
         const aliveExports = new Set<IExport | IReexport>();
         const importNames = collected.imports.map(({ imported }) => imported);
 
         exports.forEach((exp) => {
-          if (onlyExports.includes(exp.exported)) {
+          if (onlyExportsSet.has(exp.exported)) {
             aliveExports.add(exp);
           } else if (
             importNames.includes((exp.local.node as NodeWithName).name || '')
@@ -236,12 +248,12 @@ export default function shakerPlugin(
         });
 
         collected.reexports.forEach((exp) => {
-          if (onlyExports.includes(exp.exported)) {
+          if (onlyExportsSet.has(exp.exported)) {
             aliveExports.add(exp);
           }
         });
 
-        const isAllExportsFound = aliveExports.size === onlyExports.length;
+        const isAllExportsFound = aliveExports.size === onlyExportsSet.size;
         if (!isAllExportsFound && ifUnknownExport !== 'ignore') {
           if (ifUnknownExport === 'error') {
             throw new Error(
@@ -277,7 +289,7 @@ export default function shakerPlugin(
           .filter((exp) => !aliveExports.has(exp))
           .map((exp) => exp.local);
 
-        if (!keepSideEffects && sideEffectImports.length > 0) {
+        if (!keepSideEffects && !importedAsSideEffect) {
           // Remove all imports that don't import something explicitly and should not be kept
           sideEffectImports.forEach((i) => {
             if (!shouldKeepSideEffect(i.source)) {

--- a/packages/tags/src/TaggedTemplateProcessor.ts
+++ b/packages/tags/src/TaggedTemplateProcessor.ts
@@ -9,7 +9,7 @@ import { validateParams } from './utils/validateParams';
 export default abstract class TaggedTemplateProcessor extends BaseProcessor {
   #template: (TemplateElement | ExpressionValue)[];
 
-  public constructor(params: Params, ...args: TailProcessorParams) {
+  protected constructor(params: Params, ...args: TailProcessorParams) {
     // Should have at least two params and the first one should be a callee.
     validateParams(
       params,


### PR DESCRIPTION
## Motivation

This pull request addresses the limitations in the existing shaker strategy, specifically in handling namespace imports and side effect imports. It aims to improve the efficiency and accuracy of the shaker process, while also fixing a bug related to file skipping. These enhancements will lead to better code optimization and reduced compile time.

## Summary

This PR introduces the following changes:

1. Improves the search for specific imported values in namespace imports, ensuring that only correct values are identified and imported.
2. Adds shaker support for side effect imports.
3. Fixes an issue where certain files were being skipped, ensuring all relevant files are properly processed by the shaker.

## Test plan

New tests were added.