### PR TITLE
fix(babel): fixed esm detection in node_modules

### DIFF
--- a/.changeset/blue-eagles-burn.md
+++ b/.changeset/blue-eagles-burn.md
@@ -1,0 +1,5 @@
+---
+'@linaria/babel-preset': patch
+---
+
+Better support for ES-modules in node_modules (fixes #1242)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -208,7 +208,7 @@ module.exports = {
           return false;
         }
         
-        return /(?:^|\n|;)\s*(?:export|import)\s+/.test(code);
+        return /\b(?:export|import)\b/.test(code);
       },
       action: require.resolve('@linaria/shaker'),
     }

--- a/packages/babel/src/transform-stages/helpers/loadLinariaOptions.ts
+++ b/packages/babel/src/transform-stages/helpers/loadLinariaOptions.ts
@@ -49,7 +49,8 @@ export default function loadLinariaOptions(
             return false;
           }
 
-          return /(?:^|\n|;)\s*(?:export|import)\s+/.test(code);
+          // If a file contains `export` or `import` keywords, we assume it's an ES-module
+          return /\b(?:export|import)\b/.test(code);
         },
         action: require.resolve('@linaria/shaker'),
       },


### PR DESCRIPTION
## Motivation

Some files in `node_modules` weren't detected as ESM. See #1242 

## Summary

The regular expression used to detect the keywords `export` or `import` contained an error that resulted in a false negative for ESM files that did not have any imports.