### PR TITLE
fix(react): don't add `mocked-styled` classnames outside test env

### DIFF
--- a/.changeset/strong-clouds-explode.md
+++ b/.changeset/strong-clouds-explode.md
@@ -1,0 +1,5 @@
+---
+'@linaria/react': patch
+---
+
+Don't add `mocked-styled` classnames outside test env

--- a/packages/react/src/styled.ts
+++ b/packages/react/src/styled.ts
@@ -134,10 +134,14 @@ function styled(
   component: 'The target component should have a className prop'
 ): never;
 function styled(tag: any): any {
-  // eslint-disable-next-line no-plusplus
-  let mockedClass = `mocked-styled-${idx++}`;
-  if (tag?.__linaria?.className) {
-    mockedClass += ` ${tag.__linaria.className}`;
+  let mockedClass = '';
+
+  if (process.env.NODE_ENV === 'test') {
+    // eslint-disable-next-line no-plusplus
+    mockedClass += `mocked-styled-${idx++}`;
+    if (tag?.__linaria?.className) {
+      mockedClass += ` ${tag.__linaria.className}`;
+    }
   }
 
   return (options: Options) => {


### PR DESCRIPTION
## Motivation

Fixes https://github.com/callstack/linaria/issues/1251

## Summary

Adds a `process.env.NODE_ENV` check to `styled` when adding the `mocked-styled` classes, similar to how `css` is already doing.

## Test plan

Can be seen by checking the website build:

#### Before (`NODE_ENV=development`)
<img width="850" alt="Screenshot 2023-05-19 at 14 15 30" src="https://github.com/callstack/linaria/assets/3333374/01c5e85e-006d-4196-b1c2-cc8ef4d8240b">

#### After (`NODE_ENV=development`)
<img width="744" alt="Screenshot 2023-05-19 at 14 14 55" src="https://github.com/callstack/linaria/assets/3333374/bb6f7f6f-77e7-4d3b-bf53-9294a2b0045a">

