### PR TITLE
Fix: ERROR Cannot find module 'xxx' with esbuild 0.17 and linaria 4.2

### DIFF
--- a/.changeset/esbuild-linaria-cant-find-module.md
+++ b/.changeset/esbuild-linaria-cant-find-module.md
@@ -1,0 +1,5 @@
+---
+'@linaria/esbuild': patch
+---
+
+Cannot find module 'xxx' with esbuild 0.17 and linaria 4.2

--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -43,6 +43,7 @@ export default function linaria({
 
         const result = await build.resolve(token, {
           resolveDir: context,
+          kind: "import-statement"
         });
 
         if (result.errors.length > 0) {


### PR DESCRIPTION
Fix: ERROR Cannot find module './style.js'

## Motivation

Found this error in the logs

```
[stage-1:async-resolve] ❌ cannot resolve ./style.js in /home/sebasjm/Work/linaria/src/SimpleButton.tsx: Error: Must specify "kind" when calling "resolve"
```

With these dependencies

```
    "@linaria/core": "^4.2.10",
    "@linaria/esbuild": "^4.2.11",
    "@linaria/react": "^4.3.8",
    "esbuild": "^0.17.19",
```

## Summary

I checked the esbuild documentation and looks that there is a missing parameter. 
I patched locally and it worked for me.

## Test plan

I made a repo to reproduce and fix the problem 
https://github.com/sebasjm/linaria-esbuild-patch

