### PR TITLE
fix(shaker): improved references detection

### DIFF
--- a/.changeset/nine-fans-walk.md
+++ b/.changeset/nine-fans-walk.md
@@ -1,0 +1,6 @@
+---
+'@linaria/shaker': patch
+'@linaria/utils': patch
+---
+
+Improved compatibility with redux and some other libraries.

--- a/packages/shaker/src/plugins/__tests__/__snapshots__/shaker-plugin.test.ts.snap
+++ b/packages/shaker/src/plugins/__tests__/__snapshots__/shaker-plugin.test.ts.snap
@@ -35,6 +35,16 @@ exports.defaultValue = Math.random() * _foo;
 exports.foo = _foo;"
 `;
 
+exports[`shaker should keep setBatch 1`] = `
+"function defaultNoopBatch(callback) {
+  callback();
+}
+var batch = defaultNoopBatch;
+export var setBatch = function setBatch(newBatch) {
+  return batch = newBatch;
+};"
+`;
+
 exports[`shaker should keep side-effects from modules 1`] = `
 "import 'regenerator-runtime/runtime.js';
 export const a = 1;"
@@ -43,6 +53,11 @@ export const a = 1;"
 exports[`shaker should process array patterns 1`] = `
 "const [,, c] = array;
 export { c };"
+`;
+
+exports[`shaker should process constant violations inside binding paths 1`] = `
+"export function c() {}
+;"
 `;
 
 exports[`shaker should process identifiers in void expressions as references 1`] = `

--- a/packages/shaker/src/plugins/__tests__/shaker-plugin.test.ts
+++ b/packages/shaker/src/plugins/__tests__/shaker-plugin.test.ts
@@ -385,4 +385,38 @@ describe('shaker', () => {
       './Input',
     ]);
   });
+
+  it('should keep setBatch', () => {
+    // A real-world example from react-redux
+    const { code, metadata } = keep(['setBatch'])`
+      function defaultNoopBatch(callback) {
+        callback();
+      }
+
+      var batch = defaultNoopBatch;
+
+      export var setBatch = function setBatch(newBatch) {
+        return (batch = newBatch);
+      };
+
+      export var getBatch = function getBatch() {
+        return batch;
+      };
+    `;
+
+    expect(code).toMatchSnapshot();
+    expect(metadata.imports.size).toBe(0);
+  });
+
+  it('should process constant violations inside binding paths', () => {
+    // Function `a` should be removed because it's only used in removed function `b`
+    const { code, metadata } = keep(['c'])`
+      function a(flag) { return (a = function(flag) { flag ? 1 : 2 }) }
+      export function b() { return a(1) }
+      export function c() {};
+    `;
+
+    expect(code).toMatchSnapshot();
+    expect(metadata.imports.size).toBe(0);
+  });
 });


### PR DESCRIPTION
## Motivation

Shaker hasn't properly processed expressions like `return (batch = newBatch)`. See @PierreGUI's comment [#1226 ](https://github.com/callstack/linaria/issues/1226#issuecomment-1599111723)

## Summary

The reference detection algorithm has been improved.

## Test plan

A new test for that specific case was added.