### PR TITLE
feat(react): performance improvement

### DIFF
--- a/.changeset/serious-pans-pump.md
+++ b/.changeset/serious-pans-pump.md
@@ -1,0 +1,41 @@
+---
+'@linaria/babel-preset': minor
+'@linaria/griffel': minor
+'@linaria/react': minor
+'@linaria/tags': minor
+'@linaria/testkit': minor
+'@linaria/utils': minor
+'@linaria/atomic': minor
+'@linaria/cli': minor
+'@linaria/core': minor
+'@linaria/esbuild': minor
+'@linaria/extractor': minor
+'@linaria/babel-plugin-interop': minor
+'linaria': minor
+'@linaria/logger': minor
+'@linaria/postcss-linaria': minor
+'@linaria/rollup': minor
+'@linaria/server': minor
+'@linaria/shaker': minor
+'@linaria/stylelint': minor
+'@linaria/stylelint-config-standard-linaria': minor
+'@linaria/vite': minor
+'@linaria/webpack-loader': minor
+'@linaria/webpack4-loader': minor
+'@linaria/webpack5-loader': minor
+'linaria-website': minor
+---
+
+Breaking Change: Performance Optimization for `styled`
+
+When a component is wrapped in `styled`, Linaria needs to determine if that component is already a styled component. To accomplish this, the wrapped component is included in the list of variables for evaluation, along with the interpolated values used in styles. The issue arises when a wrapped component, even if it is not styled, brings along a substantial dependency tree. This situation is particularly evident when using `styled` to style components from third-party UI libraries.
+
+To address this problem, Linaria will now examine the import location of the component and check if there is an annotation in the `package.json` file of the package containing the components. This annotation indicates whether the package includes other Linaria components. If there is no such annotation, Linaria will refrain from evaluating the component.
+
+Please note that this Breaking Change solely affects developers of component libraries. In order for users to style components from your library, you must include the `linaria.components` property in the library's `package.json` file. This property should have a mask that covers all imported files with components. Here's an example of how to specify it:
+
+```json
+"linaria": {
+  "components": "**/*"
+}
+```

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -45,7 +45,6 @@
     "@linaria/tags": "workspace:^",
     "@linaria/utils": "workspace:^",
     "cosmiconfig": "^8.0.0",
-    "find-up": "^5.0.0",
     "source-map": "^0.7.3",
     "stylis": "^3.5.4"
   },

--- a/packages/babel/src/plugins/preeval.ts
+++ b/packages/babel/src/plugins/preeval.ts
@@ -14,6 +14,7 @@ import {
   isUnnecessaryReactCall,
   nonType,
   removeWithRelated,
+  addIdentifierToLinariaPreval,
 } from '@linaria/utils';
 
 import type { Core } from '../babel';
@@ -80,11 +81,18 @@ export default function preeval(
 
       log('start', 'Looking for template literals…');
 
+      const rootScope = file.scope;
       this.processors = [];
 
       file.path.traverse({
         Identifier: (p) => {
           processTemplateExpression(p, file.opts, options, (processor) => {
+            processor.dependencies.forEach((dependency) => {
+              if (dependency.ex.type === 'Identifier') {
+                addIdentifierToLinariaPreval(rootScope, dependency.ex.name);
+              }
+            });
+
             processor.doEvaltimeReplacement();
             this.processors.push(processor);
           });
@@ -199,12 +207,9 @@ export default function preeval(
         dependencies: [],
       };
 
-      const expressions: ExpressionValue['ex'][] = this.processors.flatMap(
-        (processor) => processor.dependencies.map((dependency) => dependency.ex)
-      );
-
       const linariaPreval = file.path.scope.getData('__linariaPreval');
       if (!linariaPreval) {
+        // Event if there is no dependencies, we still need to add __linariaPreval
         const linariaExport = t.expressionStatement(
           t.assignmentExpression(
             '=',
@@ -212,9 +217,7 @@ export default function preeval(
               t.identifier('exports'),
               t.identifier('__linariaPreval')
             ),
-            t.objectExpression(
-              expressions.map((ex) => t.objectProperty(ex, ex, false, true))
-            )
+            t.objectExpression([])
           )
         );
 

--- a/packages/babel/src/plugins/preeval.ts
+++ b/packages/babel/src/plugins/preeval.ts
@@ -6,7 +6,6 @@ import type { BabelFile, NodePath, PluginObj } from '@babel/core';
 import type { Identifier } from '@babel/types';
 
 import { createCustomDebug } from '@linaria/logger';
-import type { ExpressionValue } from '@linaria/tags';
 import type { StrictOptions } from '@linaria/utils';
 import {
   JSXElementsRemover,

--- a/packages/babel/src/utils/collectTemplateDependencies.ts
+++ b/packages/babel/src/utils/collectTemplateDependencies.ts
@@ -6,16 +6,11 @@
  */
 
 import { statement } from '@babel/template';
-import type { NodePath, Scope } from '@babel/traverse';
+import type { NodePath } from '@babel/traverse';
 import type {
   Expression,
-  ExpressionStatement,
   Identifier,
   JSXIdentifier,
-  ObjectExpression,
-  ObjectProperty,
-  Program,
-  SourceLocation,
   Statement,
   TaggedTemplateExpression,
   TemplateElement,
@@ -26,12 +21,14 @@ import type {
 import { cloneNode } from '@babel/types';
 
 import { debug } from '@linaria/logger';
-import type { ConstValue } from '@linaria/tags';
+import type { ConstValue, FunctionValue, LazyValue } from '@linaria/tags';
 import { hasMeta } from '@linaria/tags';
+import type { IImport } from '@linaria/utils';
 import {
+  addIdentifierToLinariaPreval,
+  createId,
   findIdentifiers,
   mutate,
-  reference,
   referenceAll,
 } from '@linaria/utils';
 
@@ -40,12 +37,6 @@ import { ValueType } from '../types';
 
 import getSource from './getSource';
 import valueToLiteral from './vlueToLiteral';
-
-const createId = (name: string, loc?: SourceLocation | null): Identifier => ({
-  type: 'Identifier',
-  name,
-  loc,
-});
 
 function staticEval(
   ex: NodePath<Expression>,
@@ -161,64 +152,19 @@ function hoistIdentifier(idPath: NodePath<Identifier>): void {
   throw unsupported(idPath);
 }
 
-function getOrAddLinariaPreval(scope: Scope): NodePath<ObjectExpression> {
-  const rootScope = scope.getProgramParent();
-  let object = rootScope.getData('__linariaPreval');
-  if (object) {
-    return object;
-  }
-
-  const prevalExport: ExpressionStatement = {
-    type: 'ExpressionStatement',
-    expression: {
-      type: 'AssignmentExpression',
-      operator: '=',
-      left: {
-        type: 'MemberExpression',
-        object: createId('exports'),
-        property: createId('__linariaPreval'),
-        computed: false,
-      },
-      right: {
-        type: 'ObjectExpression',
-        properties: [],
-      },
-    },
-  };
-
-  const programPath = rootScope.path as NodePath<Program>;
-  const [inserted] = programPath.pushContainer('body', [prevalExport]);
-  object = inserted.get('expression.right') as NodePath<ObjectExpression>;
-  rootScope.setData('__linariaPreval', object);
-  return object;
-}
-
-function addIdentifierToLinariaPreval(scope: Scope, name: string) {
-  const rootScope = scope.getProgramParent();
-  const object = getOrAddLinariaPreval(rootScope);
-  const newProperty: ObjectProperty = {
-    type: 'ObjectProperty',
-    key: createId(name),
-    value: createId(name),
-    computed: false,
-    shorthand: false,
-  };
-
-  const [inserted] = object.pushContainer('properties', [newProperty]);
-  reference(inserted.get('value') as NodePath<Identifier>);
-}
-
 /**
  * Only an expression that can be evaluated in the root scope can be
  * used in a Linaria template. This function tries to hoist the expression.
  * @param ex The expression to hoist.
  * @param evaluate If true, we try to statically evaluate the expression.
  * @param addToExport If true, we add the expression to the __linariaPreval.
+ * @param imports All the imports of the file.
  */
 export function extractExpression(
   ex: NodePath<Expression>,
   evaluate = false,
-  addToExport = true
+  addToExport = true,
+  imports: IImport[] = []
 ): Omit<ExpressionValue, 'buildCodeFrameError' | 'source'> {
   if (
     ex.isLiteral() &&
@@ -282,6 +228,12 @@ export function extractExpression(
   referenceAll(inserted);
   rootScope.registerDeclaration(inserted);
 
+  const exImport = ex.isIdentifier()
+    ? imports.find(
+        (i) => i.local.node === ex.scope.getBinding(ex.node.name)?.identifier
+      ) ?? null
+    : null;
+
   // Replace the expression with the _expN() call
   mutate(ex, (p) => {
     p.replaceWith({
@@ -298,10 +250,17 @@ export function extractExpression(
   // eslint-disable-next-line no-param-reassign
   ex.node.loc = loc;
 
-  return {
+  // noinspection UnnecessaryLocalVariableJS
+  const result: Omit<
+    LazyValue | FunctionValue,
+    'buildCodeFrameError' | 'source'
+  > = {
     kind,
     ex: createId(expUid, loc),
+    importedFrom: exImport?.source,
   };
+
+  return result;
 }
 
 /**

--- a/packages/babel/src/utils/getTagProcessor.ts
+++ b/packages/babel/src/utils/getTagProcessor.ts
@@ -10,7 +10,6 @@ import type {
   Identifier,
   MemberExpression,
 } from '@babel/types';
-import findUp from 'find-up';
 
 import { BaseProcessor } from '@linaria/tags';
 import type {
@@ -24,6 +23,7 @@ import type { IImport, StrictOptions } from '@linaria/utils';
 import {
   collectExportsAndImports,
   explicitImport,
+  findPackageJSON,
   isNotNull,
   mutate,
 } from '@linaria/utils';
@@ -67,26 +67,6 @@ function buildCodeFrameError(path: NodePath, message: string): Error {
     return path.buildCodeFrameError(message);
   } catch {
     return new Error(message);
-  }
-}
-
-function findPackageJSON(pkgName: string, filename: string | null | undefined) {
-  try {
-    const pkgPath = require.resolve(
-      pkgName,
-      filename ? { paths: [dirname(filename)] } : {}
-    );
-    return findUp.sync('package.json', { cwd: pkgPath });
-  } catch (er: unknown) {
-    if (
-      typeof er === 'object' &&
-      er !== null &&
-      (er as { code?: unknown }).code === 'MODULE_NOT_FOUND'
-    ) {
-      return undefined;
-    }
-
-    throw er;
   }
 }
 
@@ -275,7 +255,12 @@ function getBuilderForIdentifier(
             throw buildError(`Unexpected type of an argument ${arg.type}`);
           }
           const source = getSource(arg);
-          const extracted = extractExpression(arg, options.evaluate);
+          const extracted = extractExpression(
+            arg,
+            options.evaluate,
+            false,
+            imports
+          );
           return {
             ...extracted,
             source,

--- a/packages/griffel/src/processors/makeStyles.ts
+++ b/packages/griffel/src/processors/makeStyles.ts
@@ -29,6 +29,7 @@ export default class MakeStylesProcessor extends BaseProcessor {
 
     const { ex } = callParam[1];
     if (ex.type === 'Identifier') {
+      this.dependencies.push(callParam[1]);
       this.#slotsExpName = ex.name;
     } else if (ex.type === 'NullLiteral') {
       this.#slotsExpName = null;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -62,6 +62,7 @@
     "@linaria/core": "workspace:^",
     "@linaria/tags": "workspace:^",
     "@linaria/utils": "workspace:^",
+    "minimatch": "^9.0.3",
     "react-html-attributes": "^1.4.6",
     "ts-invariant": "^0.10.3"
   },

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,9 @@
 export { default as styled } from './styled';
-export type { StyledJSXIntrinsics, Styled } from './styled';
+export type {
+  HtmlStyledTag,
+  StyledComponent,
+  StyledJSXIntrinsics,
+  Styled,
+} from './styled';
 export type { CSSProperties } from '@linaria/core';
 export type { StyledMeta } from '@linaria/tags';

--- a/packages/react/src/styled.ts
+++ b/packages/react/src/styled.ts
@@ -236,14 +236,14 @@ function styled(tag: any): any {
   };
 }
 
-type StyledComponent<T> = StyledMeta &
+export type StyledComponent<T> = StyledMeta &
   ([T] extends [React.FunctionComponent<any>]
     ? T
     : React.FunctionComponent<T & { as?: React.ElementType }>);
 
 type StaticPlaceholder = string | number | CSSProperties | StyledMeta;
 
-type HtmlStyledTag<TName extends keyof JSX.IntrinsicElements> = <
+export type HtmlStyledTag<TName extends keyof JSX.IntrinsicElements> = <
   TAdditionalProps = Record<never, unknown>
 >(
   strings: TemplateStringsArray,

--- a/packages/tags/src/types.ts
+++ b/packages/tags/src/types.ts
@@ -71,7 +71,9 @@ export interface IInterpolation {
   unit: string;
 }
 
-export type WrappedNode = string | { node: Identifier; source: string };
+export type WrappedNode =
+  | string
+  | { node: Identifier; nonLinaria?: true; source: string };
 
 export type Rules = Record<string, ICSSRule>;
 
@@ -100,6 +102,7 @@ export enum ValueType {
 export type LazyValue = {
   buildCodeFrameError: BuildCodeFrameErrorFn;
   ex: Identifier;
+  importedFrom?: string;
   kind: ValueType.LAZY;
   source: string;
 };
@@ -107,6 +110,7 @@ export type LazyValue = {
 export type FunctionValue = {
   buildCodeFrameError: BuildCodeFrameErrorFn;
   ex: Identifier;
+  importedFrom?: string;
   kind: ValueType.FUNCTION;
   source: string;
 };

--- a/packages/testkit/src/__fixtures__/linaria-ui-library/components/index.js
+++ b/packages/testkit/src/__fixtures__/linaria-ui-library/components/index.js
@@ -1,0 +1,1 @@
+export const Title = () => 'Title';

--- a/packages/testkit/src/__fixtures__/linaria-ui-library/non-linaria-components.js
+++ b/packages/testkit/src/__fixtures__/linaria-ui-library/non-linaria-components.js
@@ -1,0 +1,3 @@
+export const Title = () => 'Title';
+
+throw new Error('This file should not be imported');

--- a/packages/testkit/src/__fixtures__/linaria-ui-library/package.json
+++ b/packages/testkit/src/__fixtures__/linaria-ui-library/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "linaria-ui-library",
+  "version": "1.0.0",
+  "dependencies": {
+  },
+  "linaria": {
+    "components": "components/**/*"
+  }
+}

--- a/packages/testkit/src/__fixtures__/non-linaria-ui-library/index.js
+++ b/packages/testkit/src/__fixtures__/non-linaria-ui-library/index.js
@@ -1,0 +1,3 @@
+export const Title = () => 'Title';
+
+throw new Error('This file should not be imported');

--- a/packages/testkit/src/__fixtures__/non-linaria-ui-library/package.json
+++ b/packages/testkit/src/__fixtures__/non-linaria-ui-library/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "non-linaria-ui-library",
+  "version": "1.0.0",
+  "dependencies": {
+  }
+}

--- a/packages/testkit/src/__snapshots__/babel.test.ts.snap
+++ b/packages/testkit/src/__snapshots__/babel.test.ts.snap
@@ -1857,6 +1857,27 @@ Dependencies: ../re-exports
 
 `;
 
+exports[`strategy shaker should eval component from a linaria library 1`] = `
+"import { styled } from \\"@linaria/react\\";
+import { Title } from \\"./__fixtures__/linaria-ui-library/components/index\\";
+const _exp = /*#__PURE__*/() => Title;
+export const StyledTitle = /*#__PURE__*/styled(_exp())({
+  name: \\"StyledTitle\\",
+  class: \\"StyledTitle_s13jq05\\",
+  propsAsIs: true
+});"
+`;
+
+exports[`strategy shaker should eval component from a linaria library 2`] = `
+
+CSS:
+
+.StyledTitle_s13jq05 {}
+
+Dependencies: ./__fixtures__/linaria-ui-library/components/index
+
+`;
+
 exports[`strategy shaker should handle shadowed identifier inside components 1`] = `
 "import React from 'react';
 const color = 'red';
@@ -1922,6 +1943,48 @@ CSS:
 }
 
 Dependencies: ./__fixtures__/reexports
+
+`;
+
+exports[`strategy shaker should not eval components from a non-linaria library 1`] = `
+"import { styled } from \\"@linaria/react\\";
+import { Title } from \\"./__fixtures__/non-linaria-ui-library/index\\";
+const _exp = /*#__PURE__*/() => Title;
+export const StyledTitle = /*#__PURE__*/styled(_exp())({
+  name: \\"StyledTitle\\",
+  class: \\"StyledTitle_s13jq05\\",
+  propsAsIs: true
+});"
+`;
+
+exports[`strategy shaker should not eval components from a non-linaria library 2`] = `
+
+CSS:
+
+.StyledTitle_s13jq05 {}
+
+Dependencies: NA
+
+`;
+
+exports[`strategy shaker should not eval non-linaria component from a linaria library 1`] = `
+"import { styled } from \\"@linaria/react\\";
+import { Title } from \\"./__fixtures__/linaria-ui-library/non-linaria-components\\";
+const _exp = /*#__PURE__*/() => Title;
+export const StyledTitle = /*#__PURE__*/styled(_exp())({
+  name: \\"StyledTitle\\",
+  class: \\"StyledTitle_s13jq05\\",
+  propsAsIs: true
+});"
+`;
+
+exports[`strategy shaker should not eval non-linaria component from a linaria library 2`] = `
+
+CSS:
+
+.StyledTitle_s13jq05 {}
+
+Dependencies: NA
 
 `;
 

--- a/packages/testkit/src/babel.test.ts
+++ b/packages/testkit/src/babel.test.ts
@@ -2703,4 +2703,49 @@ describe('strategy shaker', () => {
     expect(code).toMatchSnapshot();
     expect(metadata).toMatchSnapshot();
   });
+
+  it('should eval component from a linaria library', async () => {
+    const { code, metadata } = await transform(
+      dedent`
+      import { styled } from "@linaria/react";
+      import { Title } from "./__fixtures__/linaria-ui-library/components/index";
+
+      export const StyledTitle = styled(Title)\`\`;
+    `,
+      [evaluator]
+    );
+
+    expect(code).toMatchSnapshot();
+    expect(metadata).toMatchSnapshot();
+  });
+
+  it('should not eval components from a non-linaria library', async () => {
+    const { code, metadata } = await transform(
+      dedent`
+      import { styled } from "@linaria/react";
+      import { Title } from "./__fixtures__/non-linaria-ui-library/index";
+
+      export const StyledTitle = styled(Title)\`\`;
+    `,
+      [evaluator]
+    );
+
+    expect(code).toMatchSnapshot();
+    expect(metadata).toMatchSnapshot();
+  });
+
+  it('should not eval non-linaria component from a linaria library', async () => {
+    const { code, metadata } = await transform(
+      dedent`
+      import { styled } from "@linaria/react";
+      import { Title } from "./__fixtures__/linaria-ui-library/non-linaria-components";
+
+      export const StyledTitle = styled(Title)\`\`;
+    `,
+      [evaluator]
+    );
+
+    expect(code).toMatchSnapshot();
+    expect(metadata).toMatchSnapshot();
+  });
 });

--- a/packages/testkit/src/utils/getTagProcessor.test.ts
+++ b/packages/testkit/src/utils/getTagProcessor.test.ts
@@ -387,4 +387,58 @@ describe('getTagProcessor', () => {
       expect(runner).toThrow('Invalid usage of `styled` tag');
     });
   });
+
+  it('imported from a non-linaria library', () => {
+    const result = run(
+      dedent`
+      import { Title } from "../__fixtures__/non-linaria-ui-library/index";
+      import { styled } from "@linaria/react";
+
+      export const StyledLayout = styled(Title)\`\`;
+    `
+    );
+
+    expect(tagToString(result)).toBe('styled(Title)`…`');
+    expect(result?.dependencies).toHaveLength(0);
+    expect(result?.tagSource).toEqual({
+      imported: 'styled',
+      source: '@linaria/react',
+    });
+  });
+
+  it('imported from a linaria library', () => {
+    const result = run(
+      dedent`
+      import { Title } from "../__fixtures__/linaria-ui-library/components/index";
+      import { styled } from "@linaria/react";
+
+      export const StyledLayout = styled(Title)\`\`;
+    `
+    );
+
+    expect(tagToString(result)).toBe('styled(Title)`…`');
+    expect(result?.dependencies).toMatchObject([{ source: 'Title' }]);
+    expect(result?.tagSource).toEqual({
+      imported: 'styled',
+      source: '@linaria/react',
+    });
+  });
+
+  it('imported a non-linaria component from a linaria library', () => {
+    const result = run(
+      dedent`
+      import { Title } from "../__fixtures__/linaria-ui-library/non-linaria-components";
+      import { styled } from "@linaria/react";
+
+      export const StyledLayout = styled(Title)\`\`;
+    `
+    );
+
+    expect(tagToString(result)).toBe('styled(Title)`…`');
+    expect(result?.dependencies).toHaveLength(0);
+    expect(result?.tagSource).toEqual({
+      imported: 'styled',
+      source: '@linaria/react',
+    });
+  });
 });

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -38,7 +38,8 @@
     "@babel/traverse": "^7.20.1",
     "@babel/types": "^7.20.2",
     "@linaria/logger": "workspace:^",
-    "babel-merge": "^3.0.0"
+    "babel-merge": "^3.0.0",
+    "find-up": "^5.0.0"
   },
   "devDependencies": {
     "@types/babel__core": "^7.1.19",

--- a/packages/utils/src/addIdentifierToLinariaPreval.ts
+++ b/packages/utils/src/addIdentifierToLinariaPreval.ts
@@ -1,0 +1,58 @@
+import type { NodePath, Scope } from '@babel/traverse';
+import type {
+  ExpressionStatement,
+  Identifier,
+  ObjectExpression,
+  ObjectProperty,
+  Program,
+} from '@babel/types';
+
+import { createId } from './createId';
+import { reference } from './scopeHelpers';
+
+function getOrAddLinariaPreval(scope: Scope): NodePath<ObjectExpression> {
+  const rootScope = scope.getProgramParent();
+  let object = rootScope.getData('__linariaPreval');
+  if (object) {
+    return object;
+  }
+
+  const prevalExport: ExpressionStatement = {
+    type: 'ExpressionStatement',
+    expression: {
+      type: 'AssignmentExpression',
+      operator: '=',
+      left: {
+        type: 'MemberExpression',
+        object: createId('exports'),
+        property: createId('__linariaPreval'),
+        computed: false,
+      },
+      right: {
+        type: 'ObjectExpression',
+        properties: [],
+      },
+    },
+  };
+
+  const programPath = rootScope.path as NodePath<Program>;
+  const [inserted] = programPath.pushContainer('body', [prevalExport]);
+  object = inserted.get('expression.right') as NodePath<ObjectExpression>;
+  rootScope.setData('__linariaPreval', object);
+  return object;
+}
+
+export function addIdentifierToLinariaPreval(scope: Scope, name: string) {
+  const rootScope = scope.getProgramParent();
+  const object = getOrAddLinariaPreval(rootScope);
+  const newProperty: ObjectProperty = {
+    type: 'ObjectProperty',
+    key: createId(name),
+    value: createId(name),
+    computed: false,
+    shorthand: false,
+  };
+
+  const [inserted] = object.pushContainer('properties', [newProperty]);
+  reference(inserted.get('value') as NodePath<Identifier>);
+}

--- a/packages/utils/src/createId.ts
+++ b/packages/utils/src/createId.ts
@@ -1,0 +1,10 @@
+import type { Identifier, SourceLocation } from '@babel/types';
+
+export const createId = (
+  name: string,
+  loc?: SourceLocation | null
+): Identifier => ({
+  type: 'Identifier',
+  name,
+  loc,
+});

--- a/packages/utils/src/findPackageJSON.ts
+++ b/packages/utils/src/findPackageJSON.ts
@@ -1,0 +1,35 @@
+import { dirname, isAbsolute } from 'path';
+
+import findUp from 'find-up';
+
+const cache = new Map<string, string | undefined>();
+
+export function findPackageJSON(
+  pkgName: string,
+  filename: string | null | undefined
+) {
+  try {
+    const pkgPath =
+      pkgName === '.' && filename && isAbsolute(filename)
+        ? filename
+        : require.resolve(
+            pkgName,
+            filename ? { paths: [dirname(filename)] } : {}
+          );
+    if (!cache.has(pkgPath)) {
+      cache.set(pkgPath, findUp.sync('package.json', { cwd: pkgPath }));
+    }
+
+    return cache.get(pkgPath);
+  } catch (er: unknown) {
+    if (
+      typeof er === 'object' &&
+      er !== null &&
+      (er as { code?: unknown }).code === 'MODULE_NOT_FOUND'
+    ) {
+      return undefined;
+    }
+
+    throw er;
+  }
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,11 +1,14 @@
 export type { IVariableContext } from './IVariableContext';
+export { addIdentifierToLinariaPreval } from './addIdentifierToLinariaPreval';
 export {
   default as asyncResolveFallback,
   syncResolve,
 } from './asyncResolveFallback';
 export { default as collectExportsAndImports } from './collectExportsAndImports';
 export * from './collectExportsAndImports';
+export { createId } from './createId';
 export { default as findIdentifiers, nonType } from './findIdentifiers';
+export { findPackageJSON } from './findPackageJSON';
 export { default as getFileIdx } from './getFileIdx';
 export { default as isExports } from './isExports';
 export { default as isNotNull } from './isNotNull';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,7 +237,7 @@ importers:
         version: link:../../packages/vite
       babel-preset-solid:
         specifier: ^1.6.2
-        version: 1.6.2(@babel/core@7.20.2)
+        version: 1.6.2(@babel/core@7.22.9)
       compression:
         specifier: ^1.7.4
         version: 1.7.4
@@ -259,6 +259,8 @@ importers:
       vite-plugin-ssr:
         specifier: ^0.4.54
         version: 0.4.54(vite@3.2.4)
+
+  examples/vpssr-linaria-solid/dist/server: {}
 
   examples/webpack5:
     dependencies:
@@ -375,9 +377,6 @@ importers:
       cosmiconfig:
         specifier: ^8.0.0
         version: 8.0.0
-      find-up:
-        specifier: ^5.0.0
-        version: 5.0.0
       source-map:
         specifier: ^0.7.3
         version: 0.7.3
@@ -642,6 +641,9 @@ importers:
       '@linaria/utils':
         specifier: workspace:^
         version: link:../utils
+      minimatch:
+        specifier: ^9.0.3
+        version: 9.0.3
       react-html-attributes:
         specifier: ^1.4.6
         version: 1.4.6
@@ -964,6 +966,9 @@ importers:
       babel-merge:
         specifier: ^3.0.0
         version: 3.0.0(@babel/core@7.20.2)
+      find-up:
+        specifier: ^5.0.0
+        version: 5.0.0
     devDependencies:
       '@types/babel__core':
         specifier: ^7.1.19
@@ -1192,6 +1197,14 @@ packages:
       '@jridgewell/gen-mapping': 0.1.1
       '@jridgewell/trace-mapping': 0.3.17
 
+  /@ampproject/remapping@2.2.1:
+    resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/trace-mapping': 0.3.18
+    dev: false
+
   /@astrojs/compiler@0.29.17:
     resolution: {integrity: sha512-6ZbRGVunUMHxROD9Cleqkrfrj/kM9o43nLVwycdxCexCB5G372evy2ZM46LhaG/k5B5yC0PByNHTaGny0ll3iQ==}
     dev: true
@@ -1305,6 +1318,7 @@ packages:
   /@babel/cli@7.19.3(@babel/core@7.20.2):
     resolution: {integrity: sha512-643/TybmaCAe101m2tSVHi9UKpETXP9c/Ff4mD2tAwkdP6esKIfaauZFc67vGEM6r9fekbEGid+sZhbEnSe3dg==}
     engines: {node: '>=6.9.0'}
+    hasBin: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -1327,9 +1341,21 @@ packages:
     dependencies:
       '@babel/highlight': 7.18.6
 
+  /@babel/code-frame@7.22.5:
+    resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/highlight': 7.22.5
+    dev: false
+
   /@babel/compat-data@7.20.1:
     resolution: {integrity: sha512-EWZ4mE2diW3QALKvDMiXnbZpRvlj+nayZ112nK93SnhqOtpdsbVD4W+2tEoT3YNBAG9RBR0ISY758ZkOgsn6pQ==}
     engines: {node: '>=6.9.0'}
+
+  /@babel/compat-data@7.22.9:
+    resolution: {integrity: sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==}
+    engines: {node: '>=6.9.0'}
+    dev: false
 
   /@babel/core@7.20.2:
     resolution: {integrity: sha512-w7DbG8DtMrJcFOi4VrLm+8QM4az8Mo+PuLBKLp2zrYRCow8W/f9xiXm5sN53C8HksCyDQwCKha9JiDoIyPjT2g==}
@@ -1353,6 +1379,29 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/core@7.22.9:
+    resolution: {integrity: sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@ampproject/remapping': 2.2.1
+      '@babel/code-frame': 7.22.5
+      '@babel/generator': 7.22.9
+      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.22.9)
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.9)
+      '@babel/helpers': 7.22.6
+      '@babel/parser': 7.22.7
+      '@babel/template': 7.22.5
+      '@babel/traverse': 7.22.8
+      '@babel/types': 7.22.5
+      convert-source-map: 1.9.0
+      debug: 4.3.4
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/eslint-parser@7.19.1(@babel/core@7.20.2)(eslint@8.16.0):
     resolution: {integrity: sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
@@ -1374,6 +1423,16 @@ packages:
       '@babel/types': 7.20.2
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
+
+  /@babel/generator@7.22.9:
+    resolution: {integrity: sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
+      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/trace-mapping': 0.3.18
+      jsesc: 2.5.2
+    dev: false
 
   /@babel/helper-annotate-as-pure@7.18.6:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
@@ -1399,6 +1458,20 @@ packages:
       '@babel/helper-validator-option': 7.18.6
       browserslist: 4.21.4
       semver: 6.3.0
+
+  /@babel/helper-compilation-targets@7.22.9(@babel/core@7.22.9):
+    resolution: {integrity: sha512-7qYrNM6HjpnPHJbopxmb8hSPoZ0gsX8IvUS32JGVoy+pU9e5N0nLr1VjJoR6kA4d9dmGLxNYOjeB8sUDal2WMw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/compat-data': 7.22.9
+      '@babel/core': 7.22.9
+      '@babel/helper-validator-option': 7.22.5
+      browserslist: 4.21.9
+      lru-cache: 5.1.1
+      semver: 6.3.1
+    dev: false
 
   /@babel/helper-create-class-features-plugin@7.20.2(@babel/core@7.20.2):
     resolution: {integrity: sha512-k22GoYRAHPYr9I+Gvy2ZQlAe5mGy8BqWst2wRt8cwIufWTxrsVshhIBvYNqC80N0GSFWTsqRVexOtfzlgOEDvA==}
@@ -1446,6 +1519,11 @@ packages:
     resolution: {integrity: sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==}
     engines: {node: '>=6.9.0'}
 
+  /@babel/helper-environment-visitor@7.22.5:
+    resolution: {integrity: sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==}
+    engines: {node: '>=6.9.0'}
+    dev: false
+
   /@babel/helper-explode-assignable-expression@7.18.6:
     resolution: {integrity: sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==}
     engines: {node: '>=6.9.0'}
@@ -1459,11 +1537,26 @@ packages:
       '@babel/template': 7.18.10
       '@babel/types': 7.20.2
 
+  /@babel/helper-function-name@7.22.5:
+    resolution: {integrity: sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.22.5
+      '@babel/types': 7.22.5
+    dev: false
+
   /@babel/helper-hoist-variables@7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.20.2
+
+  /@babel/helper-hoist-variables@7.22.5:
+    resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
+    dev: false
 
   /@babel/helper-member-expression-to-functions@7.18.9:
     resolution: {integrity: sha512-RxifAh2ZoVU67PyKIO4AMi1wTenGfMR/O/ae0CCRqwgBAt5v7xjdtRw7UoSbsreKrQn5t7r89eruK/9JjYHuDg==}
@@ -1483,6 +1576,13 @@ packages:
     dependencies:
       '@babel/types': 7.20.2
 
+  /@babel/helper-module-imports@7.22.5:
+    resolution: {integrity: sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
+    dev: false
+
   /@babel/helper-module-transforms@7.20.2:
     resolution: {integrity: sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==}
     engines: {node: '>=6.9.0'}
@@ -1497,6 +1597,20 @@ packages:
       '@babel/types': 7.20.2
     transitivePeerDependencies:
       - supports-color
+
+  /@babel/helper-module-transforms@7.22.9(@babel/core@7.22.9):
+    resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.22.9
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-validator-identifier': 7.22.5
+    dev: false
 
   /@babel/helper-optimise-call-expression@7.18.6:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
@@ -1550,6 +1664,13 @@ packages:
     dependencies:
       '@babel/types': 7.20.2
 
+  /@babel/helper-simple-access@7.22.5:
+    resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
+    dev: false
+
   /@babel/helper-skip-transparent-expression-wrappers@7.20.0:
     resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
     engines: {node: '>=6.9.0'}
@@ -1562,17 +1683,39 @@ packages:
     dependencies:
       '@babel/types': 7.20.2
 
+  /@babel/helper-split-export-declaration@7.22.6:
+    resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
+    dev: false
+
   /@babel/helper-string-parser@7.19.4:
     resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
     engines: {node: '>=6.9.0'}
+
+  /@babel/helper-string-parser@7.22.5:
+    resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
+    engines: {node: '>=6.9.0'}
+    dev: false
 
   /@babel/helper-validator-identifier@7.19.1:
     resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
     engines: {node: '>=6.9.0'}
 
+  /@babel/helper-validator-identifier@7.22.5:
+    resolution: {integrity: sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==}
+    engines: {node: '>=6.9.0'}
+    dev: false
+
   /@babel/helper-validator-option@7.18.6:
     resolution: {integrity: sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==}
     engines: {node: '>=6.9.0'}
+
+  /@babel/helper-validator-option@7.22.5:
+    resolution: {integrity: sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==}
+    engines: {node: '>=6.9.0'}
+    dev: false
 
   /@babel/helper-wrap-function@7.19.0:
     resolution: {integrity: sha512-txX8aN8CZyYGTwcLhlk87KRqncAzhh5TpQamZUa0/u3an36NtDpUP6bQgBCBcLeBs09R/OwQu3OjK0k/HwfNDg==}
@@ -1595,6 +1738,17 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/helpers@7.22.6:
+    resolution: {integrity: sha512-YjDs6y/fVOYFV8hAf1rxd1QvR9wJe1pDBZ2AREKq/SDayfPzgk0PBnVuTCE5X1acEpMMNOVUqoe+OwiZGJ+OaA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.22.5
+      '@babel/traverse': 7.22.8
+      '@babel/types': 7.22.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/highlight@7.18.6:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
     engines: {node: '>=6.9.0'}
@@ -1602,6 +1756,15 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       chalk: 2.4.2
       js-tokens: 4.0.0
+
+  /@babel/highlight@7.22.5:
+    resolution: {integrity: sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.22.5
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+    dev: false
 
   /@babel/parser@7.18.4:
     resolution: {integrity: sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow==}
@@ -1615,6 +1778,14 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@babel/types': 7.20.2
+
+  /@babel/parser@7.22.7:
+    resolution: {integrity: sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.22.5
+    dev: false
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.18.6(@babel/core@7.20.2):
     resolution: {integrity: sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==}
@@ -1889,6 +2060,16 @@ packages:
     dependencies:
       '@babel/core': 7.20.2
       '@babel/helper-plugin-utils': 7.20.2
+
+  /@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.22.9):
+    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.9
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.20.2):
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
@@ -2542,6 +2723,15 @@ packages:
       '@babel/parser': 7.20.3
       '@babel/types': 7.20.2
 
+  /@babel/template@7.22.5:
+    resolution: {integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.22.5
+      '@babel/parser': 7.22.7
+      '@babel/types': 7.22.5
+    dev: false
+
   /@babel/traverse@7.20.1:
     resolution: {integrity: sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==}
     engines: {node: '>=6.9.0'}
@@ -2559,6 +2749,24 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/traverse@7.22.8:
+    resolution: {integrity: sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.22.5
+      '@babel/generator': 7.22.9
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-hoist-variables': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/parser': 7.22.7
+      '@babel/types': 7.22.5
+      debug: 4.3.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/types@7.20.2:
     resolution: {integrity: sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==}
     engines: {node: '>=6.9.0'}
@@ -2574,6 +2782,15 @@ packages:
       '@babel/helper-string-parser': 7.19.4
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
+
+  /@babel/types@7.22.5:
+    resolution: {integrity: sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.5
+      to-fast-properties: 2.0.0
+    dev: false
 
   /@bcoe/v8-coverage@0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -2928,11 +3145,11 @@ packages:
     dependencies:
       '@definitelytyped/typescript-versions': 0.0.163
       '@qiwi/npm-registry-client': 8.9.1
-      '@types/node': 14.18.33
+      '@types/node': 14.18.53
       charm: 1.0.2
       fs-extra: 8.1.0
       fstream: 1.0.12
-      tar: 6.1.12
+      tar: 6.1.15
       tar-stream: 2.2.0
     dev: true
 
@@ -3487,6 +3704,15 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.14
       '@jridgewell/trace-mapping': 0.3.17
 
+  /@jridgewell/gen-mapping@0.3.3:
+    resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/set-array': 1.1.2
+      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/trace-mapping': 0.3.18
+    dev: false
+
   /@jridgewell/resolve-uri@3.0.7:
     resolution: {integrity: sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==}
     engines: {node: '>=6.0.0'}
@@ -3514,6 +3740,10 @@ packages:
   /@jridgewell/sourcemap-codec@1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
 
+  /@jridgewell/sourcemap-codec@1.4.15:
+    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
+    dev: false
+
   /@jridgewell/trace-mapping@0.3.13:
     resolution: {integrity: sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==}
     dependencies:
@@ -3526,6 +3756,13 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
+
+  /@jridgewell/trace-mapping@0.3.18:
+    resolution: {integrity: sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/sourcemap-codec': 1.4.14
+    dev: false
 
   /@leichtgewicht/ip-codec@2.0.4:
     resolution: {integrity: sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==}
@@ -3628,14 +3865,14 @@ packages:
     resolution: {integrity: sha512-rZF+mG+NfijR0SHphhTLHRr4aM4gtfdwoAMY6we2VGQam8vkN1cxGG1Lg/Llrj8Dd0Mu6VjdFQRyMMRZxtZR2A==}
     dependencies:
       concat-stream: 2.0.0
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       normalize-package-data: 3.0.3
       npm-package-arg: 8.1.5
       once: 1.4.0
       request: 2.88.2
       retry: 0.12.0
       safe-buffer: 5.2.1
-      semver: 7.3.8
+      semver: 7.5.4
       slide: 1.1.6
       ssri: 8.0.1
     optionalDependencies:
@@ -4153,8 +4390,8 @@ packages:
     resolution: {integrity: sha512-CFMnEPkSXWALI73t1oIWyb8QOmVrp6RruAqIx349sd+1ImaFwzlKcz55mwrx/yLyOyz1gkq/UKuNOigt27PXqg==}
     dev: true
 
-  /@types/node@14.18.33:
-    resolution: {integrity: sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==}
+  /@types/node@14.18.53:
+    resolution: {integrity: sha512-soGmOpVBUq+gaBMwom1M+krC/NNbWlosh4AtGA03SyWNDiqSKtwp7OulO1M6+mg8YkHMvJ/y0AkCeO8d1hNb7A==}
     dev: true
 
   /@types/node@17.0.39:
@@ -4904,7 +5141,7 @@ packages:
     resolution: {integrity: sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==}
     dependencies:
       delegates: 1.0.0
-      readable-stream: 2.3.7
+      readable-stream: 2.3.8
     dev: true
     optional: true
 
@@ -5167,8 +5404,8 @@ packages:
     resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
     dev: true
 
-  /aws4@1.11.0:
-    resolution: {integrity: sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==}
+  /aws4@1.12.0:
+    resolution: {integrity: sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==}
     dev: true
 
   /axe-core@4.4.2:
@@ -5287,6 +5524,18 @@ packages:
       html-entities: 2.3.2
     dev: false
 
+  /babel-plugin-jsx-dom-expressions@0.35.4(@babel/core@7.22.9):
+    resolution: {integrity: sha512-Ab8W+36+XcNpyb644K537MtuhZRssgE3hmZD/08a1Z99Xfnd38tR2BZaDl7yEQvvHrb46N+eje2YjIg4VGAfVQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.22.9
+      '@babel/helper-module-imports': 7.16.0
+      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.22.9)
+      '@babel/types': 7.20.2
+      html-entities: 2.3.2
+    dev: false
+
   /babel-plugin-jsx-dom-expressions@0.35.6(@babel/core@7.20.2):
     resolution: {integrity: sha512-z8VBym+Scol38MiR97iqQGsANjhsDqscRRemk+po+z3TWKV/fb9kux/gdKOJJSC/ARyUL3HExBFVtr+Efd24uw==}
     peerDependencies:
@@ -5395,6 +5644,15 @@ packages:
       babel-plugin-jsx-dom-expressions: 0.35.4(@babel/core@7.20.2)
     dev: false
 
+  /babel-preset-solid@1.6.2(@babel/core@7.22.9):
+    resolution: {integrity: sha512-5sFI34g7Jtp4r04YFWkuC1o+gnekBdPXQTJb5/6lmxi5YwzazVgKAXRwEAToC3zRaPyIYJbZUVLpOi5mDzPEuw==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.22.9
+      babel-plugin-jsx-dom-expressions: 0.35.4(@babel/core@7.22.9)
+    dev: false
+
   /babel-preset-solid@1.6.3(@babel/core@7.20.2):
     resolution: {integrity: sha512-AQ6aaKQlDAZc3aAS+nFfXbNBf+NeJwKlRA55clj9PQI+Mkqv8JvTOnAEIGfYa0OW0sntMWhNWx+ih/4PK2s3/w==}
     peerDependencies:
@@ -5479,7 +5737,7 @@ packages:
     dependencies:
       buffer: 5.7.1
       inherits: 2.0.4
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
     dev: true
 
   /bl@5.1.0:
@@ -5592,7 +5850,6 @@ packages:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
     dependencies:
       balanced-match: 1.0.2
-    dev: true
 
   /braces@2.3.2:
     resolution: {integrity: sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==}
@@ -5687,7 +5944,7 @@ packages:
     resolution: {integrity: sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     dependencies:
-      caniuse-lite: 1.0.30001434
+      caniuse-lite: 1.0.30001515
       electron-to-chromium: 1.4.145
       escalade: 3.1.1
       node-releases: 2.0.5
@@ -5698,10 +5955,21 @@ packages:
     resolution: {integrity: sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     dependencies:
-      caniuse-lite: 1.0.30001434
+      caniuse-lite: 1.0.30001515
       electron-to-chromium: 1.4.284
       node-releases: 2.0.6
       update-browserslist-db: 1.0.10(browserslist@4.21.4)
+
+  /browserslist@4.21.9:
+    resolution: {integrity: sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+    dependencies:
+      caniuse-lite: 1.0.30001515
+      electron-to-chromium: 1.4.457
+      node-releases: 2.0.13
+      update-browserslist-db: 1.0.11(browserslist@4.21.9)
+    dev: false
 
   /bs-logger@0.2.6:
     resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
@@ -5899,8 +6167,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /caniuse-lite@1.0.30001434:
-    resolution: {integrity: sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==}
+  /caniuse-lite@1.0.30001515:
+    resolution: {integrity: sha512-eEFDwUOZbE24sb+Ecsx3+OvNETqjWIdabMy52oOkIgcUtAsQifjUG9q4U9dgTHJM2mfk4uEPxc0+xuFdJ629QA==}
 
   /capture-stack-trace@1.0.1:
     resolution: {integrity: sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==}
@@ -6310,7 +6578,7 @@ packages:
     dependencies:
       buffer-from: 1.1.2
       inherits: 2.0.4
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
       typedarray: 0.0.6
     dev: true
 
@@ -6974,7 +7242,7 @@ packages:
       '@definitelytyped/header-parser': 0.0.163
       command-exists: 1.2.9
       rimraf: 3.0.2
-      semver: 6.3.0
+      semver: 6.3.1
       tmp: 0.2.1
       typescript: 4.7.4
       yargs: 15.4.1
@@ -6983,6 +7251,7 @@ packages:
   /dtslint@4.2.1(typescript@4.7.4):
     resolution: {integrity: sha512-57mWY9osUEfS6k62ATS9RSgug1dZcuN4O31hO76u+iEexa6VUEbKoPGaA2mNtc0FQDcdTl0zEUtti79UQKSQyQ==}
     engines: {node: '>=10.0.0'}
+    hasBin: true
     peerDependencies:
       typescript: '>= 3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.7.0-dev || >= 3.8.0-dev || >= 3.9.0-dev || >= 4.0.0-dev'
     dependencies:
@@ -7032,6 +7301,10 @@ packages:
 
   /electron-to-chromium@1.4.284:
     resolution: {integrity: sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==}
+
+  /electron-to-chromium@1.4.457:
+    resolution: {integrity: sha512-/g3UyNDmDd6ebeWapmAoiyy+Sy2HyJ+/X8KyvNeHfKRFfHaA2W8oF5fxD5F3tjBDcjpwo0iek6YNgxNXDBoEtA==}
+    dev: false
 
   /elliptic@6.5.4:
     resolution: {integrity: sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==}
@@ -7900,6 +8173,7 @@ packages:
 
   /eslint-config-prettier@8.5.0(eslint@8.16.0):
     resolution: {integrity: sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==}
+    hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
@@ -8792,7 +9066,7 @@ packages:
     resolution: {integrity: sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==}
     engines: {node: '>=0.6'}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       inherits: 2.0.4
       mkdirp: 0.5.6
       rimraf: 2.7.1
@@ -9089,6 +9363,10 @@ packages:
 
   /graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
+
+  /graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+    dev: true
 
   /grapheme-splitter@1.0.4:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
@@ -10236,6 +10514,7 @@ packages:
   /jest-cli@28.1.0(@types/node@17.0.39):
     resolution: {integrity: sha512-fDJRt6WPRriHrBsvvgb93OxgajHHsJbk4jZxiPqmZbMDRcHskfJBBfTyjFko0jjfprP544hOktdSi9HVgl4VUQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    hasBin: true
     peerDependencies:
       node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
     peerDependenciesMeta:
@@ -10659,6 +10938,7 @@ packages:
   /jest@28.1.0(@types/node@17.0.39):
     resolution: {integrity: sha512-TZR+tHxopPhzw3c3560IJXZWLNHgpcz1Zh0w5A65vynLGNcg/5pZ+VildAd7+XGOu6jd58XMY/HNn0IkZIXVXg==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    hasBin: true
     peerDependencies:
       node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
     peerDependenciesMeta:
@@ -10763,6 +11043,12 @@ packages:
   /json5@2.2.1:
     resolution: {integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==}
     engines: {node: '>=6'}
+
+  /json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+    dev: false
 
   /jsonc-parser@2.3.1:
     resolution: {integrity: sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==}
@@ -11148,6 +11434,12 @@ packages:
     dependencies:
       pseudomap: 1.0.2
       yallist: 2.1.2
+
+  /lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+    dependencies:
+      yallist: 3.1.1
+    dev: false
 
   /lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
@@ -11930,6 +12222,13 @@ packages:
       brace-expansion: 2.0.1
     dev: true
 
+  /minimatch@9.0.3:
+    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
+
   /minimist-options@3.0.2:
     resolution: {integrity: sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==}
     engines: {node: '>= 4'}
@@ -11958,6 +12257,11 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       yallist: 4.0.0
+    dev: true
+
+  /minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
     dev: true
 
   /minizlib@2.1.2:
@@ -12169,6 +12473,10 @@ packages:
       vm-browserify: 1.1.2
     dev: false
 
+  /node-releases@2.0.13:
+    resolution: {integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==}
+    dev: false
+
   /node-releases@2.0.5:
     resolution: {integrity: sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==}
     dev: true
@@ -12220,7 +12528,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       hosted-git-info: 4.1.0
-      semver: 7.3.8
+      semver: 7.5.4
       validate-npm-package-name: 3.0.0
     dev: true
 
@@ -13135,6 +13443,11 @@ packages:
     resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
     engines: {node: '>=6'}
 
+  /punycode@2.3.0:
+    resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
+    engines: {node: '>=6'}
+    dev: true
+
   /q@1.5.1:
     resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
@@ -13365,6 +13678,19 @@ packages:
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
 
+  /readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+    dev: true
+    optional: true
+
   /readable-stream@3.6.0:
     resolution: {integrity: sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==}
     engines: {node: '>= 6'}
@@ -13372,6 +13698,15 @@ packages:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  /readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+    dev: true
 
   /readdirp@2.2.1:
     resolution: {integrity: sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==}
@@ -13631,7 +13966,7 @@ packages:
     deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
     dependencies:
       aws-sign2: 0.7.0
-      aws4: 1.11.0
+      aws4: 1.12.0
       caseless: 0.12.0
       combined-stream: 1.0.8
       extend: 3.0.2
@@ -14034,6 +14369,10 @@ packages:
   /semver@6.3.0:
     resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
 
+  /semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
   /semver@7.3.7:
     resolution: {integrity: sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==}
     engines: {node: '>=10'}
@@ -14046,6 +14385,14 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       lru-cache: 6.0.0
+
+  /semver@7.5.4:
+    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: true
 
   /send@0.18.0:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
@@ -14935,16 +15282,16 @@ packages:
       end-of-stream: 1.4.4
       fs-constants: 1.0.0
       inherits: 2.0.4
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
     dev: true
 
-  /tar@6.1.12:
-    resolution: {integrity: sha512-jU4TdemS31uABHd+Lt5WEYJuzn+TJTCBLljvIAHZOz6M9Os5pJ4dD+vRFLxPa/n3T0iEFzpi+0x1UfuDZYbRMw==}
+  /tar@6.1.15:
+    resolution: {integrity: sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==}
     engines: {node: '>=10'}
     dependencies:
       chownr: 2.0.0
       fs-minipass: 2.1.0
-      minipass: 3.3.6
+      minipass: 5.0.0
       minizlib: 2.1.2
       mkdirp: 1.0.4
       yallist: 4.0.0
@@ -15198,7 +15545,7 @@ packages:
     engines: {node: '>=0.8'}
     dependencies:
       psl: 1.9.0
-      punycode: 2.1.1
+      punycode: 2.3.0
     dev: true
 
   /tr46@0.0.3:
@@ -15251,6 +15598,7 @@ packages:
   /ts-jest@28.0.4(@babel/core@7.20.2)(babel-jest@28.1.0)(esbuild@0.15.16)(jest@28.1.0)(typescript@4.7.4):
     resolution: {integrity: sha512-S6uRDDdCJBvnZqyGjB4VCnwbQrbgdL8WPeP4jevVSpYsBaeGRQAIS08o3Svav2Ex+oXwLgJ/m7F24TNq62kA1A==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    hasBin: true
     peerDependencies:
       '@babel/core': '>=7.0.0-beta.0 <8'
       babel-jest: ^28.0.0
@@ -15310,6 +15658,7 @@ packages:
   /tslint@5.14.0(typescript@4.7.4):
     resolution: {integrity: sha512-IUla/ieHVnB8Le7LdQFRGlVJid2T/gaJe5VkjzRVSRR6pA2ODYrnfR1hmxi+5+au9l50jBwpbBL34txgv4NnTQ==}
     engines: {node: '>=4.8.0'}
+    hasBin: true
     peerDependencies:
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev'
     dependencies:
@@ -15344,6 +15693,7 @@ packages:
   /tsup@6.3.0(typescript@4.7.4):
     resolution: {integrity: sha512-IaNQO/o1rFgadLhNonVKNCT2cks+vvnWX3DnL8sB87lBDqRvJXHENr5lSPJlqwplUlDxSwZK8dSg87rgBu6Emw==}
     engines: {node: '>=14'}
+    hasBin: true
     peerDependencies:
       '@swc/core': ^1
       postcss: ^8.4.12
@@ -15749,12 +16099,24 @@ packages:
 
   /update-browserslist-db@1.0.10(browserslist@4.21.4):
     resolution: {integrity: sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==}
+    hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
     dependencies:
       browserslist: 4.21.4
       escalade: 3.1.1
       picocolors: 1.0.0
+
+  /update-browserslist-db@1.0.11(browserslist@4.21.9):
+    resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+    dependencies:
+      browserslist: 4.21.9
+      escalade: 3.1.1
+      picocolors: 1.0.0
+    dev: false
 
   /update-notifier@2.5.0:
     resolution: {integrity: sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==}
@@ -15948,6 +16310,7 @@ packages:
   /vite-plugin-ssr@0.4.54(vite@3.2.4):
     resolution: {integrity: sha512-6OQSIRPqREc/z6NJyVCm0zHp58370/3O585nYgJQSOhEWwkY5JBR50hilucsUoQJU3Z2U3X83w6pFn9SKc7lpA==}
     engines: {node: '>=12.19.0'}
+    hasBin: true
     peerDependencies:
       react-streaming: '>=0.3.5'
       vite: '>=3.0.0'
@@ -15970,6 +16333,7 @@ packages:
   /vite@3.1.8:
     resolution: {integrity: sha512-m7jJe3nufUbuOfotkntGFupinL/fmuTNuQmiVE7cH2IZMuf4UbfbGYMUT3jVWgGYuRVLY9j8NnrRqgw5rr5QTg==}
     engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
     peerDependencies:
       less: '*'
       sass: '*'
@@ -15996,6 +16360,7 @@ packages:
   /vite@3.2.4(@types/node@17.0.39):
     resolution: {integrity: sha512-Z2X6SRAffOUYTa+sLy3NQ7nlHFU100xwanq1WDwqaiFiCe+25zdxP1TfCS5ojPV2oDDcXudHIoPnI1Z/66B7Yw==}
     engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
     peerDependencies:
       '@types/node': '>= 14'
       less: '*'
@@ -16028,6 +16393,7 @@ packages:
   /vite@4.0.0:
     resolution: {integrity: sha512-ynad+4kYs8Jcnn8J7SacS9vAbk7eMy0xWg6E7bAhS1s79TK+D7tVFGXVZ55S7RNLRROU1rxoKlvZ/qjaB41DGA==}
     engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
     peerDependencies:
       '@types/node': '>= 14'
       less: '*'
@@ -16226,6 +16592,7 @@ packages:
   /webpack-cli@4.9.2(webpack-dev-server@4.9.1)(webpack@5.73.0):
     resolution: {integrity: sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==}
     engines: {node: '>=10.13.0'}
+    hasBin: true
     peerDependencies:
       '@webpack-cli/generators': '*'
       '@webpack-cli/migrate': '*'
@@ -16261,6 +16628,7 @@ packages:
   /webpack-cli@5.0.0(webpack@5.75.0):
     resolution: {integrity: sha512-AACDTo20yG+xn6HPW5xjbn2Be4KUzQPebWXsDMHwPPyKh9OnTOJgZN2Nc+g/FZKV3ObRTYsGvibAvc+5jAUrVA==}
     engines: {node: '>=14.15.0'}
+    hasBin: true
     peerDependencies:
       '@webpack-cli/generators': '*'
       webpack: 5.x.x
@@ -16307,6 +16675,7 @@ packages:
   /webpack-dev-server@4.9.1(webpack-cli@4.9.2)(webpack@5.73.0):
     resolution: {integrity: sha512-CTMfu2UMdR/4OOZVHRpdy84pNopOuigVIsRbGX3LVDMWNP8EUgC5mUBMErbwBlHTEX99ejZJpVqrir6EXAEajA==}
     engines: {node: '>= 12.13.0'}
+    hasBin: true
     peerDependencies:
       webpack: ^4.37.0 || ^5.0.0
       webpack-cli: '*'
@@ -16410,6 +16779,7 @@ packages:
   /webpack@5.73.0(esbuild@0.15.16)(webpack-cli@4.9.2):
     resolution: {integrity: sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==}
     engines: {node: '>=10.13.0'}
+    hasBin: true
     peerDependencies:
       webpack-cli: '*'
     peerDependenciesMeta:
@@ -16450,6 +16820,7 @@ packages:
   /webpack@5.75.0(esbuild@0.15.16)(webpack-cli@5.0.0):
     resolution: {integrity: sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==}
     engines: {node: '>=10.13.0'}
+    hasBin: true
     peerDependencies:
       webpack-cli: '*'
     peerDependenciesMeta:
@@ -16558,7 +16929,7 @@ packages:
   /wide-align@1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
     dependencies:
-      string-width: 4.2.3
+      string-width: 1.0.2
     dev: true
     optional: true
 
@@ -16675,6 +17046,10 @@ packages:
 
   /yallist@2.1.2:
     resolution: {integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==}
+
+  /yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+    dev: false
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}


### PR DESCRIPTION
## Motivation

Breaking Change: Performance Optimization for `styled`

When a component is wrapped in `styled`, Linaria needs to determine if that component is already a styled component. To accomplish this, the wrapped component is included in the list of variables for evaluation, along with the interpolated values used in styles. The issue arises when a wrapped component, even if it is not styled, brings along a substantial dependency tree. This situation is particularly evident when using `styled` to style components from third-party UI libraries.

## Summary

To address this problem, Linaria will now examine the import location of the component and check if there is an annotation in the `package.json` file of the package containing the components. This annotation indicates whether the package includes other Linaria components. If there is no such annotation, Linaria will refrain from evaluating the component.

Please note that this Breaking Change solely affects developers of component libraries. In order for users to style components from your library, you must include the `linaria.components` property in the library's `package.json` file. This property should have a mask that covers all imported files with components. Here's an example of how to specify it:

```json
"linaria": {
  "components": "**/*"
}
```

## Test plan

A bunch of new tests we added.