### PR TITLE
fix(vite): css `url()` windows-specific path resolve error (#1240)

### DIFF
--- a/.changeset/nine-rings-learn.md
+++ b/.changeset/nine-rings-learn.md
@@ -1,0 +1,5 @@
+---
+'@linaria/vite': patch
+---
+
+Fixed Windows support (fix for #1240)

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -159,10 +159,12 @@ export default function linaria({
 
       const cssFilename = path.normalize(
         `${id.replace(/\.[jt]sx?$/, '')}_${slug}.css`
-      );
+      ).replace(/\\/g, path.posix.sep);
+
       const cssRelativePath = path
         .relative(config.root, cssFilename)
         .replace(/\\/g, path.posix.sep);
+
       const cssId = `/${cssRelativePath}`;
 
       if (sourceMap && result.cssSourceMapText) {

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -157,9 +157,9 @@ export default function linaria({
 
       const slug = slugify(cssText);
 
-      const cssFilename = path.normalize(
-        `${id.replace(/\.[jt]sx?$/, '')}_${slug}.css`
-      ).replace(/\\/g, path.posix.sep);
+      const cssFilename = path
+        .normalize(`${id.replace(/\.[jt]sx?$/, '')}_${slug}.css`)
+        .replace(/\\/g, path.posix.sep);
 
       const cssRelativePath = path
         .relative(config.root, cssFilename)


### PR DESCRIPTION
## Motivation

Fixes fatal error in the Vite package: `transform` function fails to resolve paths correctly on Windows.

Fixes #1240 

## Summary

- Convert Windows path separator `\` to `/`

## Test plan

Tested on my local Windows machine as working.