### PR TITLE
chore(utils): move some utils and types from babel to utils package

### DIFF
--- a/.changeset/honest-otters-guess.md
+++ b/.changeset/honest-otters-guess.md
@@ -1,0 +1,12 @@
+---
+'@linaria/atomic': patch
+'@linaria/babel-preset': patch
+'@linaria/core': patch
+'@linaria/react': patch
+'@linaria/stylelint': patch
+'@linaria/tags': patch
+'@linaria/testkit': patch
+'@linaria/utils': patch
+---
+
+Nothing has changed. Just moved some utils and types from babel to utils package.

--- a/packages/atomic/src/processors/styled.ts
+++ b/packages/atomic/src/processors/styled.ts
@@ -3,8 +3,8 @@ import type { SourceLocation } from '@babel/types';
 import { debug } from '@linaria/logger';
 import type { IProps } from '@linaria/react/processors/styled';
 import StyledProcessor from '@linaria/react/processors/styled';
-import { hasMeta } from '@linaria/tags';
 import type { Rules, ValueCache } from '@linaria/tags';
+import { hasMeta } from '@linaria/utils';
 
 import atomize from './helpers/atomize';
 

--- a/packages/babel/src/index.ts
+++ b/packages/babel/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * File defines babel prest for Linaria.
+ * File defines babel preset for Linaria.
  * It uses ./extract function that is an entry point for styles extraction.
  * It also bypass babel options defined in Linaria config file with it's defaults (see ./utils/loadOptions).
  */
@@ -14,8 +14,6 @@ import loadLinariaOptions from './transform-stages/helpers/loadLinariaOptions';
 export { slugify } from '@linaria/utils';
 
 export { default as preeval } from './plugins/preeval';
-export * from './utils/collectTemplateDependencies';
-export { default as collectTemplateDependencies } from './utils/collectTemplateDependencies';
 export { default as withLinariaMetadata } from './utils/withLinariaMetadata';
 export { default as Module, DefaultModuleImplementation } from './module';
 export { default as transform } from './transform';

--- a/packages/babel/src/transform-stages/4-extract.ts
+++ b/packages/babel/src/transform-stages/4-extract.ts
@@ -4,9 +4,11 @@ import type { Mapping } from 'source-map';
 import { SourceMapGenerator } from 'source-map';
 import stylis from 'stylis';
 
-import type { BaseProcessor, Replacements } from '@linaria/tags';
+import type { Rules } from '@linaria/tags';
+import type { Replacements } from '@linaria/utils';
+import type { Artifact } from '@linaria/utils/types/types';
 
-import type { Rules, Options, PreprocessorFn } from '../types';
+import type { Options, PreprocessorFn } from '../types';
 
 const STYLIS_DECLARATION = 1;
 const posixSep = path.posix.sep;
@@ -118,7 +120,9 @@ function extractCssFromAst(
  * Extract artifacts (e.g. CSS) from processors
  */
 export default function extractStage(
-  processors: BaseProcessor[],
+  processors: {
+    artifacts: Artifact[];
+  }[],
   originalCode: string,
   options: Options
 ) {

--- a/packages/babel/src/transform-stages/helpers/loadLinariaOptions.ts
+++ b/packages/babel/src/transform-stages/helpers/loadLinariaOptions.ts
@@ -9,7 +9,24 @@ export type PluginOptions = StrictOptions & {
   stage?: Stage;
 };
 
-const explorerSync = cosmiconfigSync('linaria');
+const searchPlaces = [
+  `.linariarc`,
+  `.linariarc.json`,
+  `.linariarc.yaml`,
+  `.linariarc.yml`,
+  `.linariarc.js`,
+  `.linariarc.cjs`,
+  `.config/linariarc`,
+  `.config/linariarc.json`,
+  `.config/linariarc.yaml`,
+  `.config/linariarc.yml`,
+  `.config/linariarc.js`,
+  `.config/linariarc.cjs`,
+  `linaria.config.js`,
+  `linaria.config.cjs`,
+];
+
+const explorerSync = cosmiconfigSync('linaria', { searchPlaces });
 
 const cache = new WeakMap<Partial<PluginOptions>, StrictOptions>();
 const defaultOverrides = {};
@@ -32,17 +49,7 @@ export default function loadLinariaOptions(
   const options = {
     displayName: false,
     evaluate: true,
-    extensions: [
-      '.cjs',
-      '.cts',
-      '.json',
-      '.js',
-      '.jsx',
-      '.mjs',
-      '.mts',
-      '.ts',
-      '.tsx',
-    ],
+    extensions: ['.cjs', '.cts', '.js', '.jsx', '.mjs', '.mts', '.ts', '.tsx'],
     rules: rules ?? [
       {
         action: require.resolve('@linaria/shaker'),

--- a/packages/babel/src/types.ts
+++ b/packages/babel/src/types.ts
@@ -4,8 +4,11 @@ import type { File } from '@babel/types';
 import type { RawSourceMap } from 'source-map';
 
 import type { BaseProcessor } from '@linaria/tags';
+import type { LinariaMetadata, Replacement, Rules } from '@linaria/utils';
 
 import type { PluginOptions } from './transform-stages/helpers/loadLinariaOptions';
+
+export type { Value, ValueCache } from '@linaria/tags';
 
 export type {
   ExpressionValue,
@@ -15,31 +18,11 @@ export type {
   JSONValue,
   LazyValue,
   Serializable,
-  Value,
-  ValueCache,
-} from '@linaria/tags';
+} from '@linaria/utils';
 
-export { ValueType } from '@linaria/tags';
-
-export interface ICSSRule {
-  className: string;
-  displayName: string;
-  cssText: string;
-  start: Location | null | undefined;
-  atom?: boolean;
-}
-
-export type Rules = Record<string, ICSSRule>;
+export { ValueType } from '@linaria/utils';
 
 export type Dependencies = string[];
-
-export type LinariaMetadata = {
-  processors: BaseProcessor[];
-
-  rules: Rules;
-  replacements: Replacement[];
-  dependencies: string[];
-};
 
 export interface IPluginState extends PluginPass {
   processors: BaseProcessor[];
@@ -57,16 +40,6 @@ export interface ITransformFileResult {
 }
 
 export type Stage = 'preeval' | 'collect';
-
-export type Location = {
-  line: number;
-  column: number;
-};
-
-export type Replacement = {
-  original: { start: Location; end: Location };
-  length: number;
-};
 
 export type Result = {
   code: string;

--- a/packages/babel/src/utils/__tests__/collectTemplateDependencies.test.ts
+++ b/packages/babel/src/utils/__tests__/collectTemplateDependencies.test.ts
@@ -4,8 +4,9 @@ import generate from '@babel/generator';
 import dedent from 'dedent';
 import stripAnsi from 'strip-ansi';
 
+import { extractExpression } from '@linaria/utils';
+
 import type { MissedBabelCoreTypes } from '../../types';
-import { extractExpression } from '../collectTemplateDependencies';
 
 const { File } = babel as typeof babel & MissedBabelCoreTypes;
 

--- a/packages/babel/src/utils/getTagProcessor.ts
+++ b/packages/babel/src/utils/getTagProcessor.ts
@@ -9,29 +9,22 @@ import type {
   SourceLocation,
   Identifier,
   MemberExpression,
+  Program,
 } from '@babel/types';
 
 import { BaseProcessor } from '@linaria/tags';
-import type {
-  Param,
-  Params,
-  IFileContext,
-  ExpressionValue,
-  TagSource,
-} from '@linaria/tags';
-import type { IImport, StrictOptions } from '@linaria/utils';
+import type { Param, Params, IFileContext, TagSource } from '@linaria/tags';
+import type { ExpressionValue, IImport, StrictOptions } from '@linaria/utils';
 import {
   collectExportsAndImports,
+  collectTemplateDependencies,
   explicitImport,
+  extractExpression,
   findPackageJSON,
+  getSource,
   isNotNull,
   mutate,
 } from '@linaria/utils';
-
-import collectTemplateDependencies, {
-  extractExpression,
-} from './collectTemplateDependencies';
-import getSource from './getSource';
 
 type BuilderArgs = ConstructorParameters<typeof BaseProcessor> extends [
   Params,
@@ -337,7 +330,7 @@ function getBuilderForIdentifier(
 function getDisplayName(
   path: NodePath<Identifier>,
   idx: number,
-  fileContext: IFileContext
+  filename?: string | null
 ): string {
   let displayName: string | undefined;
 
@@ -372,11 +365,10 @@ function getDisplayName(
   }
 
   if (!displayName) {
-    const filename = fileContext.filename ?? 'unknown';
     // Try to derive the path from the filename
-    displayName = basename(filename);
+    displayName = basename(filename ?? 'unknown');
 
-    if (/^index\.[a-z\d]+$/.test(displayName)) {
+    if (filename && /^index\.[a-z\d]+$/.test(displayName)) {
       // If the file name is 'index', better to get name from parent folder
       displayName = basename(dirname(filename));
     }
@@ -446,7 +438,7 @@ export default function getTagProcessor(
   >
 ): BaseProcessor | null {
   if (!cache.has(path.node)) {
-    const root = path.scope.getProgramParent().path;
+    const root = path.scope.getProgramParent().path as NodePath<Program>;
     const { imports } = collectExportsAndImports(root);
     try {
       const builder = getBuilderForIdentifier(
@@ -461,7 +453,7 @@ export default function getTagProcessor(
         // Also used for display name if it couldn't be determined
         const idx = getNextIndex(fileContext);
 
-        const displayName = getDisplayName(path, idx, fileContext);
+        const displayName = getDisplayName(path, idx, fileContext.filename);
 
         const processor = builder(
           displayName,

--- a/packages/babel/src/utils/withLinariaMetadata.ts
+++ b/packages/babel/src/utils/withLinariaMetadata.ts
@@ -1,4 +1,4 @@
-import type { LinariaMetadata } from '../types';
+import type { LinariaMetadata } from '@linaria/utils';
 
 const withLinariaMetadata = (
   value: unknown

--- a/packages/core/src/css.ts
+++ b/packages/core/src/css.ts
@@ -1,4 +1,4 @@
-import type { StyledMeta } from '@linaria/tags';
+import type { StyledMeta } from '@linaria/utils';
 
 import type { CSSProperties } from './CSSProperties';
 import type { LinariaClassName } from './cx';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -6,4 +6,4 @@ export type {
   Styled,
 } from './styled';
 export type { CSSProperties } from '@linaria/core';
-export type { StyledMeta } from '@linaria/tags';
+export type { StyledMeta } from '@linaria/utils';

--- a/packages/react/src/processors/styled.ts
+++ b/packages/react/src/processors/styled.ts
@@ -20,14 +20,12 @@ import type {
 } from '@linaria/tags';
 import {
   buildSlug,
-  hasMeta,
   TaggedTemplateProcessor,
   validateParams,
-  ValueType,
   toValidCSSIdentifier,
 } from '@linaria/tags';
 import type { IVariableContext } from '@linaria/utils';
-import { findPackageJSON, slugify } from '@linaria/utils';
+import { findPackageJSON, hasMeta, slugify, ValueType } from '@linaria/utils';
 
 const isNotNull = <T>(x: T | null): x is T => x !== null;
 

--- a/packages/react/src/styled.ts
+++ b/packages/react/src/styled.ts
@@ -10,7 +10,7 @@ import React from 'react';
 
 import { cx } from '@linaria/core';
 import type { CSSProperties } from '@linaria/core';
-import type { StyledMeta } from '@linaria/tags';
+import type { StyledMeta } from '@linaria/utils';
 
 export type NoInfer<A> = [A][A extends any ? 0 : never];
 

--- a/packages/stylelint/src/preprocessor.ts
+++ b/packages/stylelint/src/preprocessor.ts
@@ -1,7 +1,7 @@
 import stripAnsi from 'strip-ansi';
 
 import { transform } from '@linaria/babel-preset';
-import type { Replacement } from '@linaria/babel-preset';
+import type { Replacements } from '@linaria/utils';
 import { asyncResolveFallback } from '@linaria/utils';
 
 type Errors = {
@@ -21,7 +21,7 @@ type Errors = {
 };
 
 type Cache = {
-  [key: string]: Replacement[] | null | undefined;
+  [key: string]: Replacements | null | undefined;
 };
 
 type Warning = {

--- a/packages/tags/src/BaseProcessor.ts
+++ b/packages/tags/src/BaseProcessor.ts
@@ -8,16 +8,11 @@ import type {
   MemberExpression,
 } from '@babel/types';
 
-import type {
-  ExpressionValue,
-  IInterpolation,
-  Params,
-  Value,
-  ValueCache,
-  Artifact,
-} from './types';
+import type { Artifact, ExpressionValue } from '@linaria/utils';
+import { hasMeta } from '@linaria/utils';
+
+import type { IInterpolation, Params, Value, ValueCache } from './types';
 import getClassNameAndSlug from './utils/getClassNameAndSlug';
-import hasMeta from './utils/hasMeta';
 import { isCSSable } from './utils/toCSS';
 import type { IFileContext, IOptions } from './utils/types';
 import { validateParams } from './utils/validateParams';
@@ -34,7 +29,7 @@ export type TagSource = {
   source: string;
 };
 
-export default abstract class BaseProcessor {
+export abstract class BaseProcessor {
   public static SKIP = Symbol('skip');
 
   public readonly artifacts: Artifact[] = [];

--- a/packages/tags/src/TaggedTemplateProcessor.ts
+++ b/packages/tags/src/TaggedTemplateProcessor.ts
@@ -1,9 +1,11 @@
 import type { TemplateElement, Expression, SourceLocation } from '@babel/types';
 
+import type { ExpressionValue } from '@linaria/utils';
+import { ValueType } from '@linaria/utils';
+
 import type { TailProcessorParams } from './BaseProcessor';
-import BaseProcessor from './BaseProcessor';
-import type { ExpressionValue, ValueCache, Rules, Params } from './types';
-import { ValueType } from './types';
+import { BaseProcessor } from './BaseProcessor';
+import type { ValueCache, Rules, Params } from './types';
 import templateProcessor from './utils/templateProcessor';
 import { validateParams } from './utils/validateParams';
 

--- a/packages/tags/src/index.ts
+++ b/packages/tags/src/index.ts
@@ -1,10 +1,14 @@
-export * from './BaseProcessor';
+export { BaseProcessor } from './BaseProcessor';
+export type {
+  Expression,
+  TagSource,
+  ProcessorParams,
+  TailProcessorParams,
+} from './BaseProcessor';
 export * from './types';
 export { buildSlug } from './utils/buildSlug';
-export { default as isSerializable } from './utils/isSerializable';
-export * from './utils/types';
-export * from './utils/validateParams';
-export { default as BaseProcessor } from './BaseProcessor';
+export type { IOptions, IFileContext } from './utils/types';
+export { isValidParams, validateParams } from './utils/validateParams';
+export type { MapParams, ParamConstraints } from './utils/validateParams';
 export { default as TaggedTemplateProcessor } from './TaggedTemplateProcessor';
-export { default as hasMeta } from './utils/hasMeta';
 export { default as toValidCSSIdentifier } from './utils/toValidCSSIdentifier';

--- a/packages/tags/src/types.ts
+++ b/packages/tags/src/types.ts
@@ -3,20 +3,9 @@ import type {
   Identifier,
   TemplateElement,
   MemberExpression,
-  BigIntLiteral,
-  BooleanLiteral,
-  DecimalLiteral,
-  NullLiteral,
-  NumericLiteral,
-  StringLiteral,
 } from '@babel/types';
 
-export type StyledMeta = {
-  __linaria: {
-    className: string;
-    extends: StyledMeta;
-  };
-};
+import type { ExpressionValue, Location, StyledMeta } from '@linaria/utils';
 
 export type CSSPropertyValue = string | number;
 
@@ -29,32 +18,9 @@ export type ObjectWithSelectors = {
 
 export type CSSable = ObjectWithSelectors[string];
 
-export type JSONValue =
-  | null
-  | string
-  | number
-  | boolean
-  | JSONObject
-  | JSONArray;
-
-export interface JSONObject {
-  [x: string]: JSONValue;
-}
-
-export type JSONArray = Array<JSONValue>;
-
-export type Serializable = JSONValue;
-
 export type Value = (() => void) | StyledMeta | CSSable;
 
 export type ValueCache = Map<string | number | boolean | null, unknown>;
-
-export type Artifact = [name: string, data: unknown];
-
-export type Location = {
-  column: number;
-  line: number;
-};
 
 export interface ICSSRule {
   atom?: boolean;
@@ -87,54 +53,3 @@ export type TemplateParam = readonly [
 
 export type Param = CalleeParam | CallParam | MemberParam | TemplateParam;
 export type Params = readonly Param[];
-
-export type BuildCodeFrameErrorFn = <TError extends Error>(
-  msg: string,
-  Error?: new (msg: string) => TError
-) => TError;
-
-export enum ValueType {
-  LAZY,
-  FUNCTION,
-  CONST,
-}
-
-export type LazyValue = {
-  buildCodeFrameError: BuildCodeFrameErrorFn;
-  ex: Identifier;
-  importedFrom?: string[];
-  kind: ValueType.LAZY;
-  source: string;
-};
-
-export type FunctionValue = {
-  buildCodeFrameError: BuildCodeFrameErrorFn;
-  ex: Identifier;
-  importedFrom?: string[];
-  kind: ValueType.FUNCTION;
-  source: string;
-};
-
-export type ConstValue = {
-  buildCodeFrameError: BuildCodeFrameErrorFn;
-  ex:
-    | StringLiteral
-    | NumericLiteral
-    | NullLiteral
-    | BooleanLiteral
-    | BigIntLiteral
-    | DecimalLiteral;
-  kind: ValueType.CONST;
-  source: string;
-  value: string | number | boolean | null;
-};
-
-export type ExpressionValue = LazyValue | FunctionValue | ConstValue;
-
-export type Replacements = Array<{
-  length: number;
-  original: {
-    end: Location;
-    start: Location;
-  };
-}>;

--- a/packages/tags/src/utils/hasMeta.ts
+++ b/packages/tags/src/utils/hasMeta.ts
@@ -1,5 +1,0 @@
-import type { StyledMeta } from '../types';
-
-export default function hasMeta(value: unknown): value is StyledMeta {
-  return typeof value === 'object' && value !== null && '__linaria' in value;
-}

--- a/packages/tags/src/utils/stripLines.ts
+++ b/packages/tags/src/utils/stripLines.ts
@@ -1,4 +1,4 @@
-import type { Location } from '../types';
+import type { Location } from '@linaria/utils';
 
 // Stripping away the new lines ensures that we preserve line numbers
 // This is useful in case of tools such as the stylelint pre-processor

--- a/packages/tags/src/utils/templateProcessor.ts
+++ b/packages/tags/src/utils/templateProcessor.ts
@@ -6,17 +6,13 @@
 
 import type { TemplateElement, SourceLocation } from '@babel/types';
 
+import type { ExpressionValue, Replacements } from '@linaria/utils';
+import { hasMeta, ValueType } from '@linaria/utils';
+
 import type TaggedTemplateProcessor from '../TaggedTemplateProcessor';
-import type {
-  ExpressionValue,
-  ValueCache,
-  Rules,
-  Replacements,
-} from '../types';
-import { ValueType } from '../types';
+import type { ValueCache, Rules } from '../types';
 
 import { getVariableName } from './getVariableName';
-import hasMeta from './hasMeta';
 import stripLines from './stripLines';
 import throwIfInvalid from './throwIfInvalid';
 import toCSS, { isCSSable } from './toCSS';

--- a/packages/tags/src/utils/throwIfInvalid.ts
+++ b/packages/tags/src/utils/throwIfInvalid.ts
@@ -1,4 +1,4 @@
-import type { BuildCodeFrameErrorFn } from '../types';
+import type { BuildCodeFrameErrorFn } from '@linaria/utils';
 
 const isLikeError = (value: unknown): value is Error =>
   typeof value === 'object' &&

--- a/packages/tags/src/utils/toCSS.ts
+++ b/packages/tags/src/utils/toCSS.ts
@@ -1,6 +1,7 @@
+import { isBoxedPrimitive } from '@linaria/utils';
+
 import type { CSSPropertyValue, CSSable } from '../types';
 
-import isBoxedPrimitive from './isBoxedPrimitive';
 import { unitless } from './units';
 
 const isCSSPropertyValue = (o: unknown): o is CSSPropertyValue => {

--- a/packages/testkit/src/__utils__/linaria-snapshot-serializer.ts
+++ b/packages/testkit/src/__utils__/linaria-snapshot-serializer.ts
@@ -1,5 +1,5 @@
-import type { LinariaMetadata } from '@linaria/babel-preset';
 import { withLinariaMetadata } from '@linaria/babel-preset';
+import type { LinariaMetadata } from '@linaria/utils';
 
 type Serializer<T> = {
   test: (value: unknown) => value is T;

--- a/packages/testkit/src/utils/extractExpression.test.ts
+++ b/packages/testkit/src/utils/extractExpression.test.ts
@@ -6,7 +6,7 @@ import generator from '@babel/generator';
 import dedent from 'dedent';
 
 import type { MissedBabelCoreTypes } from '@linaria/babel-preset';
-import { extractExpression } from '@linaria/babel-preset';
+import { extractExpression } from '@linaria/utils';
 
 const { File } = babel as typeof babel & MissedBabelCoreTypes;
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -32,9 +32,11 @@
   },
   "dependencies": {
     "@babel/core": "^7.22.9",
+    "@babel/generator": "^7.22.9",
     "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-transform-modules-commonjs": "^7.22.5",
+    "@babel/template": "^7.22.5",
     "@babel/traverse": "^7.22.8",
     "@babel/types": "^7.22.5",
     "@linaria/logger": "workspace:^",
@@ -43,6 +45,8 @@
   },
   "devDependencies": {
     "@types/babel__core": "^7.1.19",
+    "@types/babel__generator": "^7.6.4",
+    "@types/babel__template": "^7.4.1",
     "@types/babel__traverse": "^7.17.1",
     "@types/node": "^17.0.39"
   },

--- a/packages/utils/src/collectExportsAndImports.ts
+++ b/packages/utils/src/collectExportsAndImports.ts
@@ -1123,7 +1123,7 @@ function collectFromCallExpression(
   }
 }
 
-export default function collectExportsAndImports(
+export function collectExportsAndImports(
   path: NodePath,
   force = false
 ): IState {

--- a/packages/utils/src/collectTemplateDependencies.ts
+++ b/packages/utils/src/collectTemplateDependencies.ts
@@ -21,21 +21,21 @@ import type {
 import { cloneNode } from '@babel/types';
 
 import { debug } from '@linaria/logger';
-import type { ConstValue, FunctionValue, LazyValue } from '@linaria/tags';
-import { hasMeta } from '@linaria/tags';
-import type { IImport } from '@linaria/utils';
-import {
-  createId,
-  findIdentifiers,
-  mutate,
-  referenceAll,
-} from '@linaria/utils';
 
-import type { ExpressionValue } from '../types';
-import { ValueType } from '../types';
-
-import getSource from './getSource';
-import valueToLiteral from './vlueToLiteral';
+import type { IImport } from './collectExportsAndImports';
+import { createId } from './createId';
+import findIdentifiers from './findIdentifiers';
+import { getSource } from './getSource';
+import { hasMeta } from './hasMeta';
+import { mutate, referenceAll } from './scopeHelpers';
+import type {
+  ConstValue,
+  ExpressionValue,
+  FunctionValue,
+  LazyValue,
+} from './types';
+import { ValueType } from './types';
+import { valueToLiteral } from './valueToLiteral';
 
 function staticEval(
   ex: NodePath<Expression>,
@@ -274,7 +274,7 @@ export function extractExpression(
  * Collects, hoists, and makes lazy all expressions in the given template
  * If evaluate is true, it will try to evaluate the expressions
  */
-export default function collectTemplateDependencies(
+export function collectTemplateDependencies(
   path: NodePath<TaggedTemplateExpression>,
   evaluate = false
 ): [quasis: TemplateElement[], expressionValues: ExpressionValue[]] {

--- a/packages/utils/src/getSource.ts
+++ b/packages/utils/src/getSource.ts
@@ -1,7 +1,7 @@
 import generator from '@babel/generator';
 import type { NodePath } from '@babel/traverse';
 
-const getSource = (path: NodePath, force = false): string => {
+export const getSource = (path: NodePath, force = false): string => {
   if (path.isIdentifier()) {
     // Fast-lane for identifiers
     return path.node.name;
@@ -17,5 +17,3 @@ const getSource = (path: NodePath, force = false): string => {
 
   return path.node.extra?.parenthesized ? `(${source})` : source;
 };
-
-export default getSource;

--- a/packages/utils/src/hasEvaluatorMetadata.ts
+++ b/packages/utils/src/hasEvaluatorMetadata.ts
@@ -1,0 +1,8 @@
+import type { IEvaluatorMetadata, LinariaMetadata } from './types';
+
+export const hasEvaluatorMetadata = (
+  metadata: object | undefined
+): metadata is {
+  linariaEvaluator: IEvaluatorMetadata;
+  linaria: LinariaMetadata | undefined;
+} => metadata !== undefined && 'linariaEvaluator' in metadata;

--- a/packages/utils/src/hasMeta.ts
+++ b/packages/utils/src/hasMeta.ts
@@ -1,0 +1,5 @@
+import type { StyledMeta } from './types';
+
+export function hasMeta(value: unknown): value is StyledMeta {
+  return typeof value === 'object' && value !== null && '__linaria' in value;
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,22 +1,76 @@
-export type { IVariableContext } from './IVariableContext';
-export { addIdentifierToLinariaPreval } from './addIdentifierToLinariaPreval';
+export {
+  addIdentifierToLinariaPreval,
+  getOrAddLinariaPreval,
+} from './addIdentifierToLinariaPreval';
 export {
   default as asyncResolveFallback,
   syncResolve,
 } from './asyncResolveFallback';
-export { default as collectExportsAndImports } from './collectExportsAndImports';
-export * from './collectExportsAndImports';
+export {
+  collectExportsAndImports,
+  explicitImport,
+  sideEffectImport,
+} from './collectExportsAndImports';
+export {
+  collectTemplateDependencies,
+  extractExpression,
+} from './collectTemplateDependencies';
 export { createId } from './createId';
 export { default as findIdentifiers, nonType } from './findIdentifiers';
 export { findPackageJSON } from './findPackageJSON';
+export { hasEvaluatorMetadata } from './hasEvaluatorMetadata';
 export { default as getFileIdx } from './getFileIdx';
+export { hasMeta } from './hasMeta';
+export { getSource } from './getSource';
+export { isBoxedPrimitive } from './isBoxedPrimitive';
 export { default as isExports } from './isExports';
 export { default as isNotNull } from './isNotNull';
 export { default as isRemoved } from './isRemoved';
 export { default as isRequire } from './isRequire';
+export { isSerializable } from './isSerializable';
 export { default as isTypedNode } from './isTypedNode';
 export { default as isUnnecessaryReactCall } from './isUnnecessaryReactCall';
 export * from './options';
-export * from './scopeHelpers';
+export {
+  applyAction,
+  mutate,
+  removeWithRelated,
+  findActionForNode,
+  dereference,
+  reference,
+  referenceAll,
+} from './scopeHelpers';
 export { default as slugify } from './slugify';
+export { ValueType } from './types';
+export { valueToLiteral } from './valueToLiteral';
 export { default as JSXElementsRemover } from './visitors/JSXElementsRemover';
+
+export type {
+  IExport,
+  IImport,
+  IReexport,
+  ISideEffectImport,
+  IState,
+} from './collectExportsAndImports';
+export type { IVariableContext } from './IVariableContext';
+export type {
+  Artifact,
+  BuildCodeFrameErrorFn,
+  ConstValue,
+  ExpressionValue,
+  FunctionValue,
+  ICSSRule,
+  IEvaluatorMetadata,
+  IMetadata,
+  JSONArray,
+  JSONObject,
+  JSONValue,
+  LazyValue,
+  LinariaMetadata,
+  Location,
+  Replacement,
+  Replacements,
+  Rules,
+  Serializable,
+  StyledMeta,
+} from './types';

--- a/packages/utils/src/isBoxedPrimitive.ts
+++ b/packages/utils/src/isBoxedPrimitive.ts
@@ -2,7 +2,7 @@
 // so we cannot just use `instanceof` here
 
 const constructors = ['Number', 'String'];
-export default function isBoxedPrimitive(o: unknown): o is number | string {
+export function isBoxedPrimitive(o: unknown): o is number | string {
   if (typeof o !== 'object' || o === null) return false;
   return (
     constructors.includes(o.constructor.name) &&

--- a/packages/utils/src/isSerializable.ts
+++ b/packages/utils/src/isSerializable.ts
@@ -1,8 +1,7 @@
-import type { Serializable } from '../types';
+import { isBoxedPrimitive } from './isBoxedPrimitive';
+import type { Serializable } from './types';
 
-import isBoxedPrimitive from './isBoxedPrimitive';
-
-export default function isSerializable(o: unknown): o is Serializable {
+export function isSerializable(o: unknown): o is Serializable {
   if (Array.isArray(o)) {
     return o.every(isSerializable);
   }

--- a/packages/utils/src/isUnnecessaryReactCall.ts
+++ b/packages/utils/src/isUnnecessaryReactCall.ts
@@ -1,8 +1,8 @@
 import type { NodePath } from '@babel/core';
-import type { CallExpression } from '@babel/types';
+import type { CallExpression, Program } from '@babel/types';
 
 import type { IImport, ISideEffectImport } from './collectExportsAndImports';
-import collectExportsAndImports from './collectExportsAndImports';
+import { collectExportsAndImports } from './collectExportsAndImports';
 import { getScope } from './getScope';
 
 function getCallee(p: NodePath<CallExpression>) {
@@ -98,7 +98,9 @@ function isClassicReactRuntime(
 }
 
 export default function isUnnecessaryReactCall(path: NodePath<CallExpression>) {
-  const programPath = path.findParent((p) => p.isProgram());
+  const programPath = path.findParent((p) => p.isProgram()) as
+    | NodePath<Program>
+    | undefined;
   if (!programPath) {
     return false;
   }

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -1,0 +1,118 @@
+import type {
+  BigIntLiteral,
+  BooleanLiteral,
+  DecimalLiteral,
+  Identifier,
+  NullLiteral,
+  NumericLiteral,
+  StringLiteral,
+} from '@babel/types';
+
+export type Artifact = [name: string, data: unknown];
+
+export type JSONValue =
+  | null
+  | string
+  | number
+  | boolean
+  | JSONObject
+  | JSONArray;
+
+export interface JSONObject {
+  [x: string]: JSONValue;
+}
+
+export type JSONArray = Array<JSONValue>;
+
+export type Serializable = JSONValue;
+
+export type BuildCodeFrameErrorFn = <TError extends Error>(
+  msg: string,
+  Error?: new (msg: string) => TError
+) => TError;
+
+export enum ValueType {
+  LAZY,
+  FUNCTION,
+  CONST,
+}
+
+export type LazyValue = {
+  buildCodeFrameError: BuildCodeFrameErrorFn;
+  ex: Identifier;
+  importedFrom?: string[];
+  kind: ValueType.LAZY;
+  source: string;
+};
+
+export type FunctionValue = {
+  buildCodeFrameError: BuildCodeFrameErrorFn;
+  ex: Identifier;
+  importedFrom?: string[];
+  kind: ValueType.FUNCTION;
+  source: string;
+};
+
+export type ConstValue = {
+  buildCodeFrameError: BuildCodeFrameErrorFn;
+  ex:
+    | StringLiteral
+    | NumericLiteral
+    | NullLiteral
+    | BooleanLiteral
+    | BigIntLiteral
+    | DecimalLiteral;
+  kind: ValueType.CONST;
+  source: string;
+  value: string | number | boolean | null;
+};
+
+export type ExpressionValue = LazyValue | FunctionValue | ConstValue;
+
+export type StyledMeta = {
+  __linaria: {
+    className: string;
+    extends: StyledMeta;
+  };
+};
+
+export type Location = {
+  line: number;
+  column: number;
+};
+
+export interface ICSSRule {
+  className: string;
+  displayName: string;
+  cssText: string;
+  start: Location | null | undefined;
+  atom?: boolean;
+}
+
+export type Rules = Record<string, ICSSRule>;
+
+export type LinariaMetadata = {
+  processors: { artifacts: Artifact[] }[];
+
+  rules: Rules;
+  replacements: Replacement[];
+  dependencies: string[];
+};
+
+export type Replacement = {
+  original: { start: Location; end: Location };
+  length: number;
+};
+
+export type Replacements = Array<Replacement>;
+
+export interface IEvaluatorMetadata {
+  deadExports: string[];
+  exports: string[];
+  imports: Map<string, string[]>;
+}
+
+export interface IMetadata {
+  linaria: LinariaMetadata | undefined;
+  linariaEvaluator: IEvaluatorMetadata;
+}

--- a/packages/utils/src/valueToLiteral.ts
+++ b/packages/utils/src/valueToLiteral.ts
@@ -1,14 +1,10 @@
 import type { NodePath } from '@babel/traverse';
 import type { Expression } from '@babel/types';
 
-import { isSerializable } from '@linaria/tags';
+import { getSource } from './getSource';
+import { isSerializable } from './isSerializable';
 
-import getSource from './getSource';
-
-export default function valueToLiteral(
-  value: unknown,
-  ex: NodePath
-): Expression {
+export function valueToLiteral(value: unknown, ex: NodePath): Expression {
   if (value === undefined) {
     return {
       type: 'Identifier',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -945,6 +945,9 @@ importers:
       '@babel/core':
         specifier: ^7.22.9
         version: 7.22.9
+      '@babel/generator':
+        specifier: ^7.22.9
+        version: 7.22.9
       '@babel/plugin-proposal-export-namespace-from':
         specifier: ^7.18.9
         version: 7.18.9(@babel/core@7.22.9)
@@ -954,6 +957,9 @@ importers:
       '@babel/plugin-transform-modules-commonjs':
         specifier: ^7.22.5
         version: 7.22.5(@babel/core@7.22.9)
+      '@babel/template':
+        specifier: ^7.22.5
+        version: 7.22.5
       '@babel/traverse':
         specifier: ^7.22.8
         version: 7.22.8
@@ -973,6 +979,12 @@ importers:
       '@types/babel__core':
         specifier: ^7.1.19
         version: 7.1.19
+      '@types/babel__generator':
+        specifier: ^7.6.4
+        version: 7.6.4
+      '@types/babel__template':
+        specifier: ^7.4.1
+        version: 7.4.1
       '@types/babel__traverse':
         specifier: ^7.17.1
         version: 7.17.1
@@ -1198,7 +1210,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/gen-mapping': 0.1.1
-      '@jridgewell/trace-mapping': 0.3.17
+      '@jridgewell/trace-mapping': 0.3.18
 
   /@ampproject/remapping@2.2.1:
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
@@ -1341,12 +1353,6 @@ packages:
       chokidar: 3.5.3
     dev: true
 
-  /@babel/code-frame@7.18.6:
-    resolution: {integrity: sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/highlight': 7.18.6
-
   /@babel/code-frame@7.22.5:
     resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==}
     engines: {node: '>=6.9.0'}
@@ -1366,15 +1372,15 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@ampproject/remapping': 2.2.0
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.4
+      '@babel/code-frame': 7.22.5
+      '@babel/generator': 7.22.9
       '@babel/helper-compilation-targets': 7.20.0(@babel/core@7.20.2)
       '@babel/helper-module-transforms': 7.20.2
       '@babel/helpers': 7.20.1
-      '@babel/parser': 7.20.3
-      '@babel/template': 7.18.10
+      '@babel/parser': 7.22.7
+      '@babel/template': 7.22.5
       '@babel/traverse': 7.20.1
-      '@babel/types': 7.20.2
+      '@babel/types': 7.22.5
       convert-source-map: 1.9.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
@@ -1423,9 +1429,10 @@ packages:
     resolution: {integrity: sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.2
+      '@babel/types': 7.22.5
       '@jridgewell/gen-mapping': 0.3.3
       jsesc: 2.5.2
+    dev: true
 
   /@babel/generator@7.22.9:
     resolution: {integrity: sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==}
@@ -1440,7 +1447,7 @@ packages:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.2
+      '@babel/types': 7.22.5
 
   /@babel/helper-annotate-as-pure@7.22.5:
     resolution: {integrity: sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==}
@@ -1551,8 +1558,8 @@ packages:
     resolution: {integrity: sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.18.10
-      '@babel/types': 7.20.2
+      '@babel/template': 7.22.5
+      '@babel/types': 7.22.5
     dev: false
 
   /@babel/helper-function-name@7.22.5:
@@ -1572,7 +1579,7 @@ packages:
     resolution: {integrity: sha512-RxifAh2ZoVU67PyKIO4AMi1wTenGfMR/O/ae0CCRqwgBAt5v7xjdtRw7UoSbsreKrQn5t7r89eruK/9JjYHuDg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.2
+      '@babel/types': 7.22.5
     dev: false
 
   /@babel/helper-member-expression-to-functions@7.22.5:
@@ -1608,9 +1615,9 @@ packages:
       '@babel/helper-simple-access': 7.20.2
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/helper-validator-identifier': 7.19.1
-      '@babel/template': 7.18.10
+      '@babel/template': 7.22.5
       '@babel/traverse': 7.20.1
-      '@babel/types': 7.20.2
+      '@babel/types': 7.22.5
     transitivePeerDependencies:
       - supports-color
 
@@ -1631,7 +1638,7 @@ packages:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.2
+      '@babel/types': 7.22.5
     dev: false
 
   /@babel/helper-optimise-call-expression@7.22.5:
@@ -1653,6 +1660,7 @@ packages:
   /@babel/helper-plugin-utils@7.20.2:
     resolution: {integrity: sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==}
     engines: {node: '>=6.9.0'}
+    dev: false
 
   /@babel/helper-plugin-utils@7.22.5:
     resolution: {integrity: sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==}
@@ -1677,7 +1685,7 @@ packages:
       '@babel/helper-member-expression-to-functions': 7.18.9
       '@babel/helper-optimise-call-expression': 7.18.6
       '@babel/traverse': 7.20.1
-      '@babel/types': 7.20.2
+      '@babel/types': 7.22.5
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -1697,7 +1705,7 @@ packages:
     resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.2
+      '@babel/types': 7.22.5
 
   /@babel/helper-simple-access@7.22.5:
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
@@ -1715,7 +1723,7 @@ packages:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.2
+      '@babel/types': 7.22.5
 
   /@babel/helper-split-export-declaration@7.22.6:
     resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
@@ -1755,9 +1763,9 @@ packages:
     resolution: {integrity: sha512-J77mUVaDTUJFZ5BpP6mMn6OIl3rEWymk2ZxDBQJUG3P+PbmyMcF3bYWvz0ma69Af1oobDqT/iAsvzhB58xhQUg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.18.10
+      '@babel/template': 7.22.5
       '@babel/traverse': 7.20.1
-      '@babel/types': 7.20.2
+      '@babel/types': 7.22.5
     transitivePeerDependencies:
       - supports-color
 
@@ -1770,14 +1778,6 @@ packages:
       '@babel/types': 7.22.5
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/highlight@7.18.6:
-    resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.19.1
-      chalk: 2.4.2
-      js-tokens: 4.0.0
 
   /@babel/highlight@7.22.5:
     resolution: {integrity: sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==}
@@ -1798,7 +1798,8 @@ packages:
     resolution: {integrity: sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      '@babel/types': 7.20.2
+      '@babel/types': 7.22.5
+    dev: true
 
   /@babel/parser@7.22.7:
     resolution: {integrity: sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==}
@@ -1959,6 +1960,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.2
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.22.9):
     resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
@@ -1969,6 +1971,16 @@ packages:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.20.2
     dev: false
+
+  /@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.20.2):
+    resolution: {integrity: sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==}
@@ -2514,10 +2526,10 @@ packages:
     dependencies:
       '@babel/core': 7.20.2
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.20.2)
-      '@babel/types': 7.20.2
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.20.2)
+      '@babel/types': 7.22.5
     dev: true
 
   /@babel/plugin-transform-react-jsx@7.19.0(@babel/core@7.22.9):
@@ -2531,7 +2543,7 @@ packages:
       '@babel/helper-module-imports': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.22.9)
-      '@babel/types': 7.20.2
+      '@babel/types': 7.22.5
     dev: true
 
   /@babel/plugin-transform-react-jsx@7.22.5(@babel/core@7.22.9):
@@ -2869,14 +2881,6 @@ packages:
     dependencies:
       regenerator-runtime: 0.13.11
 
-  /@babel/template@7.18.10:
-    resolution: {integrity: sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/parser': 7.20.3
-      '@babel/types': 7.20.2
-
   /@babel/template@7.22.5:
     resolution: {integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==}
     engines: {node: '>=6.9.0'}
@@ -2890,13 +2894,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.22.5
-      '@babel/generator': 7.20.4
+      '@babel/generator': 7.22.9
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-function-name': 7.22.5
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/parser': 7.20.3
-      '@babel/types': 7.20.2
+      '@babel/parser': 7.22.7
+      '@babel/types': 7.22.5
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
@@ -2926,6 +2930,7 @@ packages:
       '@babel/helper-string-parser': 7.22.5
       '@babel/helper-validator-identifier': 7.22.5
       to-fast-properties: 2.0.0
+    dev: true
 
   /@babel/types@7.22.5:
     resolution: {integrity: sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==}
@@ -3803,7 +3808,7 @@ packages:
     dependencies:
       '@babel/core': 7.22.9
       '@jest/types': 28.1.0
-      '@jridgewell/trace-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.18
       babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
       convert-source-map: 1.9.0
@@ -3837,7 +3842,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/set-array': 1.1.2
-      '@jridgewell/sourcemap-codec': 1.4.14
+      '@jridgewell/sourcemap-codec': 1.4.15
 
   /@jridgewell/gen-mapping@0.3.3:
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
@@ -3846,11 +3851,6 @@ packages:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
       '@jridgewell/trace-mapping': 0.3.18
-
-  /@jridgewell/resolve-uri@3.0.7:
-    resolution: {integrity: sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==}
-    engines: {node: '>=6.0.0'}
-    dev: true
 
   /@jridgewell/resolve-uri@3.1.0:
     resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
@@ -3864,11 +3864,7 @@ packages:
     resolution: {integrity: sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==}
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
-      '@jridgewell/trace-mapping': 0.3.17
-    dev: true
-
-  /@jridgewell/sourcemap-codec@1.4.13:
-    resolution: {integrity: sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==}
+      '@jridgewell/trace-mapping': 0.3.18
     dev: true
 
   /@jridgewell/sourcemap-codec@1.4.14:
@@ -3876,19 +3872,6 @@ packages:
 
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-
-  /@jridgewell/trace-mapping@0.3.13:
-    resolution: {integrity: sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==}
-    dependencies:
-      '@jridgewell/resolve-uri': 3.0.7
-      '@jridgewell/sourcemap-codec': 1.4.13
-    dev: true
-
-  /@jridgewell/trace-mapping@0.3.17:
-    resolution: {integrity: sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==}
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.0
-      '@jridgewell/sourcemap-codec': 1.4.14
 
   /@jridgewell/trace-mapping@0.3.18:
     resolution: {integrity: sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==}
@@ -4284,7 +4267,7 @@ packages:
   /@types/babel__template@7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
-      '@babel/parser': 7.18.4
+      '@babel/parser': 7.22.7
       '@babel/types': 7.22.5
     dev: true
 
@@ -5506,7 +5489,7 @@ packages:
       typescript: 4.7.4
       unist-util-visit: 4.1.1
       vfile: 5.3.6
-      vite: 3.2.4
+      vite: 3.2.4(@types/node@17.0.39)
       vitefu: 0.2.1(vite@3.2.4)
       yargs-parser: 21.0.1
       zod: 3.19.1
@@ -5660,7 +5643,7 @@ packages:
       '@babel/core': 7.20.2
       '@babel/helper-module-imports': 7.16.0
       '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.20.2)
-      '@babel/types': 7.20.2
+      '@babel/types': 7.22.5
       html-entities: 2.3.2
     dev: false
 
@@ -5672,7 +5655,7 @@ packages:
       '@babel/core': 7.22.9
       '@babel/helper-module-imports': 7.16.0
       '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.22.9)
-      '@babel/types': 7.20.2
+      '@babel/types': 7.22.5
       html-entities: 2.3.2
     dev: false
 
@@ -11411,7 +11394,7 @@ packages:
   /jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
     optionalDependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
 
   /jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
@@ -15068,9 +15051,9 @@ packages:
     peerDependencies:
       solid-js: ^1.3
     dependencies:
-      '@babel/generator': 7.20.4
+      '@babel/generator': 7.22.9
       '@babel/helper-module-imports': 7.18.6
-      '@babel/types': 7.20.2
+      '@babel/types': 7.22.5
       solid-js: 1.6.2
     dev: false
 
@@ -15779,7 +15762,7 @@ packages:
       uglify-js:
         optional: true
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.18
       esbuild: 0.15.16
       jest-worker: 27.5.1
       schema-utils: 3.1.1
@@ -15804,7 +15787,7 @@ packages:
       uglify-js:
         optional: true
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.17
+      '@jridgewell/trace-mapping': 0.3.18
       esbuild: 0.15.16
       jest-worker: 27.5.1
       schema-utils: 3.1.1
@@ -16799,39 +16782,6 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vite@3.2.4:
-    resolution: {integrity: sha512-Z2X6SRAffOUYTa+sLy3NQ7nlHFU100xwanq1WDwqaiFiCe+25zdxP1TfCS5ojPV2oDDcXudHIoPnI1Z/66B7Yw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      esbuild: 0.15.12
-      postcss: 8.4.19
-      resolve: 1.22.1
-      rollup: 2.79.1
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
-
   /vite@3.2.4(@types/node@17.0.39):
     resolution: {integrity: sha512-Z2X6SRAffOUYTa+sLy3NQ7nlHFU100xwanq1WDwqaiFiCe+25zdxP1TfCS5ojPV2oDDcXudHIoPnI1Z/66B7Yw==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -16917,7 +16867,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 3.2.4
+      vite: 3.2.4(@types/node@17.0.39)
     dev: true
 
   /vitefu@0.2.3(vite@4.0.0):
@@ -17404,7 +17354,7 @@ packages:
   /wide-align@1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
     dependencies:
-      string-width: 1.0.2
+      string-width: 4.2.3
     dev: true
     optional: true
 


### PR DESCRIPTION
## Motivation

I just wanted to extract some toothless changes from #1289

## Summary

Nothing has changed. Just moved some utils and types from babel to utils package.
