### PR TITLE
fix(babel): resolve babel config for every processed file

### DIFF
--- a/.changeset/stale-swans-raise.md
+++ b/.changeset/stale-swans-raise.md
@@ -1,0 +1,8 @@
+---
+'@linaria/babel-preset': patch
+'@linaria/shaker': patch
+'@linaria/testkit': patch
+'@linaria/utils': patch
+---
+
+Fix the issues with processing files that are supposed to be parsed with their respective Babel config.

--- a/packages/babel/src/cache.ts
+++ b/packages/babel/src/cache.ts
@@ -23,7 +23,7 @@ export class TransformCacheCollection {
       }
     > = new Map(),
     public readonly evalCache: Map<string, Module> = new Map(),
-    public readonly originalASTCache: Map<string, File | 'ignored'> = new Map()
+    public readonly originalASTCache: Map<string, File> = new Map()
   ) {}
 
   public invalidateForFile(filename: string) {

--- a/packages/babel/src/evaluators/index.ts
+++ b/packages/babel/src/evaluators/index.ts
@@ -2,19 +2,17 @@
  * This file is an entry point for module evaluation for getting lazy dependencies.
  */
 
+import type { StrictOptions } from '@linaria/utils';
+
 import type { TransformCacheCollection } from '../cache';
 import Module from '../module';
-import loadLinariaOptions from '../transform-stages/helpers/loadLinariaOptions';
-import type { Options } from '../types';
 
 export default function evaluate(
   cache: TransformCacheCollection,
   code: string,
-  options: Pick<Options, 'filename' | 'pluginOptions'>
+  pluginOptions: StrictOptions,
+  filename: string
 ) {
-  const filename = options?.filename ?? 'unknown';
-  const pluginOptions = loadLinariaOptions(options.pluginOptions);
-
   const m = new Module(filename ?? 'unknown', pluginOptions, cache);
 
   m.dependencies = [];

--- a/packages/babel/src/index.ts
+++ b/packages/babel/src/index.ts
@@ -9,7 +9,6 @@ import { debug } from '@linaria/logger';
 
 import transform from './plugins/babel-transform';
 import type { PluginOptions } from './transform-stages/helpers/loadLinariaOptions';
-import loadLinariaOptions from './transform-stages/helpers/loadLinariaOptions';
 
 export { slugify } from '@linaria/utils';
 
@@ -21,14 +20,17 @@ export * from './types';
 export { parseFile } from './transform-stages/helpers/parseFile';
 export { default as loadLinariaOptions } from './transform-stages/helpers/loadLinariaOptions';
 export type { PluginOptions } from './transform-stages/helpers/loadLinariaOptions';
-export { prepareCode } from './transform-stages/1-prepare-for-eval';
+export {
+  createEntrypoint,
+  prepareCode,
+} from './transform-stages/1-prepare-for-eval';
 export { transformUrl } from './transform-stages/4-extract';
 export { default as isNode } from './utils/isNode';
 export { default as getTagProcessor } from './utils/getTagProcessor';
 export { default as getVisitorKeys } from './utils/getVisitorKeys';
 export type { VisitorKeys } from './utils/getVisitorKeys';
 export { default as peek } from './utils/peek';
-export { default as processTemplateExpression } from './utils/processTemplateExpression';
+export { processTemplateExpression } from './utils/processTemplateExpression';
 export { TransformCacheCollection } from './cache';
 
 function isEnabled(caller?: TransformCaller & { evaluate?: true }) {
@@ -41,6 +43,6 @@ export default function linaria(babel: ConfigAPI, options: PluginOptions) {
   }
   debug('options', JSON.stringify(options));
   return {
-    plugins: [[transform, loadLinariaOptions(options)]],
+    plugins: [[transform, options]],
   };
 }

--- a/packages/babel/src/plugins/preeval.ts
+++ b/packages/babel/src/plugins/preeval.ts
@@ -15,7 +15,7 @@ import {
 
 import type { Core } from '../babel';
 import type { IPluginState } from '../types';
-import processTemplateExpression from '../utils/processTemplateExpression';
+import { processTemplateExpression } from '../utils/processTemplateExpression';
 
 export type PreevalOptions = Pick<
   StrictOptions,

--- a/packages/babel/src/transform-stages/2-eval.ts
+++ b/packages/babel/src/transform-stages/2-eval.ts
@@ -1,10 +1,10 @@
 import { createCustomDebug } from '@linaria/logger';
 import type { ValueCache } from '@linaria/tags';
+import type { StrictOptions } from '@linaria/utils';
 import { getFileIdx } from '@linaria/utils';
 
 import type { TransformCacheCollection } from '../cache';
 import evaluate from '../evaluators';
-import type { Options } from '../types';
 import hasLinariaPreval from '../utils/hasLinariaPreval';
 
 const wrap = <T>(fn: () => T): T | Error => {
@@ -21,13 +21,14 @@ const wrap = <T>(fn: () => T): T | Error => {
 export default function evalStage(
   cache: TransformCacheCollection,
   code: string,
-  options: Pick<Options, 'filename' | 'pluginOptions'>
+  pluginOptions: StrictOptions,
+  filename: string
 ): [ValueCache, string[]] | null {
-  const log = createCustomDebug('transform', getFileIdx(options.filename));
+  const log = createCustomDebug('transform', getFileIdx(filename));
 
   log('stage-2', `>> evaluate __linariaPreval`);
 
-  const evaluated = evaluate(cache, code, options);
+  const evaluated = evaluate(cache, code, pluginOptions, filename);
 
   const linariaPreval = hasLinariaPreval(evaluated.value)
     ? evaluated.value.__linariaPreval

--- a/packages/babel/src/transform-stages/3-prepare-for-runtime.ts
+++ b/packages/babel/src/transform-stages/3-prepare-for-runtime.ts
@@ -5,12 +5,11 @@ import type {
 } from '@babel/core';
 import type { File } from '@babel/types';
 
+import type { StrictOptions } from '@linaria/utils';
 import { buildOptions } from '@linaria/utils';
 
 import type { Core } from '../babel';
 import type { Options, ValueCache } from '../types';
-
-import loadLinariaOptions from './helpers/loadLinariaOptions';
 
 /**
  * Parses the specified file, finds tags, applies run-time replacements,
@@ -21,10 +20,10 @@ export default function prepareForRuntime(
   ast: File,
   code: string,
   valueCache: ValueCache,
-  options: Options,
+  pluginOptions: StrictOptions,
+  options: Pick<Options, 'filename' | 'inputSourceMap' | 'root'>,
   babelConfig: TransformOptions
 ): BabelFileResult {
-  const pluginOptions = loadLinariaOptions(options.pluginOptions);
   const transformPlugins: PluginItem[] = [
     [
       require.resolve('../plugins/collector'),

--- a/packages/babel/src/transform-stages/4-extract.ts
+++ b/packages/babel/src/transform-stages/4-extract.ts
@@ -4,9 +4,7 @@ import type { Mapping } from 'source-map';
 import { SourceMapGenerator } from 'source-map';
 import stylis from 'stylis';
 
-import type { Rules } from '@linaria/tags';
-import type { Replacements } from '@linaria/utils';
-import type { Artifact } from '@linaria/utils/types/types';
+import type { Artifact, Replacements, Rules } from '@linaria/utils';
 
 import type { Options, PreprocessorFn } from '../types';
 
@@ -36,7 +34,7 @@ export function transformUrl(
 function extractCssFromAst(
   rules: Rules,
   originalCode: string,
-  options: Options
+  options: Pick<Options, 'preprocessor' | 'filename' | 'outputFilename'>
 ) {
   const mappings: Mapping[] = [];
 
@@ -120,11 +118,9 @@ function extractCssFromAst(
  * Extract artifacts (e.g. CSS) from processors
  */
 export default function extractStage(
-  processors: {
-    artifacts: Artifact[];
-  }[],
+  processors: { artifacts: Artifact[] }[],
   originalCode: string,
-  options: Options
+  options: Pick<Options, 'preprocessor' | 'filename' | 'outputFilename'>
 ) {
   let allRules: Rules = {};
   const allReplacements: Replacements = [];

--- a/packages/babel/src/transform-stages/helpers/loadLinariaOptions.ts
+++ b/packages/babel/src/transform-stages/helpers/loadLinariaOptions.ts
@@ -80,6 +80,7 @@ export default function loadLinariaOptions(
       },
     ],
     babelOptions,
+    highPriorityPlugins: ['module-resolver'],
     ...(result ? result.config : {}),
     ...rest,
     features: {

--- a/packages/babel/src/transform-stages/helpers/parseFile.ts
+++ b/packages/babel/src/transform-stages/helpers/parseFile.ts
@@ -1,13 +1,11 @@
+import type { TransformOptions } from '@babel/core';
 import type { File } from '@babel/types';
 
 import { createCustomDebug } from '@linaria/logger';
 import type { EvalRule } from '@linaria/utils';
-import { buildOptions, getFileIdx } from '@linaria/utils';
+import { getFileIdx } from '@linaria/utils';
 
 import type { Core } from '../../babel';
-import type { Options } from '../../types';
-
-import loadLinariaOptions from './loadLinariaOptions';
 
 export function getMatchedRule(
   rules: EvalRule[],
@@ -36,44 +34,16 @@ export function parseFile(
   babel: Core,
   filename: string,
   originalCode: string,
-  options: Pick<Options, 'root' | 'pluginOptions' | 'inputSourceMap'>
-): [ast: File | 'ignored', code: string] {
+  parseConfig: TransformOptions
+): File {
   const log = createCustomDebug('transform:parse', getFileIdx(filename));
 
-  const pluginOptions = loadLinariaOptions(options.pluginOptions);
-  const { action, babelOptions } = getMatchedRule(
-    pluginOptions.rules,
-    filename,
-    originalCode
-  );
-
-  if (action === 'ignore' || filename.endsWith('.json')) {
-    log(
-      'stage-1',
-      `${filename} has been ignored because of ${
-        action === 'ignore' ? 'rule' : 'extension'
-      }`
-    );
-
-    return ['ignored', originalCode];
-  }
-
-  const parseConfig = buildOptions(pluginOptions?.babelOptions, babelOptions);
-
-  const parseResult = babel.parseSync(originalCode, {
-    ...parseConfig,
-    sourceMaps: true,
-    sourceFileName: filename,
-    inputSourceMap: options.inputSourceMap,
-    root: options.root,
-    ast: true,
-    filename,
-  });
+  const parseResult = babel.parseSync(originalCode, parseConfig);
   if (!parseResult) {
     throw new Error(`Failed to parse ${filename}`);
   }
 
   log('stage-1', `${filename} has been parsed`);
 
-  return [parseResult, originalCode];
+  return parseResult;
 }

--- a/packages/babel/src/utils/processTemplateExpression.ts
+++ b/packages/babel/src/utils/processTemplateExpression.ts
@@ -8,7 +8,7 @@ import getTagProcessor from './getTagProcessor';
 
 const processed = new WeakSet<Identifier>();
 
-const processTemplateExpression = (
+export const processTemplateExpression = (
   p: NodePath<Identifier>,
   fileContext: IFileContext,
   options: Pick<
@@ -28,5 +28,3 @@ const processTemplateExpression = (
 
   emit(tagProcessor);
 };
-
-export default processTemplateExpression;

--- a/packages/shaker/src/index.ts
+++ b/packages/shaker/src/index.ts
@@ -1,66 +1,77 @@
-import type { TransformOptions } from '@babel/core';
+import type { TransformOptions, PluginItem } from '@babel/core';
 
-import { buildOptions, loadBabelOptions } from '@linaria/utils';
 import type { Evaluator } from '@linaria/utils';
-
-import { hasShakerMetadata } from './plugins/shaker-plugin';
+import { hasEvaluatorMetadata } from '@linaria/utils';
 
 export { default as shakerPlugin } from './plugins/shaker-plugin';
 
-const configCache = new Map<string, TransformOptions>();
-const getShakerConfig = (only: string[] | null): TransformOptions => {
-  const sortedOnly = [...(only ?? [])];
-  sortedOnly.sort();
-  const key = sortedOnly.join('\0');
-  if (configCache.has(key)) {
-    return configCache.get(key)!;
+const getKey = (plugin: PluginItem): string | null => {
+  if (typeof plugin === 'string') {
+    return plugin;
   }
 
-  const config = {
-    ast: true,
+  if (Array.isArray(plugin)) {
+    return getKey(plugin[0]);
+  }
+
+  if (typeof plugin === 'object' && plugin !== null && 'key' in plugin) {
+    return (plugin as { key?: string | null }).key ?? null;
+  }
+
+  return null;
+};
+
+const hasKeyInList = (plugin: PluginItem, list: string[]): boolean => {
+  const pluginKey = getKey(plugin);
+  return pluginKey ? list.some((i) => pluginKey.includes(i)) : false;
+};
+
+const shaker: Evaluator = (
+  babelOptions,
+  ast,
+  code,
+  { highPriorityPlugins, ...config },
+  babel
+) => {
+  const preShakePlugins =
+    babelOptions.plugins?.filter((i) => hasKeyInList(i, highPriorityPlugins)) ??
+    [];
+
+  const plugins = [
+    ...preShakePlugins,
+    [require.resolve('./plugins/shaker-plugin'), config],
+    ...(babelOptions.plugins ?? []).filter(
+      (i) => !hasKeyInList(i, highPriorityPlugins)
+    ),
+  ];
+
+  const hasCommonjsPlugin = babelOptions.plugins?.some(
+    (i) => getKey(i) === 'transform-modules-commonjs'
+  );
+
+  if (!hasCommonjsPlugin) {
+    plugins.push(require.resolve('@babel/plugin-transform-modules-commonjs'));
+  }
+
+  const transformOptions: TransformOptions = {
+    ...babelOptions,
     caller: {
       name: 'linaria',
     },
-    targets: {
-      node: 'current',
-      esmodules: false,
-    },
-    plugins: [
-      [
-        require.resolve('./plugins/shaker-plugin'),
-        {
-          onlyExports: sortedOnly,
-        },
-      ],
-      require.resolve('@babel/plugin-transform-modules-commonjs'),
-    ],
+    plugins,
   };
 
-  configCache.set(key, config);
-  return config;
-};
+  const transformed = babel.transformFromAstSync(ast, code, transformOptions);
 
-const shaker: Evaluator = (filename, options, code, only, babel) => {
-  const transformOptions = loadBabelOptions(
-    babel,
-    filename,
-    buildOptions(options?.babelOptions, getShakerConfig(only))
-  );
-
-  if (typeof code === 'string') {
-    throw new Error('shaker does not support string code');
+  if (!transformed || !hasEvaluatorMetadata(transformed.metadata)) {
+    throw new Error(`${babelOptions.filename} has no shaker metadata`);
   }
 
-  const transformed =
-    typeof code === 'string'
-      ? babel.transformSync(code, transformOptions)
-      : babel.transformFromAstSync(...code, transformOptions);
-
-  if (!transformed || !hasShakerMetadata(transformed.metadata)) {
-    throw new Error(`${filename} has no shaker metadata`);
-  }
-
-  return [transformed.code ?? '', transformed.metadata.__linariaShaker.imports];
+  return [
+    transformed.ast!,
+    transformed.code ?? '',
+    transformed.metadata.linariaEvaluator.imports,
+  ];
 };
 
 export default shaker;

--- a/packages/shaker/src/plugins/__tests__/shaker-plugin.test.ts
+++ b/packages/shaker/src/plugins/__tests__/shaker-plugin.test.ts
@@ -4,7 +4,9 @@ import type { PluginItem } from '@babel/core';
 import { transformSync } from '@babel/core';
 import dedent from 'dedent';
 
-import shakerPlugin, { hasShakerMetadata } from '../shaker-plugin';
+import { hasEvaluatorMetadata } from '@linaria/utils';
+
+import shakerPlugin from '../shaker-plugin';
 
 type Extension = 'js' | 'ts' | 'jsx' | 'tsx';
 
@@ -46,14 +48,14 @@ const keep =
     if (
       !transformed ||
       !transformed.code ||
-      !hasShakerMetadata(transformed.metadata)
+      !hasEvaluatorMetadata(transformed.metadata)
     ) {
       throw new Error(`${filename} has no shaker metadata`);
     }
 
     return {
       code: transformed.code,
-      metadata: transformed.metadata.__linariaShaker,
+      metadata: transformed.metadata.linariaEvaluator,
     };
   };
 

--- a/packages/shaker/src/plugins/shaker-plugin.ts
+++ b/packages/shaker/src/plugins/shaker-plugin.ts
@@ -9,7 +9,7 @@ import type {
 } from '@babel/types';
 
 import { createCustomDebug } from '@linaria/logger';
-import type { IExport, IReexport, IState } from '@linaria/utils';
+import type { IExport, IMetadata, IReexport, IState } from '@linaria/utils';
 import {
   applyAction,
   collectExportsAndImports,
@@ -32,22 +32,9 @@ export interface IShakerOptions {
   onlyExports: string[];
 }
 
-export interface IShakerMetadata {
-  imports: Map<string, string[]>;
-}
-
-export interface IMetadata {
-  __linariaShaker: IShakerMetadata;
-}
-
 interface NodeWithName {
   name: string;
 }
-
-export const hasShakerMetadata = (
-  metadata: object | undefined
-): metadata is IMetadata =>
-  metadata !== undefined && '__linariaShaker' in metadata;
 
 function getBindingForExport(exportPath: NodePath): Binding | undefined {
   if (exportPath.isIdentifier()) {
@@ -372,7 +359,7 @@ export default function shakerPlugin(
       log('end', `remaining imports: %O`, imports);
 
       // eslint-disable-next-line no-param-reassign
-      (file.metadata as IMetadata).__linariaShaker = {
+      (file.metadata as IMetadata).linariaEvaluator = {
         imports,
       };
     },

--- a/packages/testkit/src/__snapshots__/prepareCode.test.ts.snap
+++ b/packages/testkit/src/__snapshots__/prepareCode.test.ts.snap
@@ -17,13 +17,13 @@ Object.defineProperty(exports, 'collectExportsAndImports', {
 Object.defineProperty(exports, 'slugify', {
   enumerable: true,
   get: function get() {
-    return _slugify.default;
+    return _slugify[\\"default\\"];
   }
 });
 var _slugify = _interopRequireDefault(require('./slugify'));
 function _interopRequireDefault(obj) {
   return obj && obj.__esModule ? obj : {
-    default: obj
+    \\"default\\": obj
   };
 }"
 `;

--- a/packages/testkit/src/module.test.ts
+++ b/packages/testkit/src/module.test.ts
@@ -22,6 +22,7 @@ const options: StrictOptions = {
   features: {
     dangerousCodeRemover: true,
   },
+  highPriorityPlugins: [],
 };
 
 it('creates module for JS files', () => {

--- a/packages/utils/src/hasEvaluatorMetadata.ts
+++ b/packages/utils/src/hasEvaluatorMetadata.ts
@@ -1,8 +1,6 @@
-import type { IEvaluatorMetadata, LinariaMetadata } from './types';
+import type { IMetadata } from './types';
 
 export const hasEvaluatorMetadata = (
   metadata: object | undefined
-): metadata is {
-  linariaEvaluator: IEvaluatorMetadata;
-  linaria: LinariaMetadata | undefined;
-} => metadata !== undefined && 'linariaEvaluator' in metadata;
+): metadata is IMetadata =>
+  metadata !== undefined && 'linariaEvaluator' in metadata;

--- a/packages/utils/src/options/types.ts
+++ b/packages/utils/src/options/types.ts
@@ -21,13 +21,20 @@ export type ClassNameFn = (
 
 export type VariableNameFn = (context: IVariableContext) => string;
 
+export type EvaluatorConfig = {
+  features: StrictOptions['features'];
+  highPriorityPlugins: string[];
+  onlyExports: string[];
+};
+
 export type Evaluator = (
-  filename: string,
-  options: StrictOptions,
-  code: string | [ast: File, text: string],
-  only: string[] | null,
+  babelOptions: TransformOptions,
+  ast: File,
+  code: string,
+  config: EvaluatorConfig,
   babel: Core
 ) => [
+  ast: File,
   code: string,
   imports: Map<string, string[]> | null,
   exports?: string[] | null
@@ -47,6 +54,7 @@ export type FeatureFlags = {
 
 export type StrictOptions = {
   babelOptions: TransformOptions;
+  highPriorityPlugins: string[];
   classNameSlug?: string | ClassNameFn;
   displayName: boolean;
   evaluate: boolean;

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -107,12 +107,9 @@ export type Replacement = {
 export type Replacements = Array<Replacement>;
 
 export interface IEvaluatorMetadata {
-  deadExports: string[];
-  exports: string[];
   imports: Map<string, string[]>;
 }
 
 export interface IMetadata {
-  linaria: LinariaMetadata | undefined;
   linariaEvaluator: IEvaluatorMetadata;
 }


### PR DESCRIPTION
## Motivation

Sometimes Linaria tried to use the wrong Babel configs for parsing files.

## Summary

`babel.loadOptions` is now used for every processed file, and the loaded config is reused for every transformation.
