### PR TITLE
feat: debug mode for Vite, and Webpack

### DIFF
--- a/.changeset/stale-brooms-kick.md
+++ b/.changeset/stale-brooms-kick.md
@@ -1,0 +1,11 @@
+---
+'@linaria/babel-preset': patch
+'@linaria/cli': patch
+'@linaria/testkit': patch
+'@linaria/utils': patch
+'@linaria/vite': patch
+'@linaria/webpack5-loader': patch
+'linaria-website': patch
+---
+
+Debug mode for CLI, Webpack 5 and Vite. When enabled, prints brief perf report to console and information about processed dependency tree to the specified file.

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ logs
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+**/linaria-debug.json
 
 # Runtime data
 pids

--- a/packages/testkit/src/prepareCode.test.ts
+++ b/packages/testkit/src/prepareCode.test.ts
@@ -9,6 +9,7 @@ import {
   parseFile,
   prepareCode,
 } from '@linaria/babel-preset';
+import { EventEmitter } from '@linaria/utils';
 
 const testCasesDir = join(__dirname, '__fixtures__', 'prepare-code-test-cases');
 
@@ -64,7 +65,8 @@ describe('prepareCode', () => {
         pluginOptions,
         {
           root,
-        }
+        },
+        EventEmitter.dummy
       );
 
       if (entrypoint === 'ignored') {
@@ -78,7 +80,8 @@ describe('prepareCode', () => {
         babel,
         entrypoint,
         ast,
-        pluginOptions
+        pluginOptions,
+        EventEmitter.dummy
       );
 
       expect(transformedCode).toMatchSnapshot('code');

--- a/packages/utils/src/EventEmitter.ts
+++ b/packages/utils/src/EventEmitter.ts
@@ -1,0 +1,22 @@
+export class EventEmitter {
+  static dummy = new EventEmitter(() => {});
+
+  constructor(
+    protected onEvent: (
+      labels: Record<string, unknown>,
+      type: 'start' | 'finish' | 'single',
+      event?: unknown
+    ) => void
+  ) {}
+
+  public pair(labels: Record<string, string>) {
+    this.onEvent(labels, 'start');
+    return () => {
+      this.onEvent(labels, 'finish');
+    };
+  }
+
+  public single(labels: Record<string, unknown>) {
+    this.onEvent(labels, 'single');
+  }
+}

--- a/packages/utils/src/debug/perfMetter.ts
+++ b/packages/utils/src/debug/perfMetter.ts
@@ -1,0 +1,144 @@
+/* eslint-disable no-console */
+import path from 'path';
+
+import { EventEmitter } from '../EventEmitter';
+
+type Timings = Map<string, Map<string, number>>;
+
+export interface IPerfMeterOptions {
+  filename?: string;
+  print?: boolean;
+}
+
+interface IProcessedFile {
+  exports: string[];
+  imports: { from: string; what: string[] }[];
+  passes: number;
+}
+
+export interface IProcessedEvent {
+  type: 'dependency';
+  file: string;
+  only: string[];
+  imports: { from: string; what: string[] }[];
+}
+
+function replacer(key: string, value: unknown) {
+  if (value instanceof Map) {
+    return Array.from(value.entries()).reduce(
+      (obj, [k, v]) => ({
+        ...obj,
+        [k]: v,
+      }),
+      {}
+    );
+  }
+
+  return value;
+}
+
+function printTimings(timings: Timings, startedAt: number, sourceRoot: string) {
+  if (timings.size === 0) {
+    return;
+  }
+
+  console.log(`\nTimings:`);
+  console.log(`  Total: ${(performance.now() - startedAt).toFixed()}ms`);
+
+  Array.from(timings.entries()).forEach(([label, byLabel]) => {
+    console.log(`\n  By ${label}:`);
+
+    const array = Array.from(byLabel.entries());
+    // array.sort(([, a], [, b]) => b - a);
+    array.forEach(([value, time]) => {
+      const name = value.startsWith(sourceRoot)
+        ? path.relative(sourceRoot, value)
+        : value;
+      console.log(`    ${name}: ${time}ms`);
+    });
+  });
+}
+
+export const createPerfMeter = (
+  options: IPerfMeterOptions | boolean = true
+) => {
+  if (!options) {
+    return {
+      emitter: EventEmitter.dummy,
+      onDone: () => {},
+    };
+  }
+
+  const startedAt = performance.now();
+  const timings: Timings = new Map();
+  const addTiming = (label: string, key: string, value: number) => {
+    if (!timings.has(label)) {
+      timings.set(label, new Map());
+    }
+
+    const forLabel = timings.get(label)!;
+    forLabel.set(key, Math.round((forLabel.get(key) || 0) + value));
+  };
+
+  const processedFiles = new Map<string, IProcessedFile>();
+  const processDependencyEvent = ({ file, only, imports }: IProcessedEvent) => {
+    if (!processedFiles.has(file)) {
+      processedFiles.set(file, {
+        exports: [],
+        imports: [],
+        passes: 0,
+      });
+    }
+
+    const processed = processedFiles.get(file)!;
+    processed.passes += 1;
+    processed.exports = only;
+    processed.imports = imports;
+  };
+
+  const processSingleEvent = (
+    meta: Record<string, unknown> | IProcessedEvent
+  ) => {
+    if (meta.type === 'dependency') {
+      processDependencyEvent(meta as IProcessedEvent);
+    }
+  };
+
+  const startTimes = new Map<string, number>();
+  const emitter = new EventEmitter((meta, type) => {
+    if (type === 'single') {
+      processSingleEvent(meta);
+      return;
+    }
+
+    if (type === 'start') {
+      Object.entries(meta).forEach(([label, value]) => {
+        startTimes.set(`${label}\0${value}`, performance.now());
+      });
+    } else {
+      Object.entries(meta).forEach(([label, value]) => {
+        const startTime = startTimes.get(`${label}\0${value}`);
+        if (startTime) {
+          addTiming(label, String(value), performance.now() - startTime);
+        }
+      });
+    }
+  });
+
+  return {
+    emitter,
+    onDone: (sourceRoot: string) => {
+      if (options === true || options.print) {
+        printTimings(timings, startedAt, sourceRoot);
+      }
+
+      if (options !== true && options.filename) {
+        const fs = require('fs');
+        fs.writeFileSync(
+          options.filename,
+          JSON.stringify({ processedFiles, timings }, replacer, 2)
+        );
+      }
+    },
+  };
+};

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -16,6 +16,8 @@ export {
   extractExpression,
 } from './collectTemplateDependencies';
 export { createId } from './createId';
+export { createPerfMeter } from './debug/perfMetter';
+export { EventEmitter } from './EventEmitter';
 export { default as findIdentifiers, nonType } from './findIdentifiers';
 export { findPackageJSON } from './findPackageJSON';
 export { hasEvaluatorMetadata } from './hasEvaluatorMetadata';
@@ -53,6 +55,7 @@ export type {
   ISideEffectImport,
   IState,
 } from './collectExportsAndImports';
+export type { IPerfMeterOptions } from './debug/perfMetter';
 export type { IVariableContext } from './IVariableContext';
 export type {
   Artifact,

--- a/packages/webpack5-loader/package.json
+++ b/packages/webpack5-loader/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@linaria/babel-preset": "workspace:^",
     "@linaria/logger": "workspace:^",
+    "@linaria/utils": "workspace:^",
     "enhanced-resolve": "^5.3.1",
     "mkdirp": "^0.5.1"
   },

--- a/packages/webpack5-loader/src/LinariaDebugPlugin.ts
+++ b/packages/webpack5-loader/src/LinariaDebugPlugin.ts
@@ -1,0 +1,24 @@
+import type { Compiler } from 'webpack';
+
+import type { EventEmitter, IPerfMeterOptions } from '@linaria/utils';
+import { createPerfMeter } from '@linaria/utils';
+
+export const sharedState: {
+  emitter?: EventEmitter;
+} = {};
+
+export class LinariaDebugPlugin {
+  private readonly onDone: (root: string) => void;
+
+  constructor(options?: IPerfMeterOptions) {
+    const { emitter, onDone } = createPerfMeter(options ?? true);
+    sharedState.emitter = emitter;
+    this.onDone = onDone;
+  }
+
+  apply(compiler: Compiler) {
+    compiler.hooks.shutdown.tap('LinariaDebug', () => {
+      this.onDone(process.cwd());
+    });
+  }
+}

--- a/packages/webpack5-loader/src/index.ts
+++ b/packages/webpack5-loader/src/index.ts
@@ -13,8 +13,11 @@ import type { Result, Preprocessor } from '@linaria/babel-preset';
 import { transform, TransformCacheCollection } from '@linaria/babel-preset';
 import { debug } from '@linaria/logger';
 
+import { sharedState } from './LinariaDebugPlugin';
 import type { ICache } from './cache';
 import { getCacheInstance } from './cache';
+
+export { LinariaDebugPlugin } from './LinariaDebugPlugin';
 
 const outputCssLoader = require.resolve('./outputCssLoader');
 
@@ -93,7 +96,8 @@ const webpack5Loader: Loader = function webpack5LoaderPlugin(
     },
     asyncResolve,
     emptyConfig,
-    cache
+    cache,
+    sharedState.emitter
   ).then(
     async (result: Result) => {
       if (result.cssText) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,6 +260,8 @@ importers:
         specifier: ^0.4.54
         version: 0.4.54(vite@3.2.4)
 
+  examples/vpssr-linaria-solid/dist/server: {}
+
   examples/webpack5:
     dependencies:
       linaria-website:
@@ -1072,6 +1074,9 @@ importers:
       '@linaria/logger':
         specifier: workspace:^
         version: link:../logger
+      '@linaria/utils':
+        specifier: workspace:^
+        version: link:../utils
       enhanced-resolve:
         specifier: ^5.3.1
         version: 5.9.3

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -1,6 +1,7 @@
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { join } = require('path'); // eslint-disable-line import/no-extraneous-dependencies
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const { LinariaDebugPlugin } = require('@linaria/webpack5-loader');
 
 const dev = process.env.NODE_ENV !== 'production';
 
@@ -18,6 +19,10 @@ module.exports = {
     emitOnErrors: false,
   },
   plugins: [
+    new LinariaDebugPlugin({
+      filename: 'linaria-debug.json',
+      print: true,
+    }),
     new MiniCssExtractPlugin({ filename: 'styles.css' }),
     new HtmlWebpackPlugin({
       title: 'Linaria – zero-runtime CSS in JS library',


### PR DESCRIPTION
## Motivation

Improve debugging experience.

## Summary

For the Vite plugin, a new option was added:
```
…
debug: {
  filename: "linaria-debug.json",
  print: true,
},
…
```

For Webpack, a new plugin was added:
```
const { LinariaDebugPlugin } = require('@linaria/webpack5-loader');
…
  plugins: [
    new LinariaDebugPlugin({
      filename: 'linaria-debug.json',
      print: true,
    }),
   …
  ]
…
```