### PR TITLE
fix(babel): use path.data instead of scope.data (fixes #1300)

### DIFF
--- a/.changeset/slimy-cougars-hammer.md
+++ b/.changeset/slimy-cougars-hammer.md
@@ -1,0 +1,6 @@
+---
+'@linaria/babel-preset': patch
+'@linaria/utils': patch
+---
+
+Fix for "The expression evaluated to 'undefined'" in Webpack (fixes #1300 and #1287)

--- a/packages/babel/src/plugins/preeval.ts
+++ b/packages/babel/src/plugins/preeval.ts
@@ -98,7 +98,7 @@ export default function preeval(
         dependencies: [],
       };
 
-      const linariaPreval = file.path.scope.getData('__linariaPreval');
+      const linariaPreval = file.path.getData('__linariaPreval');
       if (!linariaPreval) {
         // Event if there is no dependencies, we still need to add __linariaPreval
         const linariaExport = t.expressionStatement(

--- a/packages/utils/src/addIdentifierToLinariaPreval.ts
+++ b/packages/utils/src/addIdentifierToLinariaPreval.ts
@@ -15,12 +15,12 @@ export function getOrAddLinariaPreval(
   scope: Scope
 ): NodePath<ObjectExpression> {
   const rootScope = scope.getProgramParent();
-  let object = rootScope.getData('__linariaPreval');
+  const programPath = rootScope.path as NodePath<Program>;
+
+  let object = programPath.getData('__linariaPreval');
   if (object) {
     return object;
   }
-
-  const programPath = rootScope.path as NodePath<Program>;
 
   if (programPath.node.sourceType === 'script') {
     // CJS exports.__linariaPreval = {};
@@ -71,7 +71,7 @@ export function getOrAddLinariaPreval(
     ) as NodePath<ObjectExpression>;
   }
 
-  rootScope.setData('__linariaPreval', object);
+  programPath.setData('__linariaPreval', object);
   return object;
 }
 


### PR DESCRIPTION
## Motivation

See #1300 and #1287

## Summary

Something destroys `data` inside the root scope, so preeval can't find saved `__linariaPreval` and recreates it with an empty list of expressions.

Another interesting undocumented feature of Babel.
