### PR TITLE
fix(babel): improved cache (fixes #1304 and #1287)

### DIFF
--- a/.changeset/poor-chefs-share.md
+++ b/.changeset/poor-chefs-share.md
@@ -1,0 +1,7 @@
+---
+'@linaria/babel-preset': patch
+'@linaria/logger': patch
+'@linaria/testkit': patch
+---
+
+The improved cache that fixes race conditions which lead to "The expression evaluated to 'undefined'" (fixes #1304 and #1287)

--- a/packages/babel/src/cache.ts
+++ b/packages/babel/src/cache.ts
@@ -2,35 +2,90 @@ import { createHash } from 'crypto';
 
 import type { File } from '@babel/types';
 
-import type Module from './module';
+import { linariaLogger } from '@linaria/logger';
+
+import type { IModule } from './module';
 import type { ITransformFileResult } from './types';
 
 function hashContent(content: string) {
   return createHash('sha256').update(content).digest('hex');
 }
 
+interface ICaches {
+  resolve: Map<string, string>;
+  resolveTask: Map<
+    string,
+    Promise<{
+      importedFile: string;
+      importsOnly: string[];
+      resolved: string | null;
+    }>
+  >;
+  code: Map<
+    string,
+    {
+      imports: Map<string, string[]> | null;
+      only: string[];
+      result: ITransformFileResult;
+    }
+  >;
+  eval: Map<string, IModule>;
+  originalAST: Map<string, File>;
+}
+
+type MapValue<T> = T extends Map<string, infer V> ? V : never;
+
+const cacheLogger = linariaLogger.extend('cache');
+
+const cacheNames = [
+  'resolve',
+  'resolveTask',
+  'code',
+  'eval',
+  'originalAST',
+] as const;
+type CacheNames = typeof cacheNames[number];
+
+const loggers = cacheNames.reduce(
+  (acc, key) => ({
+    ...acc,
+    [key]: cacheLogger.extend(key),
+  }),
+  {} as Record<CacheNames, typeof linariaLogger>
+);
+
 export class TransformCacheCollection {
   private contentHashes = new Map<string, string>();
 
-  constructor(
-    public readonly resolveCache: Map<string, string> = new Map(),
-    public readonly codeCache: Map<
-      string,
-      {
-        imports: Map<string, string[]> | null;
-        only: string[];
-        result: ITransformFileResult;
-      }
-    > = new Map(),
-    public readonly evalCache: Map<string, Module> = new Map(),
-    public readonly originalASTCache: Map<string, File> = new Map()
-  ) {}
+  protected readonly resolve: Map<string, string>;
+
+  protected readonly resolveTask: Map<string, Promise<string>>;
+
+  protected readonly code: Map<
+    string,
+    {
+      imports: Map<string, string[]> | null;
+      only: string[];
+      result: ITransformFileResult;
+    }
+  >;
+
+  protected readonly eval: Map<string, IModule>;
+
+  protected readonly originalAST: Map<string, File>;
+
+  constructor(caches: Partial<ICaches> = {}) {
+    this.resolve = caches.resolve || new Map();
+    this.resolveTask = caches.resolveTask || new Map();
+    this.code = caches.code || new Map();
+    this.eval = caches.eval || new Map();
+    this.originalAST = caches.originalAST || new Map();
+  }
 
   public invalidateForFile(filename: string) {
-    this.resolveCache.delete(filename);
-    this.codeCache.delete(filename);
-    this.evalCache.delete(filename);
-    this.originalASTCache.delete(filename);
+    cacheNames.forEach((cacheName) => {
+      this.invalidate(cacheName, filename);
+    });
   }
 
   public invalidateIfChanged(filename: string, content: string) {
@@ -38,8 +93,58 @@ export class TransformCacheCollection {
     const newHash = hashContent(content);
 
     if (hash !== newHash) {
+      cacheLogger('content has changed, invalidate all for %s', filename);
       this.contentHashes.set(filename, newHash);
       this.invalidateForFile(filename);
     }
+  }
+
+  public add<
+    TCache extends CacheNames,
+    TValue extends MapValue<ICaches[TCache]>
+  >(cacheName: TCache, key: string, value: TValue): void {
+    const cache = this[cacheName] as Map<string, TValue>;
+    loggers[cacheName]('add %s %f', key, () => {
+      if (!cache.has(key)) {
+        return 'added';
+      }
+
+      return cache.get(key) === value ? 'unchanged' : 'updated';
+    });
+
+    cache.set(key, value);
+  }
+
+  public get<
+    TCache extends CacheNames,
+    TValue extends MapValue<ICaches[TCache]>
+  >(cacheName: TCache, key: string): TValue | undefined {
+    const cache = this[cacheName] as Map<string, TValue>;
+
+    const res = cache.get(key);
+    loggers[cacheName]('get', key, res === undefined ? 'miss' : 'hit');
+    return res;
+  }
+
+  public has(cacheName: CacheNames, key: string): boolean {
+    const cache = this[cacheName] as Map<string, unknown>;
+
+    const res = cache.has(key);
+    loggers[cacheName]('has', key, res);
+    return res;
+  }
+
+  public invalidate(cacheName: CacheNames, key: string): void {
+    loggers[cacheName]('invalidate', key);
+    const cache = this[cacheName] as Map<string, unknown>;
+
+    cache.delete(key);
+  }
+
+  public clear(cacheName: CacheNames): void {
+    loggers[cacheName]('clear');
+    const cache = this[cacheName] as Map<string, unknown>;
+
+    cache.clear();
   }
 }

--- a/packages/babel/src/evaluators/index.ts
+++ b/packages/babel/src/evaluators/index.ts
@@ -13,7 +13,12 @@ export default function evaluate(
   pluginOptions: StrictOptions,
   filename: string
 ) {
-  const m = new Module(filename ?? 'unknown', pluginOptions, cache);
+  const m = new Module(
+    filename ?? 'unknown',
+    '__linariaPreval',
+    pluginOptions,
+    cache
+  );
 
   m.dependencies = [];
   m.evaluate(code);

--- a/packages/babel/src/index.ts
+++ b/packages/babel/src/index.ts
@@ -15,6 +15,7 @@ export { slugify } from '@linaria/utils';
 export { default as preeval } from './plugins/preeval';
 export { default as withLinariaMetadata } from './utils/withLinariaMetadata';
 export { default as Module, DefaultModuleImplementation } from './module';
+export type { IModule } from './module';
 export { default as transform } from './transform';
 export * from './types';
 export { parseFile } from './transform-stages/helpers/parseFile';

--- a/packages/babel/src/transform-stages/helpers/ModuleQueue.ts
+++ b/packages/babel/src/transform-stages/helpers/ModuleQueue.ts
@@ -2,7 +2,7 @@ import { relative, sep } from 'path';
 
 import type { TransformOptions } from '@babel/core';
 
-import type { CustomDebug } from '@linaria/logger';
+import type { CustomDebug, Debugger } from '@linaria/logger';
 import { createCustomDebug } from '@linaria/logger';
 import type { Evaluator } from '@linaria/utils';
 import { getFileIdx } from '@linaria/utils';
@@ -13,6 +13,7 @@ export interface IEntrypoint {
   name: string;
   only: string[];
   parseConfig: TransformOptions;
+  log: Debugger;
 }
 
 type Node = [entrypoint: IEntrypoint, stack: string[], refCount?: number];

--- a/packages/babel/src/transform-stages/helpers/loadLinariaOptions.ts
+++ b/packages/babel/src/transform-stages/helpers/loadLinariaOptions.ts
@@ -74,7 +74,7 @@ export default function loadLinariaOptions(
           }
 
           // If a file contains `export` or `import` keywords, we assume it's an ES-module
-          return /\b(?:export|import)\b/.test(code);
+          return /^(?:export|import)\b/.test(code);
         },
         action: require.resolve('@linaria/shaker'),
       },

--- a/packages/babel/src/transform.ts
+++ b/packages/babel/src/transform.ts
@@ -37,7 +37,7 @@ function syncStages(
   eventEmitter = EventEmitter.dummy
 ) {
   const { filename } = options;
-  const ast = cache.originalASTCache.get(filename) ?? 'ignored';
+  const ast = cache.get('originalAST', filename) ?? 'ignored';
 
   // File is ignored or does not contain any tags. Return original code.
   if (
@@ -177,10 +177,6 @@ export default async function transform(
   eventEmitter = EventEmitter.dummy
 ): Promise<Result> {
   const { filename } = options;
-
-  // Cache may contain a code that was loaded from disk, but transform
-  // is called with a code that already processed by another loaders
-  cache.invalidateIfChanged(filename, originalCode);
 
   // *** 1st stage ***
 

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -7,7 +7,9 @@ type LogLevel = 'error' | 'warn' | 'info' | 'debug';
 const levels = ['error', 'warn', 'info', 'debug'];
 const currentLevel = levels.indexOf(process.env.LINARIA_LOG || 'warn');
 
-const linariaLogger = genericDebug('linaria');
+export type { Debugger };
+
+export const linariaLogger = genericDebug('linaria');
 
 const loggers = new Map<string, Debugger>();
 

--- a/packages/testkit/src/__snapshots__/babel.test.ts.snap
+++ b/packages/testkit/src/__snapshots__/babel.test.ts.snap
@@ -16,6 +16,57 @@ Dependencies: ./__fixtures__/assignToExport
 
 `;
 
+exports[`strategy shaker cache should cache evaluation 1`] = `
+"import { foo2 } from \\"./__fixtures__/foo\\";
+export const text = \\"text_t13jq05\\";"
+`;
+
+exports[`strategy shaker cache should cache evaluation 2`] = `
+
+CSS:
+
+.text_t13jq05 {font-size: foo1}
+
+Dependencies: ./__fixtures__/foo
+
+`;
+
+exports[`strategy shaker cache should ignore uncompleted cached value 1`] = `"export const text = \\"text_t13jq05\\";"`;
+
+exports[`strategy shaker cache should ignore uncompleted cached value 2`] = `
+
+CSS:
+
+.text_t13jq05 {font-size: foo1foo2}
+
+Dependencies: ./__fixtures__/foo
+
+`;
+
+exports[`strategy shaker cache should use cached value 1`] = `"export const text = \\"text_t13jq05\\";"`;
+
+exports[`strategy shaker cache should use cached value 2`] = `
+
+CSS:
+
+.text_t13jq05 {font-size: cached-foo1}
+
+Dependencies: ./__fixtures__/foo
+
+`;
+
+exports[`strategy shaker cache should use cached value even if only part is required 1`] = `"export const text = \\"text_t13jq05\\";"`;
+
+exports[`strategy shaker cache should use cached value even if only part is required 2`] = `
+
+CSS:
+
+.text_t13jq05 {font-size: cached-foo1}
+
+Dependencies: ./__fixtures__/foo
+
+`;
+
 exports[`strategy shaker compiles atomic css 1`] = `
 "/* @flow */
 

--- a/packages/testkit/src/prepareCode.test.ts
+++ b/packages/testkit/src/prepareCode.test.ts
@@ -9,6 +9,7 @@ import {
   parseFile,
   prepareCode,
 } from '@linaria/babel-preset';
+import { linariaLogger } from '@linaria/logger';
 import { EventEmitter } from '@linaria/utils';
 
 const testCasesDir = join(__dirname, '__fixtures__', 'prepare-code-test-cases');
@@ -59,6 +60,7 @@ describe('prepareCode', () => {
       const sourceCode = restLines.join('\n');
       const entrypoint = createEntrypoint(
         babel,
+        linariaLogger,
         inputFilePath,
         only,
         sourceCode,


### PR DESCRIPTION
## Motivation

In some cases, a race condition happens, leading to "The expression evaluated to 'undefined'" error.

## Summary

This PR introduces the new cache layer for tasks of imports resolver. Old cache layers were refactored.

## Test plan

A couple of new tests were added.
