### PR TITLE
fix(babel): ignore babelrc for preeval and shaker transforms

### DIFF
--- a/.changeset/empty-lemons-admire.md
+++ b/.changeset/empty-lemons-admire.md
@@ -1,0 +1,8 @@
+---
+'@linaria/babel-preset': minor
+'@linaria/shaker': minor
+'@linaria/testkit': minor
+'@linaria/utils': minor
+---
+
+babelrc should not be used for preeval transformations (fixes #1308)

--- a/packages/babel/src/module.ts
+++ b/packages/babel/src/module.ts
@@ -383,7 +383,7 @@ class Module {
 
       // Resolve module id (and filename) relatively to parent module
       const resolved = this.resolve(id);
-      const [filename, onlyAsString] = resolved.split('\0');
+      const [filename, onlyAsString = '*'] = resolved.split('\0');
       if (filename === id && !path.isAbsolute(id)) {
         // The module is a builtin node modules, but not in the allowed list
         throw new Error(

--- a/packages/babel/src/transform-stages/helpers/ModuleQueue.ts
+++ b/packages/babel/src/transform-stages/helpers/ModuleQueue.ts
@@ -4,16 +4,18 @@ import type { TransformOptions } from '@babel/core';
 
 import type { CustomDebug, Debugger } from '@linaria/logger';
 import { createCustomDebug } from '@linaria/logger';
-import type { Evaluator } from '@linaria/utils';
+import type { Evaluator, StrictOptions } from '@linaria/utils';
 import { getFileIdx } from '@linaria/utils';
 
 export interface IEntrypoint {
   code: string;
+  evalConfig: TransformOptions;
   evaluator: Evaluator;
+  log: Debugger;
   name: string;
   only: string[];
   parseConfig: TransformOptions;
-  log: Debugger;
+  pluginOptions: StrictOptions;
 }
 
 type Node = [entrypoint: IEntrypoint, stack: string[], refCount?: number];

--- a/packages/shaker/src/index.ts
+++ b/packages/shaker/src/index.ts
@@ -1,60 +1,57 @@
 import type { TransformOptions, PluginItem } from '@babel/core';
 
 import type { Evaluator } from '@linaria/utils';
-import { hasEvaluatorMetadata } from '@linaria/utils';
+import { getPluginKey, hasEvaluatorMetadata } from '@linaria/utils';
 
 export { default as shakerPlugin } from './plugins/shaker-plugin';
 
-const getKey = (plugin: PluginItem): string | null => {
-  if (typeof plugin === 'string') {
-    return plugin;
-  }
-
-  if (Array.isArray(plugin)) {
-    return getKey(plugin[0]);
-  }
-
-  if (typeof plugin === 'object' && plugin !== null && 'key' in plugin) {
-    return (plugin as { key?: string | null }).key ?? null;
-  }
-
-  return null;
-};
-
 const hasKeyInList = (plugin: PluginItem, list: string[]): boolean => {
-  const pluginKey = getKey(plugin);
+  const pluginKey = getPluginKey(plugin);
   return pluginKey ? list.some((i) => pluginKey.includes(i)) : false;
 };
 
 const shaker: Evaluator = (
-  babelOptions,
+  evalConfig,
   ast,
   code,
   { highPriorityPlugins, ...config },
   babel
 ) => {
   const preShakePlugins =
-    babelOptions.plugins?.filter((i) => hasKeyInList(i, highPriorityPlugins)) ??
+    evalConfig.plugins?.filter((i) => hasKeyInList(i, highPriorityPlugins)) ??
     [];
 
   const plugins = [
     ...preShakePlugins,
     [require.resolve('./plugins/shaker-plugin'), config],
-    ...(babelOptions.plugins ?? []).filter(
+    ...(evalConfig.plugins ?? []).filter(
       (i) => !hasKeyInList(i, highPriorityPlugins)
     ),
   ];
 
-  const hasCommonjsPlugin = babelOptions.plugins?.some(
-    (i) => getKey(i) === 'transform-modules-commonjs'
+  const hasCommonjsPlugin = evalConfig.plugins?.some(
+    (i) => getPluginKey(i) === 'transform-modules-commonjs'
   );
 
   if (!hasCommonjsPlugin) {
     plugins.push(require.resolve('@babel/plugin-transform-modules-commonjs'));
   }
 
+  if (
+    evalConfig.filename?.endsWith('.ts') ||
+    evalConfig.filename?.endsWith('.tsx')
+  ) {
+    const hasTypescriptPlugin = evalConfig.plugins?.some(
+      (i) => getPluginKey(i) === '@babel/plugin-transform-typescript'
+    );
+
+    if (!hasTypescriptPlugin) {
+      plugins.push(require.resolve('@babel/plugin-transform-typescript'));
+    }
+  }
+
   const transformOptions: TransformOptions = {
-    ...babelOptions,
+    ...evalConfig,
     caller: {
       name: 'linaria',
     },
@@ -64,7 +61,7 @@ const shaker: Evaluator = (
   const transformed = babel.transformFromAstSync(ast, code, transformOptions);
 
   if (!transformed || !hasEvaluatorMetadata(transformed.metadata)) {
-    throw new Error(`${babelOptions.filename} has no shaker metadata`);
+    throw new Error(`${evalConfig.filename} has no shaker metadata`);
   }
 
   return [

--- a/packages/testkit/src/babel.test.ts
+++ b/packages/testkit/src/babel.test.ts
@@ -2722,11 +2722,19 @@ describe('strategy shaker', () => {
   });
 
   it('respects module-resolver plugin', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
     const { code, metadata } = await transformFile(
       resolve(__dirname, './__fixtures__/with-babelrc/index.js'),
       [evaluator]
     );
 
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'This works for now but will be an error in the future'
+      )
+    );
+    warn.mockRestore();
     expect(code).toMatchSnapshot();
     expect(metadata).toMatchSnapshot();
   });

--- a/packages/testkit/src/prepareCode.test.ts
+++ b/packages/testkit/src/prepareCode.test.ts
@@ -82,7 +82,6 @@ describe('prepareCode', () => {
         babel,
         entrypoint,
         ast,
-        pluginOptions,
         EventEmitter.dummy
       );
 

--- a/packages/utils/src/getPluginKey.ts
+++ b/packages/utils/src/getPluginKey.ts
@@ -1,0 +1,17 @@
+import type { PluginItem } from '@babel/core';
+
+export const getPluginKey = (plugin: PluginItem): string | null => {
+  if (typeof plugin === 'string') {
+    return plugin;
+  }
+
+  if (Array.isArray(plugin)) {
+    return getPluginKey(plugin[0]);
+  }
+
+  if (typeof plugin === 'object' && plugin !== null && 'key' in plugin) {
+    return (plugin as { key?: string | null }).key ?? null;
+  }
+
+  return null;
+};

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -22,6 +22,7 @@ export { default as findIdentifiers, nonType } from './findIdentifiers';
 export { findPackageJSON } from './findPackageJSON';
 export { hasEvaluatorMetadata } from './hasEvaluatorMetadata';
 export { default as getFileIdx } from './getFileIdx';
+export { getPluginKey } from './getPluginKey';
 export { hasMeta } from './hasMeta';
 export { getSource } from './getSource';
 export { isBoxedPrimitive } from './isBoxedPrimitive';

--- a/packages/utils/src/options/types.ts
+++ b/packages/utils/src/options/types.ts
@@ -28,7 +28,7 @@ export type EvaluatorConfig = {
 };
 
 export type Evaluator = (
-  babelOptions: TransformOptions,
+  evalConfig: TransformOptions,
   ast: File,
   code: string,
   config: EvaluatorConfig,


### PR DESCRIPTION
## Motivation

Some Babel plugins generate code that the evaluator can not handle.

## Summary

An assumption from #1297 was wrong. Even though we have to resolve babelrc to parse files, we can't use resolved config for pre-eval transformations since it can generate a lot of unprocessable code. The solution is to split the config into `parse` and `transform` parts with only the necessary plugins in `transform`.
