### PR TITLE
feat: support dynamic imports for evaluation

### DIFF
--- a/.changeset/kind-ligers-retire.md
+++ b/.changeset/kind-ligers-retire.md
@@ -1,0 +1,6 @@
+---
+"@linaria/babel-preset": patch
+"@linaria/testkit": patch
+---
+
+feat: support dynamic imports for evaluation

--- a/packages/babel/src/module.ts
+++ b/packages/babel/src/module.ts
@@ -461,6 +461,7 @@ class Module {
       module: this,
       exports: this.#exports,
       require: this.require,
+      __linaria_dynamic_import: async (id: string) => this.require(id),
       __filename: filename,
       __dirname: path.dirname(filename),
     });

--- a/packages/babel/src/plugins/dynamic-import.ts
+++ b/packages/babel/src/plugins/dynamic-import.ts
@@ -1,0 +1,31 @@
+import type { NodePath, PluginObj } from '@babel/core';
+
+import type { Core } from '../babel';
+
+/**
+ * The plugin that replaces `import()` with `__linaria_dynamic_import` as Node VM does not support dynamic imports yet.
+ */
+export default function dynamicImport(babel: Core): PluginObj {
+  const { types: t } = babel;
+
+  return {
+    name: '@linaria/babel/dynamic-import',
+    visitor: {
+      CallExpression(path) {
+        if (path.get('callee').isImport()) {
+          const moduleName = path.get('arguments.0') as NodePath;
+
+          if (!moduleName.isStringLiteral()) {
+            throw new Error('Dynamic import argument must be a string literal');
+          }
+
+          path.replaceWith(
+            t.callExpression(t.identifier('__linaria_dynamic_import'), [
+              t.stringLiteral(moduleName.node.value),
+            ])
+          );
+        }
+      },
+    },
+  };
+}

--- a/packages/babel/src/transform-stages/1-prepare-for-eval.ts
+++ b/packages/babel/src/transform-stages/1-prepare-for-eval.ts
@@ -72,6 +72,7 @@ function runPreevalStage(
   const plugins = [
     ...preShakePlugins,
     [require.resolve('../plugins/preeval'), { ...pluginOptions, eventEmitter }],
+    [require.resolve('../plugins/dynamic-import')],
     ...(evalConfig.plugins ?? []).filter(
       (i) => !hasKeyInList(i, pluginOptions.highPriorityPlugins)
     ),

--- a/packages/testkit/src/__fixtures__/prepare-code-test-cases/dynamic-import/input.ts
+++ b/packages/testkit/src/__fixtures__/prepare-code-test-cases/dynamic-import/input.ts
@@ -1,0 +1,5 @@
+// *
+
+export function foo(onImport) {
+  import('./foo').then(onImport);
+}

--- a/packages/testkit/src/__snapshots__/prepareCode.test.ts.snap
+++ b/packages/testkit/src/__snapshots__/prepareCode.test.ts.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`prepareCode Testing transformation for dynamic-import: code 1`] = `
+"\\"use strict\\";
+
+exports.__esModule = true;
+exports.foo = foo;
+function foo(onImport) {
+  __linaria_dynamic_import(\\"./foo\\").then(onImport);
+}"
+`;
+
+exports[`prepareCode Testing transformation for dynamic-import: imports 1`] = `Map {}`;
+
+exports[`prepareCode Testing transformation for dynamic-import: metadata 1`] = `Object {}`;
+
 exports[`prepareCode Testing transformation for for-debug: code 1`] = `
 "'use strict';
 

--- a/packages/testkit/tsconfig.json
+++ b/packages/testkit/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "extends": "../../tsconfig.json",
   "exclude": [
+    // Contains broken code that should not be type-checked
+    "src/__fixtures__/prepare-code-test-cases/dynamic-import/input.ts",
+    "src/__fixtures__/prepare-code-test-cases/for-debug/input.ts",
+    "src/__fixtures__/linaria-ui-library/types.ts",
+
     "node_modules"
   ],
   "compilerOptions": { "paths": {}, "rootDir": "src/", "types": ["jest", "node"] },


### PR DESCRIPTION
## Summary

Fixes #1317.

The new plugin transforms `import()` to `__linaria_dynamic_import()` call. `__linaria_dynamic_import` is exposed on `Module` as a new field. This is very similar to implementation in Vite/vite-node.

## Test plan

New tests were added.