### PR TITLE
fix(module): add .cjs extension

### DIFF
--- a/packages/babel/src/module.ts
+++ b/packages/babel/src/module.ts
@@ -156,7 +156,7 @@ class Module {
     this.exports = {};
 
     // We support following extensions by default
-    this.extensions = ['.json', '.js', '.jsx', '.ts', '.tsx'];
+    this.extensions = ['.json', '.js', '.jsx', '.ts', '.tsx', '.cjs'];
     this.debug('prepare', filename);
   }
 


### PR DESCRIPTION
## Motivation

This PR adds `.cjs` extension to `Module` in v3. It's required as new version of `@swc/helpers` uses export maps and points files to `.cjs`, for example:

```
"./_/_class_private_field_loose_key": {
  "import": "./esm/_class_private_field_loose_key.js",
  "default": "./cjs/_class_private_field_loose_key.cjs"
},
``` 
