### PR TITLE
fix(utils): support for `export enum …` and transpiled reexports

### DIFF
--- a/.changeset/neat-worms-clean.md
+++ b/.changeset/neat-worms-clean.md
@@ -1,0 +1,8 @@
+---
+'@linaria/babel-preset': patch
+'@linaria/shaker': patch
+'@linaria/testkit': patch
+'@linaria/utils': patch
+---
+
+Improved exports finder so it works with pure TS files and better detects transpiled reexports.

--- a/packages/babel/src/transform/generators/getExports.ts
+++ b/packages/babel/src/transform/generators/getExports.ts
@@ -60,8 +60,8 @@ export function* getExports(
   this.services.babel.traverse(loadedAndParsed.ast!, {
     Program(path) {
       const { exports, reexports } = collectExportsAndImports(path, 'disabled');
-      exports.forEach((e) => {
-        result.push(e.exported);
+      Object.keys(exports).forEach((token) => {
+        result.push(token);
       });
 
       reexports.forEach((e) => {

--- a/packages/babel/src/types.ts
+++ b/packages/babel/src/types.ts
@@ -1,6 +1,6 @@
 import type { BabelFile, PluginPass } from '@babel/core';
 import type { NodePath } from '@babel/traverse';
-import type { File } from '@babel/types';
+import type { File, Program } from '@babel/types';
 import type { RawSourceMap } from 'source-map';
 
 import type { Debugger } from '@linaria/logger';
@@ -84,5 +84,5 @@ export type MissedBabelCoreTypes = {
   File: new (
     options: { filename: string },
     file: { ast: File; code: string }
-  ) => { path: NodePath<File> };
+  ) => { path: NodePath<Program> };
 };

--- a/packages/shaker/src/plugins/__tests__/shaker-plugin.test.ts
+++ b/packages/shaker/src/plugins/__tests__/shaker-plugin.test.ts
@@ -35,6 +35,9 @@ const keep =
       configFile: false,
       filename,
       presets,
+      sourceType: /(?:^|\*\/|;)\s*(?:export|import)\s/m.test(formattedCode)
+        ? 'module'
+        : 'script',
       plugins: [
         [
           shakerPlugin,
@@ -296,15 +299,6 @@ describe('shaker', () => {
   });
 
   it('deletes non-default exports when importing default export of a module with an __esModule: true property', () => {
-    /* without workaround, this will be transformed by shaker to:
-      const n = require('n');
-      const defaultExports = {
-        createContext: n.createContext
-      };
-      exports.default = defaultExports;
-
-      i.e, exports.createContext is deleted
-    */
     const { code } = keep(['default'])`
     const n = require('n');
     const defaultExports = { createContext: n.createContext }

--- a/packages/testkit/src/collectExportsAndImports.test.ts
+++ b/packages/testkit/src/collectExportsAndImports.test.ts
@@ -73,6 +73,10 @@ function babelCommonJS(source: string): string {
   return result?.code ?? '';
 }
 
+function asIs(source: string): string {
+  return source;
+}
+
 function babelNode16(source: string): string {
   const result = babel.transformSync(source, {
     babelrc: false,
@@ -92,7 +96,8 @@ function babelNode16(source: string): string {
 }
 
 const compilers: [name: string, compiler: (code: string) => string][] = [
-  ['as is', babelNode16],
+  ['as is', asIs],
+  ['babel', babelNode16],
   ['babelCommonJS', babelCommonJS],
   ['esbuildCommonJS', esbuildCommonJS],
   ['swcCommonJSes5', swcCommonJS('es5')],
@@ -100,13 +105,18 @@ const compilers: [name: string, compiler: (code: string) => string][] = [
   ['typescriptCommonJS', typescriptCommonJS],
 ];
 
-function runWithCompiler(compiler: (code: string) => string, code: string) {
+function runWithCompiler(
+  compiler: (code: string) => string,
+  code: string,
+  compilerName: string
+) {
   const compiled = compiler(code);
   const filename = join(__dirname, 'source.ts');
 
   const ast = babel.parse(compiled, {
     babelrc: false,
     filename,
+    presets: ['@babel/preset-typescript'],
   })!;
 
   const file = new File({ filename }, { code, ast });
@@ -128,28 +138,50 @@ function runWithCompiler(compiler: (code: string) => string, code: string) {
     return a.imported.localeCompare(b.imported);
   };
 
+  const evaluateOrSource = (path: NodePath) => {
+    const evaluated = path.evaluate() as {
+      confident: boolean;
+      deopt?: NodePath;
+      value: any;
+    };
+    if (evaluated.confident) {
+      return evaluated.value;
+    }
+
+    if (evaluated.deopt?.isVariableDeclarator()) {
+      const evaluatedInit = evaluated.deopt.get('init').evaluate();
+      if (evaluatedInit.confident) {
+        return evaluatedInit.value;
+      }
+    }
+
+    return generator(path.node).code;
+  };
+
   return {
     exports:
-      collected?.exports
-        .map(({ local, ...i }) => ({
-          ...i,
-          local: generator(local.node).code,
+      Object.entries(collected?.exports ?? {})
+        .map(([exported, local]) => ({
+          exported,
+          local: evaluateOrSource(local),
         }))
         .sort((a, b) => a.exported.localeCompare(b.exported)) ?? [],
     imports:
       collected?.imports
         .map(({ local, ...i }) => ({
           ...i,
-          local: generator(local.node).code,
+          local: evaluateOrSource(local),
         }))
         .sort(sortImports) ?? [],
-    reexports: collected?.reexports ?? [],
+    reexports: collected?.reexports.sort(sortImports) ?? [],
+    compilerName,
+    compiled,
   };
 }
 
 describe.each(compilers)('collectExportsAndImports (%s)', (name, compiler) => {
   const run = (code: TemplateStringsArray) =>
-    runWithCompiler(compiler, dedent(code));
+    runWithCompiler(compiler, dedent(code), name);
 
   describe('import', () => {
     it('default', () => {
@@ -524,6 +556,18 @@ describe.each(compilers)('collectExportsAndImports (%s)', (name, compiler) => {
       ]);
     });
 
+    it('module.exports =', () => {
+      const { exports } = run`
+        module.exports = 42;
+      `;
+
+      expect(exports).toMatchObject([
+        {
+          exported: 'default',
+        },
+      ]);
+    });
+
     it('with declaration', () => {
       const { exports } = run`
         export const a = 1, b = 2;
@@ -535,6 +579,18 @@ describe.each(compilers)('collectExportsAndImports (%s)', (name, compiler) => {
         },
         {
           exported: 'b',
+        },
+      ]);
+    });
+
+    it('enum', () => {
+      const { exports } = run`
+        export enum E { A, B, C }
+      `;
+
+      expect(exports).toMatchObject([
+        {
+          exported: 'E',
         },
       ]);
     });
@@ -575,6 +631,34 @@ describe.each(compilers)('collectExportsAndImports (%s)', (name, compiler) => {
         },
       ]);
     });
+
+    it('with defineProperty with value', () => {
+      const { exports } = run`
+        Object.defineProperty(exports, 'a', {
+          value: 1,
+        });
+      `;
+
+      expect(exports).toMatchObject([
+        {
+          exported: 'a',
+        },
+      ]);
+    });
+
+    it('with defineProperty with getter', () => {
+      const { exports } = run`
+        Object.defineProperty(exports, 'a', {
+          get: () => 1,
+        });
+      `;
+
+      expect(exports).toMatchObject([
+        {
+          exported: 'a',
+        },
+      ]);
+    });
   });
 
   describe('re-export', () => {
@@ -584,23 +668,15 @@ describe.each(compilers)('collectExportsAndImports (%s)', (name, compiler) => {
         export default from "unknown-package";
       `;
 
-      if (reexports.length) {
-        expect(reexports.map(withoutLocal)).toMatchObject([
-          {
-            imported: 'default',
-            exported: 'default',
-            source: 'unknown-package',
-          },
-        ]);
-        expect(exports).toHaveLength(0);
-        expect(imports).toHaveLength(0);
-      } else {
-        expect(reexports).toHaveLength(0);
-        expect(exports).toMatchObject([
-          {
-            exported: 'default',
-          },
-        ]);
+      expect(reexports.map(withoutLocal)).toMatchObject([
+        {
+          imported: 'default',
+          exported: 'default',
+          source: 'unknown-package',
+        },
+      ]);
+      expect(exports).toHaveLength(0);
+      if (imports.length) {
         expect(imports).toMatchObject([
           {
             source: 'unknown-package',
@@ -615,23 +691,15 @@ describe.each(compilers)('collectExportsAndImports (%s)', (name, compiler) => {
         export { token } from "unknown-package";
       `;
 
-      if (reexports.length) {
-        expect(reexports.map(withoutLocal)).toMatchObject([
-          {
-            imported: 'token',
-            exported: 'token',
-            source: 'unknown-package',
-          },
-        ]);
-        expect(exports).toHaveLength(0);
-        expect(imports).toHaveLength(0);
-      } else {
-        expect(reexports).toHaveLength(0);
-        expect(exports).toMatchObject([
-          {
-            exported: 'token',
-          },
-        ]);
+      expect(reexports.map(withoutLocal)).toMatchObject([
+        {
+          imported: 'token',
+          exported: 'token',
+          source: 'unknown-package',
+        },
+      ]);
+      expect(exports).toHaveLength(0);
+      if (imports.length) {
         expect(imports).toMatchObject([
           {
             source: 'unknown-package',
@@ -646,23 +714,15 @@ describe.each(compilers)('collectExportsAndImports (%s)', (name, compiler) => {
         export { token as renamed } from "unknown-package";
       `;
 
-      if (reexports.length) {
-        expect(reexports.map(withoutLocal)).toMatchObject([
-          {
-            imported: 'token',
-            exported: 'renamed',
-            source: 'unknown-package',
-          },
-        ]);
-        expect(exports).toHaveLength(0);
-        expect(imports).toHaveLength(0);
-      } else {
-        expect(reexports).toHaveLength(0);
-        expect(exports).toMatchObject([
-          {
-            exported: 'renamed',
-          },
-        ]);
+      expect(reexports.map(withoutLocal)).toMatchObject([
+        {
+          imported: 'token',
+          exported: 'renamed',
+          source: 'unknown-package',
+        },
+      ]);
+      expect(exports).toHaveLength(0);
+      if (imports.length) {
         expect(imports).toMatchObject([
           {
             source: 'unknown-package',
@@ -708,26 +768,52 @@ describe.each(compilers)('collectExportsAndImports (%s)', (name, compiler) => {
         export * from "unknown-package";
       `;
 
-      if (reexports.length) {
-        expect(reexports.map(withoutLocal)).toMatchObject([
-          {
-            imported: '*',
-            exported: '*',
-            source: 'unknown-package',
-          },
-        ]);
-        expect(exports).toHaveLength(0);
-        expect(imports).toHaveLength(0);
-      } else {
-        expect(reexports).toHaveLength(0);
-        expect(exports).toMatchObject([
-          {
-            exported: '*',
-          },
-        ]);
+      expect(reexports.map(withoutLocal)).toMatchObject([
+        {
+          imported: '*',
+          exported: '*',
+          source: 'unknown-package',
+        },
+      ]);
+      expect(exports).toHaveLength(0);
+      if (imports.length) {
         expect(imports).toMatchObject([
           {
             source: 'unknown-package',
+            imported: '*',
+          },
+        ]);
+      }
+    });
+
+    it('multiple export all', () => {
+      const { exports, imports, reexports } = run`
+        export * from "unknown-package-1";
+        export * from "unknown-package-2";
+      `;
+
+      expect(reexports.map(withoutLocal)).toMatchObject([
+        {
+          imported: '*',
+          exported: '*',
+          source: 'unknown-package-1',
+        },
+        {
+          imported: '*',
+          exported: '*',
+          source: 'unknown-package-2',
+        },
+      ]);
+      expect(exports).toHaveLength(0);
+
+      if (imports.length) {
+        expect(imports).toMatchObject([
+          {
+            source: 'unknown-package-1',
+            imported: '*',
+          },
+          {
+            source: 'unknown-package-2',
             imported: '*',
           },
         ]);
@@ -764,83 +850,31 @@ describe.each(compilers)('collectExportsAndImports (%s)', (name, compiler) => {
         export default 123;
       `;
 
-      if (reexports.length === 3) {
-        // If all re-exports are supported
-        expect(reexports.map(withoutLocal)).toMatchObject([
-          {
-            imported: 'syncResolve',
-            exported: 'syncResolve',
-            source: './asyncResolveFallback',
-          },
-          {
-            imported: '*',
-            exported: '*',
-            source: './collectExportsAndImports',
-          },
-          {
-            imported: 'default',
-            exported: 'isUnnecessaryReactCall',
-            source: './isUnnecessaryReactCall',
-          },
-        ]);
-        expect(exports).toMatchObject([
-          {
-            exported: 'default',
-            local: '123',
-          },
-        ]);
-        expect(imports).toHaveLength(0);
-      } else if (reexports.length === 1) {
-        // If only wildcard re-export is supported
-        expect(reexports.map(withoutLocal)).toMatchObject([
-          {
-            imported: '*',
-            exported: '*',
-            source: './collectExportsAndImports',
-          },
-        ]);
-        expect(exports).toMatchObject([
-          {
-            exported: 'default',
-          },
-          {
-            exported: 'isUnnecessaryReactCall',
-          },
-          {
-            exported: 'syncResolve',
-          },
-        ]);
-        expect(imports).toMatchObject([
-          {
-            imported: 'default',
-            source: './isUnnecessaryReactCall',
-          },
-          {
-            imported: 'syncResolve',
-            source: './asyncResolveFallback',
-          },
-        ]);
-      } else {
-        // If all re-exports were transpiled to CommonJS (babel)
-        expect(reexports).toHaveLength(0);
-        expect(exports).toMatchObject([
-          {
-            exported: '*',
-            local: '_collectExportsAndImports[key]',
-          },
-          {
-            exported: 'default',
-            local: '_default',
-          },
-          {
-            exported: 'isUnnecessaryReactCall',
-            local: '_isUnnecessaryReactCall.default',
-          },
-          {
-            exported: 'syncResolve',
-            local: '_asyncResolveFallback.syncResolve',
-          },
-        ]);
+      expect(reexports.map(withoutLocal)).toMatchObject([
+        {
+          imported: '*',
+          exported: '*',
+          source: './collectExportsAndImports',
+        },
+        {
+          imported: 'default',
+          exported: 'isUnnecessaryReactCall',
+          source: './isUnnecessaryReactCall',
+        },
+        {
+          imported: 'syncResolve',
+          exported: 'syncResolve',
+          source: './asyncResolveFallback',
+        },
+      ]);
+      expect(exports).toMatchObject([
+        {
+          exported: 'default',
+          local: 123,
+        },
+      ]);
+
+      if (imports.length === 3) {
         expect(imports).toMatchObject([
           {
             imported: '*',
@@ -855,6 +889,18 @@ describe.each(compilers)('collectExportsAndImports (%s)', (name, compiler) => {
           {
             imported: 'syncResolve',
             local: '_asyncResolveFallback.syncResolve',
+            source: './asyncResolveFallback',
+          },
+        ]);
+      } else if (imports.length === 2) {
+        // If wildcard re-export is supported natively
+        expect(imports).toMatchObject([
+          {
+            imported: 'default',
+            source: './isUnnecessaryReactCall',
+          },
+          {
+            imported: 'syncResolve',
             source: './asyncResolveFallback',
           },
         ]);

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -60,7 +60,7 @@ export { valueToLiteral } from './valueToLiteral';
 export { default as JSXElementsRemover } from './visitors/JSXElementsRemover';
 
 export type {
-  IExport,
+  Exports,
   IImport,
   IReexport,
   ISideEffectImport,


### PR DESCRIPTION
## Motivation

It appeared that the exports collector didn't correctly work with pure TS files and didn't process `export enum …` as an export.

## Summary

`collectExportsAndImports` has been fixed to support TS-specific nodes. Also, better detection of reexports has been added.

## Test plan

A set of tests for TS has been added.