### PR TITLE
fix(utils): prevent prototype methods from removing

### DIFF
--- a/.changeset/seven-windows-repeat.md
+++ b/.changeset/seven-windows-repeat.md
@@ -1,0 +1,5 @@
+---
+'@linaria/utils': patch
+---
+
+Prototype methods assignments cannot be deleted safely, so it is replaced with a dummy function.

--- a/packages/utils/src/__tests__/__snapshots__/removeWithRelated.test.ts.snap
+++ b/packages/utils/src/__tests__/__snapshots__/removeWithRelated.test.ts.snap
@@ -13,10 +13,19 @@ exports[`removeWithRelated should not delete params of functions 1`] = `
 }"
 `;
 
+exports[`removeWithRelated should not remove functions that are assigned to prototype 1`] = `
+"(function () {
+  function SomeClass() {}
+  SomeClass.prototype.foo = function foo() {};
+  SomeClass.prototype.bar = function bar() {};
+})();"
+`;
+
 exports[`removeWithRelated should not remove top-level functions with empty bodies 1`] = `
 "function testFn() {}
 export const testArrow1 = () => {};
-const testArrow2 = () => {};"
+const testArrow2 = () => {};
+export default function testDefaultFn() {}"
 `;
 
 exports[`removeWithRelated should remove node if it becomes invalid after removing its children 1`] = `""`;

--- a/packages/utils/src/__tests__/removeWithRelated.test.ts
+++ b/packages/utils/src/__tests__/removeWithRelated.test.ts
@@ -188,4 +188,20 @@ describe('removeWithRelated', () => {
 
     expect(code).toMatchSnapshot();
   });
+
+  it('should not remove functions that are assigned to prototype', () => {
+    const code = run`
+      (function() {
+        function SomeClass() {}
+
+        SomeClass.prototype.foo = function foo() {}
+
+        SomeClass.prototype.bar = function bar() {
+          /* remove */console.log(arg);
+        };
+      })();
+    `;
+
+    expect(code).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
## Motivation

Sometimes, dead code remover removes method declarations that may cause `is not a function` errors.

## Summary

Code remover detects if an is-going-to-be-removed function is part of a prototype declaration and replaces it with a dummy function instead of removing it.

## Test plan

A new test was added.