### PR TITLE
fix(webpack-loader5): resolve to ES modules instead of CJS

### DIFF
--- a/.changeset/chilly-foxes-smash.md
+++ b/.changeset/chilly-foxes-smash.md
@@ -1,0 +1,5 @@
+---
+"@linaria/webpack5-loader": patch
+---
+
+fix(webpack-loader5): resolve to ES modules instead of CJS

--- a/packages/webpack5-loader/src/index.ts
+++ b/packages/webpack5-loader/src/index.ts
@@ -66,13 +66,14 @@ const webpack5Loader: Loader = function webpack5LoaderPlugin(
   } = this.getOptions() || {};
 
   const outputFileName = this.resourcePath.replace(/\.[^.]+$/, extension);
+  const resolveModule = this.getResolve({ dependencyType: 'esm' });
 
   const asyncResolve = (token: string, importer: string): Promise<string> => {
     const context = path.isAbsolute(importer)
       ? path.dirname(importer)
       : path.join(process.cwd(), path.dirname(importer));
     return new Promise((resolve, reject) => {
-      this.resolve(context, token, (err, result) => {
+      resolveModule(context, token, (err, result) => {
         if (err) {
           reject(err);
         } else if (result) {


### PR DESCRIPTION
## Motivation

Currently, Webpack loader resolves modules to CommonJS instead of ESM how it should, this PR fixes it.
