### PR TITLE
fix(utils): fix exports finder for enum that were transpilled with tsc

### DIFF
--- a/.changeset/orange-islands-juggle.md
+++ b/.changeset/orange-islands-juggle.md
@@ -1,0 +1,6 @@
+---
+'@linaria/testkit': patch
+'@linaria/utils': patch
+---
+
+The exports finder didn't support enums that were transpiled to esm by tsc. Fixed.

--- a/packages/testkit/src/collectExportsAndImports.test.ts
+++ b/packages/testkit/src/collectExportsAndImports.test.ts
@@ -22,6 +22,14 @@ function typescriptCommonJS(source: string): string {
   return result.outputText;
 }
 
+function typescriptES2022(source: string): string {
+  const result = ts.transpileModule(source, {
+    compilerOptions: { module: ts.ModuleKind.ES2022 },
+  });
+
+  return result.outputText;
+}
+
 const withoutLocal = <T extends { local: NodePath }>({
   local,
   ...obj
@@ -103,6 +111,7 @@ const compilers: [name: string, compiler: (code: string) => string][] = [
   ['swcCommonJSes5', swcCommonJS('es5')],
   ['swcCommonJSes2015', swcCommonJS('es2015')],
   ['typescriptCommonJS', typescriptCommonJS],
+  ['typescriptES2022', typescriptES2022],
 ];
 
 function runWithCompiler(


### PR DESCRIPTION
## Motivation

The exports finder didn't support enums that were transpiled to ESM by tsc.
