### PR TITLE
fix(babel): endless loop and stack overflow

### DIFF
--- a/packages/babel/src/transform/BaseEntrypoint.ts
+++ b/packages/babel/src/transform/BaseEntrypoint.ts
@@ -161,11 +161,11 @@ export abstract class BaseEntrypoint {
     public readonly generation: number,
     public readonly name: string,
     public readonly only: string[],
-    public readonly parent: ParentEntrypoint
+    public readonly parent: ParentEntrypoint[]
   ) {
     this.idx = getIdx(name);
     this.log =
-      parent?.log.extend(this.ref, '->') ?? services.log.extend(this.ref);
+      parent[0]?.log.extend(this.ref, '->') ?? services.log.extend(this.ref);
 
     let isExportsInherited = false;
     if (exports) {
@@ -189,7 +189,7 @@ export abstract class BaseEntrypoint {
       idx: this.idx,
       isExportsInherited,
       only,
-      parentId: parent?.seqId ?? null,
+      parentId: parent[0]?.seqId ?? null,
       type: 'created',
     });
   }

--- a/packages/babel/src/transform/BaseEntrypoint.ts
+++ b/packages/babel/src/transform/BaseEntrypoint.ts
@@ -161,11 +161,11 @@ export abstract class BaseEntrypoint {
     public readonly generation: number,
     public readonly name: string,
     public readonly only: string[],
-    public readonly parent: ParentEntrypoint[]
+    public readonly parents: ParentEntrypoint[]
   ) {
     this.idx = getIdx(name);
     this.log =
-      parent[0]?.log.extend(this.ref, '->') ?? services.log.extend(this.ref);
+      parents[0]?.log.extend(this.ref, '->') ?? services.log.extend(this.ref);
 
     let isExportsInherited = false;
     if (exports) {
@@ -189,7 +189,7 @@ export abstract class BaseEntrypoint {
       idx: this.idx,
       isExportsInherited,
       only,
-      parentId: parent[0]?.seqId ?? null,
+      parentId: parents[0]?.seqId ?? null,
       type: 'created',
     });
   }

--- a/packages/babel/src/transform/Entrypoint.helpers.ts
+++ b/packages/babel/src/transform/Entrypoint.helpers.ts
@@ -228,9 +228,9 @@ export function getStack(entrypoint: ParentEntrypoint) {
   const stack = [entrypoint.name];
 
   let { parent } = entrypoint;
-  while (parent) {
-    stack.push(parent.name);
-    parent = parent.parent;
+  while (parent.length) {
+    stack.push(parent[0].name);
+    parent = parent[0].parent;
   }
 
   return stack;

--- a/packages/babel/src/transform/Entrypoint.helpers.ts
+++ b/packages/babel/src/transform/Entrypoint.helpers.ts
@@ -227,10 +227,10 @@ export function getStack(entrypoint: ParentEntrypoint) {
 
   const stack = [entrypoint.name];
 
-  let { parent } = entrypoint;
-  while (parent.length) {
-    stack.push(parent[0].name);
-    parent = parent[0].parent;
+  let { parents } = entrypoint;
+  while (parents.length) {
+    stack.push(parents[0].name);
+    parents = parents[0].parents;
   }
 
   return stack;

--- a/packages/babel/src/transform/Entrypoint.ts
+++ b/packages/babel/src/transform/Entrypoint.ts
@@ -29,7 +29,7 @@ function hasLoop(
     return true;
   }
 
-  for (const p of parent.parent) {
+  for (const p of parent.parents) {
     const found = hasLoop(name, p, [...processed, parent.name]);
     if (found) {
       return found;
@@ -60,7 +60,7 @@ export class Entrypoint extends BaseEntrypoint {
 
   private constructor(
     services: Services,
-    parent: ParentEntrypoint[],
+    parents: ParentEntrypoint[],
     public readonly initialCode: string | undefined,
     name: string,
     only: string[],
@@ -75,7 +75,7 @@ export class Entrypoint extends BaseEntrypoint {
     protected readonly dependencies = new Map<string, IEntrypointDependency>(),
     generation = 1
   ) {
-    super(services, evaluatedOnly, exports, generation, name, only, parent);
+    super(services, evaluatedOnly, exports, generation, name, only, parents);
 
     this.loadedAndParsed =
       loadedAndParsed ??
@@ -83,7 +83,7 @@ export class Entrypoint extends BaseEntrypoint {
         services,
         name,
         initialCode,
-        parent[0]?.log ?? services.log,
+        parents[0]?.log ?? services.log,
         pluginOptions
       );
 
@@ -166,7 +166,7 @@ export class Entrypoint extends BaseEntrypoint {
               evaluated: parent.evaluated,
               log: parent.log,
               name: parent.name,
-              parent: parent.parent,
+              parents: parent.parents,
               seqId: parent.seqId,
             }
           : null,
@@ -221,8 +221,8 @@ export class Entrypoint extends BaseEntrypoint {
         parent.log('[createEntrypoint] %s is a loop', name);
       }
 
-      if (parent && !cached.parent.map((p) => p.name).includes(parent.name)) {
-        cached.parent.push(parent);
+      if (parent && !cached.parents.map((p) => p.name).includes(parent.name)) {
+        cached.parents.push(parent);
       }
 
       if (isSuperSet(cached.only, mergedOnly)) {
@@ -351,7 +351,7 @@ export class Entrypoint extends BaseEntrypoint {
       this.generation + 1,
       this.name,
       this.only,
-      this.parent
+      this.parents
     );
   }
 
@@ -401,7 +401,7 @@ export class Entrypoint extends BaseEntrypoint {
         ? newOnlyOrEntrypoint
         : new Entrypoint(
             this.services,
-            this.parent,
+            this.parents,
             this.initialCode,
             this.name,
             newOnlyOrEntrypoint,

--- a/packages/babel/src/transform/__tests__/createEntrypoint.test.ts
+++ b/packages/babel/src/transform/__tests__/createEntrypoint.test.ts
@@ -14,7 +14,7 @@ describe('createEntrypoint', () => {
     expect(entrypoint).toMatchObject({
       name: '/foo/bar.js',
       only: ['default'],
-      parent: null,
+      parents: [],
     });
   });
 

--- a/packages/babel/src/transform/generators/__tests__/processEntrypoint.test.ts
+++ b/packages/babel/src/transform/generators/__tests__/processEntrypoint.test.ts
@@ -44,7 +44,7 @@ describe('processEntrypoint', () => {
     expectIteratorReturnResult(gen.next(), undefined);
   });
 
-  it('should abort previously emitted actions if entrypoint was superseded', () => {
+  it('should abort previously emitted actions if entrypoint was superseded and emit a new processEntrypoint', () => {
     const fooBarDefault = createEntrypoint(services, '/foo/bar.js', [
       'default',
     ]);
@@ -68,14 +68,16 @@ describe('processEntrypoint', () => {
       false,
     ]);
 
-    createEntrypoint(services, '/foo/bar.js', ['named']);
+    const supersededWith = createEntrypoint(services, '/foo/bar.js', ['named']);
     expect(emittedSignals.map((signal) => signal?.aborted)).toEqual([
       true,
       true,
     ]);
 
-    expect(() => gen.next()).toThrow(/superseded/);
-    expectIteratorReturnResult(gen.next(), undefined);
+    const nextResult = gen.next();
+    expectIteratorYieldResult(nextResult);
+    expect(nextResult.value[0]).toBe('processEntrypoint');
+    expect(nextResult.value[1]).toBe(supersededWith);
   });
 
   it('should abort previously emitted actions if parent aborts', () => {

--- a/packages/babel/src/types.ts
+++ b/packages/babel/src/types.ts
@@ -35,7 +35,7 @@ export type ParentEntrypoint = {
   evaluated: boolean;
   log: Debugger;
   name: string;
-  parent: ParentEntrypoint[];
+  parents: ParentEntrypoint[];
   seqId: number;
 };
 

--- a/packages/babel/src/types.ts
+++ b/packages/babel/src/types.ts
@@ -35,9 +35,9 @@ export type ParentEntrypoint = {
   evaluated: boolean;
   log: Debugger;
   name: string;
-  parent: ParentEntrypoint | null;
+  parent: ParentEntrypoint[];
   seqId: number;
-} | null;
+};
 
 export type Dependencies = string[];
 

--- a/packages/shaker/src/plugins/shaker-plugin.ts
+++ b/packages/shaker/src/plugins/shaker-plugin.ts
@@ -142,7 +142,7 @@ export default function shakerPlugin(
         'import-and-exports',
         [
           `imports: ${collected.imports.length} (side-effects: ${sideEffectImports.length})`,
-          `exports: ${collected.exports.length}`,
+          `exports: ${Object.values(collected.exports).length}`,
           `reexports: ${collected.reexports.length}`,
         ].join(', ')
       );

--- a/packages/testkit/src/__fixtures__/loop/a.js
+++ b/packages/testkit/src/__fixtures__/loop/a.js
@@ -1,0 +1,5 @@
+const b = require('./b');
+
+exports.A = 'A';
+
+exports.smallB = b.B.toLowerCase();

--- a/packages/testkit/src/__fixtures__/loop/ab.js
+++ b/packages/testkit/src/__fixtures__/loop/ab.js
@@ -1,0 +1,3 @@
+const a = require('./a');
+
+exports.AB = a.A + a.smallB;

--- a/packages/testkit/src/__fixtures__/loop/b.js
+++ b/packages/testkit/src/__fixtures__/loop/b.js
@@ -1,0 +1,5 @@
+const a = require('./a');
+
+exports.B = 'B';
+
+exports.smallA = a.A.toLowerCase();

--- a/packages/testkit/src/__fixtures__/loop/ba.js
+++ b/packages/testkit/src/__fixtures__/loop/ba.js
@@ -1,0 +1,3 @@
+const b = require('./b');
+
+exports.BA = b.B + b.smallA;

--- a/packages/testkit/src/__fixtures__/loop/index.js
+++ b/packages/testkit/src/__fixtures__/loop/index.js
@@ -1,0 +1,5 @@
+const ab = require('./ab');
+const ba = require('./ba');
+
+exports.AB = ab.AB;
+exports.BA = ba.BA;

--- a/packages/testkit/src/__fixtures__/self-import.js
+++ b/packages/testkit/src/__fixtures__/self-import.js
@@ -1,0 +1,4 @@
+import { constant as importedConstant } from './self-import';
+
+export const constant = 42;
+export const stringConstant = importedConstant.toString(16);

--- a/packages/testkit/src/__snapshots__/babel.test.ts.snap
+++ b/packages/testkit/src/__snapshots__/babel.test.ts.snap
@@ -2635,6 +2635,20 @@ Dependencies: NA
 
 `;
 
+exports[`strategy shaker should work with short-circuit imports 1`] = `"export const StyledTitle = "StyledTitle_s13jq05";"`;
+
+exports[`strategy shaker should work with short-circuit imports 2`] = `
+
+CSS:
+
+.StyledTitle_s13jq05 {
+  content: "2a";
+}
+
+Dependencies: ./__fixtures__/self-import
+
+`;
+
 exports[`strategy shaker should work with wildcard imports 1`] = `"export const square = "square_s13jq05";"`;
 
 exports[`strategy shaker should work with wildcard imports 2`] = `

--- a/packages/testkit/src/babel.test.ts
+++ b/packages/testkit/src/babel.test.ts
@@ -3325,5 +3325,30 @@ describe('strategy shaker', () => {
         expect(metadata).toMatchSnapshot();
       }
     });
+
+    it('loop in evaluated files', async () => {
+      const cache = new TransformCacheCollection();
+
+      await expect(() =>
+        Promise.all(
+          ['AB', 'BA'].map((token) =>
+            transform(
+              dedent`
+              import { styled } from '@linaria/react';
+              import { ${token} } from "./__fixtures__/loop/${token.toLowerCase()}";
+
+              export const H1${token} = styled.h1\`
+                color: ${`\${${token}}`};
+              \`
+            `,
+              [evaluator],
+              cache,
+              emitter,
+              token
+            )
+          )
+        )
+      ).rejects.toThrowError(/reading 'toLowerCase'/);
+    });
   });
 });

--- a/packages/testkit/src/babel.test.ts
+++ b/packages/testkit/src/babel.test.ts
@@ -3090,6 +3090,23 @@ describe('strategy shaker', () => {
     expect(metadata).toMatchSnapshot();
   });
 
+  it('should work with short-circuit imports', async () => {
+    const { code, metadata } = await transform(
+      dedent`
+        import { css } from "@linaria/core";
+        import { stringConstant } from "./__fixtures__/self-import";
+
+        export const StyledTitle = css\`
+          content: "${'${stringConstant}'}";
+        \`;
+      `,
+      [evaluator]
+    );
+
+    expect(code).toMatchSnapshot();
+    expect(metadata).toMatchSnapshot();
+  });
+
   xit('should shake out side effect because its definition uses DOM API', async () => {
     const { code, metadata } = await transform(
       dedent`

--- a/packages/testkit/src/collectExportsAndImports.test.ts
+++ b/packages/testkit/src/collectExportsAndImports.test.ts
@@ -604,6 +604,18 @@ describe.each(compilers)('collectExportsAndImports (%s)', (name, compiler) => {
       ]);
     });
 
+    it('class', () => {
+      const { exports } = run`
+        export class Foo {}
+      `;
+
+      expect(exports).toMatchObject([
+        {
+          exported: 'Foo',
+        },
+      ]);
+    });
+
     it('with destruction', () => {
       const { exports } = run`
         const obj = { a: 1, b: 2 };

--- a/packages/utils/src/collectExportsAndImports.ts
+++ b/packages/utils/src/collectExportsAndImports.ts
@@ -1095,6 +1095,14 @@ function collectFromExportNamedDeclaration(
       state.exports[id.node.name] = id;
     }
   }
+
+  if (declaration.isClassDeclaration()) {
+    const id = declaration.get('id');
+    if (id.isIdentifier()) {
+      // eslint-disable-next-line no-param-reassign
+      state.exports[id.node.name] = id;
+    }
+  }
 }
 
 function collectFromExportDefaultDeclaration(


### PR DESCRIPTION
## Motivation

When two concurrent tasks try to process two files that have circular imports to each other, a build fails with a stack overflow error or goes into an endless cycle.

## Summary

This PR introduces a better cycle detection algorithm.

## Test plan

A couple of new tests were added.