### PR TITLE
fix(babel): happy-dom doesn't work on Stackblitz (fixes #1345)

### DIFF
--- a/.changeset/seven-fishes-exist.md
+++ b/.changeset/seven-fishes-exist.md
@@ -1,0 +1,5 @@
+---
+'@linaria/babel-preset': patch
+---
+
+For some reason, happy-dom setups context with undefined values when it is run on Stackblitz. Fixed with the workaround. (fixes #1345)

--- a/packages/babel/src/vm/createVmContext.ts
+++ b/packages/babel/src/vm/createVmContext.ts
@@ -10,7 +10,8 @@ import * as process from './process';
 const NOOP = () => {};
 
 function createWindow(): Window {
-  const HappyWindow = require('happy-dom').Window;
+  const { Window, GlobalWindow } = require('happy-dom');
+  const HappyWindow = GlobalWindow || Window;
   const win = new HappyWindow();
 
   // TODO: browser doesn't expose Buffer, but a lot of dependencies use it
@@ -43,7 +44,7 @@ function createBaseContext(
   baseContext.setInterval = NOOP;
   baseContext.setTimeout = NOOP;
 
-  // eslint-disable-next-line
+  // eslint-disable-next-line guard-for-in,no-restricted-syntax
   for (const key in additionalContext) {
     baseContext[key] = additionalContext[key];
   }


### PR DESCRIPTION
## Motivation

See #1345

## Summary

Vitests uses deprecated GlobalWindow, and so do we.
