### PR TITLE
fix(utils): logical and ternary expressions in code remover (fixes #1310)

### DIFF
--- a/.changeset/pretty-horses-behave.md
+++ b/.changeset/pretty-horses-behave.md
@@ -1,0 +1,5 @@
+---
+'@linaria/utils': patch
+---
+
+The code remover is trained to handle logical and ternary expressions. Fixes #1310.

--- a/.changeset/six-elephants-design.md
+++ b/.changeset/six-elephants-design.md
@@ -1,0 +1,5 @@
+---
+'@linaria/utils': patch
+---
+
+Browser-specific code can now be wrapped in `if (typeof window !== 'undefined') { /* will be deleted */ }`.

--- a/packages/utils/src/__tests__/__snapshots__/removeDangerousCode.test.ts.snap
+++ b/packages/utils/src/__tests__/__snapshots__/removeDangerousCode.test.ts.snap
@@ -9,6 +9,16 @@ export function setVersion(packageName, packageVersion) {
 }"
 `;
 
+exports[`removeDangerousCode should remove code under is-it-browser checks 1`] = `
+"let method;
+if (true) {
+  console.log('it is not browser');
+}
+export function testFn(arg) {
+  method(arg);
+}"
+`;
+
 exports[`removeDangerousCode should replace body of react component with null 1`] = `
 "export var Popup = /*#__PURE__*/function () {
   var Popup = function Popup() {
@@ -27,7 +37,7 @@ exports[`removeDangerousCode should simplify OR expression 1`] = `
 
 exports[`removeDangerousCode should simplify ternary operator 1`] = `
 "export function getHostname(opts) {
-  return typeof location !== "undefined" ? undefined : "localhost";
+  return "localhost";
 }"
 `;
 
@@ -39,6 +49,12 @@ exports[`removeDangerousCode should simplify ternary operator 2`] = `
 
 exports[`removeDangerousCode should simplify ternary operator 3`] = `
 "export function getHostname(opts) {
-  return typeof location === "undefined" ? "localhost" : undefined;
+  return opts ? "localhost" : undefined;
+}"
+`;
+
+exports[`removeDangerousCode should simplify ternary operator 4`] = `
+"export function getHostname(opts) {
+  return opts ? undefined : "localhost";
 }"
 `;

--- a/packages/utils/src/__tests__/__snapshots__/removeDangerousCode.test.ts.snap
+++ b/packages/utils/src/__tests__/__snapshots__/removeDangerousCode.test.ts.snap
@@ -11,7 +11,7 @@ export function setVersion(packageName, packageVersion) {
 
 exports[`removeDangerousCode should remove code under is-it-browser checks 1`] = `
 "let method;
-if (true) {
+{
   console.log('it is not browser');
 }
 export function testFn(arg) {
@@ -32,6 +32,18 @@ exports[`removeDangerousCode should replace body of react component with null 1`
 exports[`removeDangerousCode should simplify OR expression 1`] = `
 "export function getHostname(opts) {
   return opts.hostname;
+}"
+`;
+
+exports[`removeDangerousCode should simplify if statement 1`] = `
+"{
+  console.log('it is not browser');
+}
+{
+  console.log('it is not browser');
+}
+{
+  console.log('it is not browser');
 }"
 `;
 

--- a/packages/utils/src/__tests__/__snapshots__/removeDangerousCode.test.ts.snap
+++ b/packages/utils/src/__tests__/__snapshots__/removeDangerousCode.test.ts.snap
@@ -18,3 +18,27 @@ exports[`removeDangerousCode should replace body of react component with null 1`
   return Popup;
 }();"
 `;
+
+exports[`removeDangerousCode should simplify OR expression 1`] = `
+"export function getHostname(opts) {
+  return opts.hostname;
+}"
+`;
+
+exports[`removeDangerousCode should simplify ternary operator 1`] = `
+"export function getHostname(opts) {
+  return typeof location !== "undefined" ? undefined : "localhost";
+}"
+`;
+
+exports[`removeDangerousCode should simplify ternary operator 2`] = `
+"export function getHostname(opts) {
+  return "localhost";
+}"
+`;
+
+exports[`removeDangerousCode should simplify ternary operator 3`] = `
+"export function getHostname(opts) {
+  return typeof location === "undefined" ? "localhost" : undefined;
+}"
+`;

--- a/packages/utils/src/__tests__/__snapshots__/removeWithRelated.test.ts.snap
+++ b/packages/utils/src/__tests__/__snapshots__/removeWithRelated.test.ts.snap
@@ -2,11 +2,6 @@
 
 exports[`removeWithRelated should keep alive used import specifier 1`] = `"import { b } from './source';"`;
 
-exports[`removeWithRelated should keep logical expression 1`] = `
-"const c = 3;
-const res = false && c;"
-`;
-
 exports[`removeWithRelated should not delete params of functions 1`] = `
 "function test(arg) {
   return null;
@@ -27,6 +22,8 @@ export const testArrow1 = () => {};
 const testArrow2 = () => {};
 export default function testDefaultFn() {}"
 `;
+
+exports[`removeWithRelated should optimize logical expression 1`] = `"const res = false;"`;
 
 exports[`removeWithRelated should remove node if it becomes invalid after removing its children 1`] = `""`;
 

--- a/packages/utils/src/__tests__/removeDangerousCode.test.ts
+++ b/packages/utils/src/__tests__/removeDangerousCode.test.ts
@@ -64,4 +64,34 @@ describe('removeDangerousCode', () => {
 
     expect(result).toMatchSnapshot();
   });
+
+  it('should simplify ternary operator', () => {
+    expect(run`
+      export function getHostname(opts) {
+        return typeof location !== "undefined" ? location.hostname : "localhost";
+      }
+    `).toMatchSnapshot();
+
+    expect(run`
+      export function getHostname(opts) {
+        return location.hostname ? "location.hostname" : "localhost";
+      }
+    `).toMatchSnapshot();
+
+    expect(run`
+      export function getHostname(opts) {
+        return typeof location === "undefined" ? "localhost" : location.hostname;
+      }
+    `).toMatchSnapshot();
+  });
+
+  it('should simplify OR expression', () => {
+    const result = run`
+      export function getHostname(opts) {
+        return opts.hostname || location.hostname;
+      }
+    `;
+
+    expect(result).toMatchSnapshot();
+  });
 });

--- a/packages/utils/src/__tests__/removeDangerousCode.test.ts
+++ b/packages/utils/src/__tests__/removeDangerousCode.test.ts
@@ -122,4 +122,30 @@ describe('removeDangerousCode', () => {
 
     expect(result).toMatchSnapshot();
   });
+
+  it('should simplify if statement', () => {
+    const result = run`
+      if (typeof window !== 'undefined') {
+        console.log('it is browser');
+      }
+
+      if (typeof window === 'undefined') {
+        console.log('it is not browser');
+      }
+
+      if (typeof window === 'undefined') {
+        console.log('it is not browser');
+      } else {
+        console.log('it is browser');
+      }
+
+      if (typeof window !== 'undefined') {
+        console.log('it is browser');
+      } else {
+        console.log('it is not browser');
+      }
+    `;
+
+    expect(result).toMatchSnapshot();
+  });
 });

--- a/packages/utils/src/__tests__/removeDangerousCode.test.ts
+++ b/packages/utils/src/__tests__/removeDangerousCode.test.ts
@@ -80,7 +80,13 @@ describe('removeDangerousCode', () => {
 
     expect(run`
       export function getHostname(opts) {
-        return typeof location === "undefined" ? "localhost" : location.hostname;
+        return opts ? "localhost" : location.hostname;
+      }
+    `).toMatchSnapshot();
+
+    expect(run`
+      export function getHostname(opts) {
+        return opts ? location.hostname : "localhost";
       }
     `).toMatchSnapshot();
   });
@@ -89,6 +95,28 @@ describe('removeDangerousCode', () => {
     const result = run`
       export function getHostname(opts) {
         return opts.hostname || location.hostname;
+      }
+    `;
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should remove code under is-it-browser checks', () => {
+    const result = run`
+      let method;
+
+      if (typeof window !== 'undefined') {
+        console.log('it is browser');
+        method = window.fetch;
+      }
+
+      if (typeof window === 'undefined') {
+        console.log('it is not browser');
+        method = fetch;
+      }
+
+      export function testFn(arg) {
+        method(arg);
       }
     `;
 

--- a/packages/utils/src/__tests__/removeWithRelated.test.ts
+++ b/packages/utils/src/__tests__/removeWithRelated.test.ts
@@ -98,7 +98,7 @@ describe('removeWithRelated', () => {
     expect(code).toMatchSnapshot();
   });
 
-  it('should keep logical expression', () => {
+  it('should optimize logical expression', () => {
     const code = run`
       const a = 1;
       /* remove */const b = 2;

--- a/packages/utils/src/scopeHelpers.ts
+++ b/packages/utils/src/scopeHelpers.ts
@@ -279,6 +279,20 @@ export function findActionForNode(
     }
   }
 
+  if (parent.isConditionalExpression()) {
+    if (path.key === 'test') {
+      return ['replace', parent, parent.node.alternate];
+    }
+
+    if (path.key === 'consequent') {
+      return ['replace', path, { type: 'Identifier', name: 'undefined' }];
+    }
+
+    if (path.key === 'alternate') {
+      return ['replace', path, { type: 'Identifier', name: 'undefined' }];
+    }
+  }
+
   if (parent.isLogicalExpression({ operator: '&&' })) {
     return [
       'replace',
@@ -287,6 +301,14 @@ export function findActionForNode(
         type: 'BooleanLiteral',
         value: false,
       },
+    ];
+  }
+
+  if (parent.isLogicalExpression({ operator: '||' })) {
+    return [
+      'replace',
+      parent,
+      path.key === 'left' ? parent.node.right : parent.node.left,
     ];
   }
 

--- a/packages/utils/src/scopeHelpers.ts
+++ b/packages/utils/src/scopeHelpers.ts
@@ -552,11 +552,20 @@ function staticEvaluate(path: NodePath | null | undefined): void {
     }
   }
 
-  if (
-    path.isIfStatement() &&
-    path.get('test').isBooleanLiteral({ value: false })
-  ) {
-    applyAction(['remove', path]);
+  if (path.isIfStatement()) {
+    const test = path.get('test');
+    if (!test.isBooleanLiteral()) {
+      return;
+    }
+
+    const { consequent, alternate } = path.node;
+    if (test.node.value) {
+      applyAction(['replace', path, consequent]);
+    } else if (alternate) {
+      applyAction(['replace', path, alternate]);
+    } else {
+      applyAction(['remove', path]);
+    }
   }
 }
 


### PR DESCRIPTION
## Motivation

See #1310 

## Summary

The code remover is trained to handle logical and ternary expressions:
- `opts.hostname || location.hostname` -> `opts.hostname`
- `typeof location !== "undefined" ? location.hostname : "localhost"` -> `typeof location !== "undefined" ? undefined : "localhost"`
- `location.hostname ? "location.hostname" : "localhost"` -> `"localhost"`

It also handles some popular 'is-it-browser' checks like `typeof window !== 'undefined'` or `typeof location !== 'undefined'` and removes unreachable branches in `if` statements.

## Test plan

A couple of new tests were added.