### PR TITLE
fix(utils): code remover should not delete classes if any member was deleted

### DIFF
--- a/.changeset/gorgeous-jobs-approve.md
+++ b/.changeset/gorgeous-jobs-approve.md
@@ -1,0 +1,5 @@
+---
+'@linaria/utils': patch
+---
+
+The code remover should not delete classes if the last member was deleted.

--- a/packages/utils/src/__tests__/__snapshots__/removeDangerousCode.test.ts.snap
+++ b/packages/utils/src/__tests__/__snapshots__/removeDangerousCode.test.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`removeDangerousCode should not remove class 1`] = `"class Test {}"`;
+
 exports[`removeDangerousCode should remove \`window\` but keep \`setVersion\` function untouched 1`] = `
 "let _win = undefined;
 export function setVersion(packageName, packageVersion) {

--- a/packages/utils/src/__tests__/removeDangerousCode.test.ts
+++ b/packages/utils/src/__tests__/removeDangerousCode.test.ts
@@ -148,4 +148,16 @@ describe('removeDangerousCode', () => {
 
     expect(result).toMatchSnapshot();
   });
+
+  it('should not remove class', () => {
+    const result = run`
+      class Test {
+        constructor() {
+          window.fetch();
+        }
+      }
+    `;
+
+    expect(result).toMatchSnapshot();
+  });
 });

--- a/packages/utils/src/scopeHelpers.ts
+++ b/packages/utils/src/scopeHelpers.ts
@@ -249,6 +249,12 @@ export function findActionForNode(
     return ['remove', path];
   }
 
+  if (parent.isClassDeclaration() || parent.isClassExpression()) {
+    if (path.key === 'body') {
+      return ['replace', path, { type: 'ClassBody', body: [] }];
+    }
+  }
+
   if (parent.isFunction()) {
     if (path.listKey === 'params') {
       // Do not remove params of functions


### PR DESCRIPTION
## Motivation

Broken compatibility with socket.io. See #1310

## Summary

Shaker was too aggressive and removed classes when any member of it was deleted.
