### PR TITLE
feat(babel): introduces `useBabelConfigs` feature flag

### DIFF
--- a/.changeset/short-cats-travel.md
+++ b/.changeset/short-cats-travel.md
@@ -4,4 +4,4 @@
 '@linaria/utils': patch
 ---
 
-`babelrc` feature flag.
+`useBabelConfigs` feature flag.

--- a/.changeset/short-cats-travel.md
+++ b/.changeset/short-cats-travel.md
@@ -1,0 +1,7 @@
+---
+'@linaria/babel-preset': patch
+'@linaria/testkit': patch
+'@linaria/utils': patch
+---
+
+`babelrc` feature flag.

--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -11,12 +11,6 @@ Feature flags are used to enable or disable specific features provided. The `fea
 - `["glob1", "!glob2"]`: Enables the feature for files matching `glob1` but excludes files that match `glob2`.
 
 
-# 'babelrc' Feature
-
-The `babelrc` feature is enabled by default. If it is enabled, Linaria will try to resolve the `.babelrc` file for each processed file. Otherwise, it will use the default Babel configuration from `babelOptions` in the configuration.
-
-Please note that the default value of `babelrc` will be changed to `false` in the next major release.
-
 # `dangerousCodeRemover` Feature
 
 The `dangerousCodeRemover` is a flag that is enabled by default. It is designed to enhance the static evaluation of values that are interpolated in styles and to optimize the processing of styled-wrapped components during the build stage. This optimization is crucial for maintaining a stable and fast build process. It is important to note that the `dangerousCodeRemover` does not impact the runtime code; it solely focuses on the code used during the build.
@@ -67,3 +61,10 @@ The `happyDOM` is enabled by default. This feature enables usage of https://gith
 # `softErrors` Feature
 
 The `softErrors` is disabled by default. It is designed to provide a more lenient evaluation of styles and values that are interpolated in styles. This flag is useful for debugging and prevents the build from failing even if some files cannot be processed with Linaria.
+
+
+# 'useBabelConfigs' Feature
+
+The `useBabelConfigs` feature is enabled by default. If it is enabled, Linaria will try to resolve the `.babelrc` file for each processed file. Otherwise, it will use the default Babel configuration from `babelOptions` in the configuration.
+
+Please note that the default value of `useBabelConfigs` will be changed to `false` in the next major release.

--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -11,6 +11,12 @@ Feature flags are used to enable or disable specific features provided. The `fea
 - `["glob1", "!glob2"]`: Enables the feature for files matching `glob1` but excludes files that match `glob2`.
 
 
+# 'babelrc' Feature
+
+The `babelrc` feature is enabled by default. If it is enabled, Linaria will try to resolve the `.babelrc` file for each processed file. Otherwise, it will use the default Babel configuration from `babelOptions` in the configuration.
+
+Please note that the default value of `babelrc` will be changed to `false` in the next major release.
+
 # `dangerousCodeRemover` Feature
 
 The `dangerousCodeRemover` is a flag that is enabled by default. It is designed to enhance the static evaluation of values that are interpolated in styles and to optimize the processing of styled-wrapped components during the build stage. This optimization is crucial for maintaining a stable and fast build process. It is important to note that the `dangerousCodeRemover` does not impact the runtime code; it solely focuses on the code used during the build.

--- a/packages/babel/src/transform/Entrypoint.helpers.ts
+++ b/packages/babel/src/transform/Entrypoint.helpers.ts
@@ -11,6 +11,7 @@ import {
   buildOptions,
   getFileIdx,
   getPluginKey,
+  isFeatureEnabled,
   loadBabelOptions,
 } from '@linaria/utils';
 
@@ -101,7 +102,7 @@ function buildConfigs(
   );
 
   const parseConfig = loadBabelOptions(babel, name, {
-    babelrc: true,
+    babelrc: isFeatureEnabled(pluginOptions.features, 'babelrc', name),
     ...rawConfig,
   });
 

--- a/packages/babel/src/transform/Entrypoint.helpers.ts
+++ b/packages/babel/src/transform/Entrypoint.helpers.ts
@@ -101,8 +101,18 @@ function buildConfigs(
     commonOptions
   );
 
+  const useBabelConfigs = isFeatureEnabled(
+    pluginOptions.features,
+    'useBabelConfigs',
+    name
+  );
+
+  if (!useBabelConfigs) {
+    rawConfig.configFile = false;
+  }
+
   const parseConfig = loadBabelOptions(babel, name, {
-    babelrc: isFeatureEnabled(pluginOptions.features, 'babelrc', name),
+    babelrc: useBabelConfigs,
     ...rawConfig,
   });
 

--- a/packages/babel/src/transform/helpers/loadLinariaOptions.ts
+++ b/packages/babel/src/transform/helpers/loadLinariaOptions.ts
@@ -49,6 +49,7 @@ export default function loadLinariaOptions(
       : explorerSync.search();
 
   const defaultFeatures: FeatureFlags = {
+    babelrc: true,
     dangerousCodeRemover: true,
     globalCache: true,
     happyDOM: true,

--- a/packages/babel/src/transform/helpers/loadLinariaOptions.ts
+++ b/packages/babel/src/transform/helpers/loadLinariaOptions.ts
@@ -49,11 +49,11 @@ export default function loadLinariaOptions(
       : explorerSync.search();
 
   const defaultFeatures: FeatureFlags = {
-    babelrc: true,
     dangerousCodeRemover: true,
     globalCache: true,
     happyDOM: true,
     softErrors: false,
+    useBabelConfigs: true,
   };
 
   const options: StrictOptions = {

--- a/packages/testkit/src/babel.test.ts
+++ b/packages/testkit/src/babel.test.ts
@@ -17,10 +17,10 @@ import {
 import { linariaLogger } from '@linaria/logger';
 import type {
   Evaluator,
-  StrictOptions,
   OnEvent,
   OnActionStartArgs,
   OnActionFinishArgs,
+  FeatureFlags,
 } from '@linaria/utils';
 import { EventEmitter } from '@linaria/utils';
 import type { EntrypointEvent } from '@linaria/utils/types/EventEmitter';
@@ -31,9 +31,13 @@ expect.addSnapshotSerializer(serializer);
 
 const dirName = __dirname;
 
+type PartialOptions = Partial<Omit<PluginOptions, 'features'>> & {
+  features?: Partial<FeatureFlags>;
+};
+
 type Options = [
   evaluator: Evaluator,
-  linariaConfig?: Partial<StrictOptions>,
+  linariaConfig?: PartialOptions,
   extension?: 'js' | 'ts' | 'jsx' | 'tsx',
   filename?: string,
   babelConfig?: babel.TransformOptions,
@@ -63,7 +67,7 @@ const getPresets = (extension: 'js' | 'ts' | 'jsx' | 'tsx') => {
 
 const getLinariaConfig = (
   evaluator: Evaluator,
-  linariaConfig: Partial<StrictOptions>,
+  linariaConfig: PartialOptions,
   presets: PluginItem[],
   stage?: Stage
 ): PluginOptions =>
@@ -2823,6 +2827,23 @@ describe('strategy shaker', () => {
     hasNotBeenProcessed(
       resolve(__dirname, './__fixtures__/re-exports/empty.js')
     );
+  });
+
+  it('should fail because babelrc options is disabled', async () => {
+    const fn = () =>
+      transformFile(
+        resolve(__dirname, './__fixtures__/with-babelrc/index.js'),
+        [
+          evaluator,
+          {
+            features: {
+              babelrc: false,
+            },
+          },
+        ]
+      );
+
+    expect(fn).rejects.toThrowError(`Cannot find module '_/re-exports'`);
   });
 
   it('respects module-resolver plugin and show waring', async () => {

--- a/packages/testkit/src/babel.test.ts
+++ b/packages/testkit/src/babel.test.ts
@@ -2837,7 +2837,7 @@ describe('strategy shaker', () => {
           evaluator,
           {
             features: {
-              babelrc: false,
+              useBabelConfigs: false,
             },
           },
         ]

--- a/packages/testkit/src/module.test.ts
+++ b/packages/testkit/src/module.test.ts
@@ -42,6 +42,7 @@ const options: StrictOptions = {
   evaluate: true,
   extensions: ['.cjs', '.js', '.jsx', '.ts', '.tsx'],
   features: {
+    babelrc: true,
     dangerousCodeRemover: true,
     globalCache: true,
     happyDOM: true,

--- a/packages/testkit/src/module.test.ts
+++ b/packages/testkit/src/module.test.ts
@@ -42,11 +42,11 @@ const options: StrictOptions = {
   evaluate: true,
   extensions: ['.cjs', '.js', '.jsx', '.ts', '.tsx'],
   features: {
-    babelrc: true,
     dangerousCodeRemover: true,
     globalCache: true,
     happyDOM: true,
     softErrors: false,
+    useBabelConfigs: true,
   },
   highPriorityPlugins: [],
   overrideContext: (context) => ({

--- a/packages/utils/src/options/types.ts
+++ b/packages/utils/src/options/types.ts
@@ -51,6 +51,7 @@ export type EvalRule = {
 export type FeatureFlag = boolean | string | string[];
 
 type AllFeatureFlags = {
+  babelrc: FeatureFlag;
   dangerousCodeRemover: FeatureFlag;
   globalCache: FeatureFlag;
   happyDOM: FeatureFlag;

--- a/packages/utils/src/options/types.ts
+++ b/packages/utils/src/options/types.ts
@@ -51,11 +51,11 @@ export type EvalRule = {
 export type FeatureFlag = boolean | string | string[];
 
 type AllFeatureFlags = {
-  babelrc: FeatureFlag;
   dangerousCodeRemover: FeatureFlag;
   globalCache: FeatureFlag;
   happyDOM: FeatureFlag;
   softErrors: FeatureFlag;
+  useBabelConfigs: FeatureFlag;
 };
 
 export type FeatureFlags<


### PR DESCRIPTION
## Motivation

It wasn't a good idea to always resolve `.babelrc` for every parsed file.

## Summary

The new feature flag `useBabelConfigs` has been added. The default value is `true` but will be changed to `false` in the next major release. 

## Test plan

One new test was added.
