### PR TITLE
fix(vite): issue with dev mode and deoptimized deps (fixes #1246)

### DIFF
--- a/.changeset/orange-baboons-reflect.md
+++ b/.changeset/orange-baboons-reflect.md
@@ -1,0 +1,5 @@
+---
+'@linaria/vite': patch
+---
+
+Fix an issue with deoptimized deps and dev mode. Fixes #1246

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -4,11 +4,13 @@
  * returns transformed code without template literals and attaches generated source maps
  */
 
+import { existsSync } from 'fs';
 import path from 'path';
 
 import { createFilter } from '@rollup/pluginutils';
 import type { FilterPattern } from '@rollup/pluginutils';
 import type { ModuleNode, Plugin, ResolvedConfig, ViteDevServer } from 'vite';
+import { optimizeDeps } from 'vite';
 
 import {
   transform,
@@ -129,6 +131,10 @@ export default function linaria({
             // \0 is a special character in Rollup that tells Rollup to not include this in the bundle
             // https://rollupjs.org/guide/en/#outputexports
             return null;
+          }
+
+          if (!existsSync(resolvedId)) {
+            await optimizeDeps(config);
           }
 
           return resolvedId;


### PR DESCRIPTION
## Motivation

See #1246

## Summary

If the resolver meets a file that is resolved but doesn't exist, it calls `optimizeDeps`, so Vite will forcefully create it.
