### PR TITLE
fix(babel): do not try to read built-in modules

### DIFF
--- a/.changeset/great-seahorses-talk.md
+++ b/.changeset/great-seahorses-talk.md
@@ -1,0 +1,5 @@
+---
+'@linaria/babel-preset': patch
+---
+
+Fix an ENOENT error for built-in modules. Fixes #1353.

--- a/packages/babel/src/transform/Entrypoint.helpers.ts
+++ b/packages/babel/src/transform/Entrypoint.helpers.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { dirname, extname } from 'path';
+import { dirname, extname, isAbsolute } from 'path';
 
 import type { TransformOptions, PluginItem } from '@babel/core';
 import type { File } from '@babel/types';
@@ -169,7 +169,11 @@ export function loadAndParse(
 
     return {
       get code() {
-        return loadedCode ?? readFileSync(name, 'utf-8');
+        if (isAbsolute(name)) {
+          return loadedCode ?? readFileSync(name, 'utf-8');
+        }
+
+        return ''; // it is a built-in module
       },
       evaluator: 'ignored',
       reason: 'extension',

--- a/packages/testkit/src/__snapshots__/babel.test.ts.snap
+++ b/packages/testkit/src/__snapshots__/babel.test.ts.snap
@@ -2615,6 +2615,20 @@ Dependencies: NA
 
 `;
 
+exports[`strategy shaker should work with built-in modules 1`] = `"export const square = "square_s13jq05";"`;
+
+exports[`strategy shaker should work with built-in modules 2`] = `
+
+CSS:
+
+.square_s13jq05 {
+  background: url(https://example.com/);
+}
+
+Dependencies: NA
+
+`;
+
 exports[`strategy shaker should work with generated classnames as selectors 1`] = `
 "export const text = "text_t13jq05";
 export const square = "square_s1vhermz";"

--- a/packages/testkit/src/babel.test.ts
+++ b/packages/testkit/src/babel.test.ts
@@ -3074,6 +3074,25 @@ describe('strategy shaker', () => {
     expect(metadata).toMatchSnapshot();
   });
 
+  it('should work with built-in modules', async () => {
+    const { code, metadata } = await transform(
+      dedent`
+        import { css } from "@linaria/core";
+        import { URL } from "url";
+
+        const url = (new URL("https://example.com")).toString();
+
+        export const square = css\`
+          background: url(${'${url}'});
+        \`;
+      `,
+      [evaluator]
+    );
+
+    expect(code).toMatchSnapshot();
+    expect(metadata).toMatchSnapshot();
+  });
+
   it('should process module.exports = require(…)', async () => {
     const { code, metadata } = await transform(
       dedent`


### PR DESCRIPTION
## Motivation

See #1353

## Summary

Built-in modules are handled in `Module.require`, and we don't need their source code, so we can skip the reading step.

## Test plan

One new test has been added.