### PR TITLE
fix(babel): lost plugin options

### DIFF
--- a/.changeset/afraid-starfishes-film.md
+++ b/.changeset/afraid-starfishes-film.md
@@ -1,0 +1,6 @@
+---
+'@linaria/babel-preset': patch
+'@linaria/testkit': patch
+---
+
+Fix for lost `pluginOptions` in some entrypoints.

--- a/.changeset/tall-clouds-reply.md
+++ b/.changeset/tall-clouds-reply.md
@@ -1,0 +1,6 @@
+---
+'@linaria/babel-preset': patch
+'@linaria/testkit': patch
+---
+
+`pluginOptions` could be lost during processing.

--- a/packages/babel/src/evaluators/index.ts
+++ b/packages/babel/src/evaluators/index.ts
@@ -2,9 +2,9 @@
  * This file is an entry point for module evaluation for getting lazy dependencies.
  */
 
-import type { TransformCacheCollection } from '../cache';
 import Module from '../module';
 import type { Entrypoint } from '../transform/Entrypoint';
+import type { Services } from '../transform/types';
 
 export interface IEvaluateResult {
   dependencies: string[];
@@ -12,10 +12,10 @@ export interface IEvaluateResult {
 }
 
 export default function evaluate(
-  cache: TransformCacheCollection,
+  services: Services,
   entrypoint: Entrypoint
 ): IEvaluateResult {
-  const m = new Module(entrypoint, cache);
+  const m = new Module(services, entrypoint);
 
   m.evaluate();
 

--- a/packages/babel/src/module.ts
+++ b/packages/babel/src/module.ts
@@ -216,7 +216,7 @@ class Module {
       this.callstack = [entrypoint.name];
     }
 
-    this.extensions = entrypoint.pluginOptions.extensions;
+    this.extensions = services.options.pluginOptions.extensions;
 
     this.debug('init', entrypoint.name);
   }
@@ -252,7 +252,8 @@ class Module {
       evaluatedCreated = true;
     }
 
-    const { transformedCode: source, pluginOptions } = entrypoint;
+    const { transformedCode: source } = entrypoint;
+    const { pluginOptions } = this.services.options;
 
     if (!source) {
       this.debug(`evaluate`, 'there is nothing to evaluate');
@@ -393,8 +394,7 @@ class Module {
       this.services,
       filename,
       only,
-      code,
-      this.services.options.pluginOptions
+      code
     );
 
     if (newEntrypoint.evaluated) {

--- a/packages/babel/src/module.ts
+++ b/packages/babel/src/module.ts
@@ -21,14 +21,13 @@ import { invariant } from 'ts-invariant';
 import type { Debugger } from '@linaria/logger';
 
 import './utils/dispose-polyfill';
-import { TransformCacheCollection } from './cache';
+import type { TransformCacheCollection } from './cache';
 import { Entrypoint } from './transform/Entrypoint';
 import { getStack, isSuperSet } from './transform/Entrypoint.helpers';
 import type { IEntrypointDependency } from './transform/Entrypoint.types';
 import type { IEvaluatedEntrypoint } from './transform/EvaluatedEntrypoint';
 import { isUnprocessedEntrypointError } from './transform/actions/UnprocessedEntrypointError';
-import loadLinariaOptions from './transform/helpers/loadLinariaOptions';
-import { withDefaultServices } from './transform/helpers/withDefaultServices';
+import type { Services } from './transform/types';
 import { createVmContext } from './vm/createVmContext';
 
 type HiddenModuleMembers = {
@@ -191,14 +190,17 @@ class Module {
 
   public resolve = resolve.bind(this);
 
+  private cache: TransformCacheCollection;
+
   #entrypointRef: WeakRef<Entrypoint>;
 
   constructor(
+    private services: Services,
     entrypoint: Entrypoint,
-    private cache = new TransformCacheCollection(),
     parentModule?: Module,
     private moduleImpl: HiddenModuleMembers = DefaultModuleImplementation
   ) {
+    this.cache = services.cache;
     this.#entrypointRef = new WeakRef(entrypoint);
     this.idx = entrypoint.idx;
     this.id = entrypoint.name;
@@ -386,21 +388,13 @@ class Module {
 
     // If code wasn't extracted from cache, it indicates that we were unable
     // to process some of the imports on stage1. Let's try to reprocess.
-    const services = withDefaultServices({
-      cache: this.cache,
-      options: {
-        filename,
-      },
-    });
-
-    const pluginOptions = loadLinariaOptions({});
     const code = fs.readFileSync(filename, 'utf-8');
     const newEntrypoint = Entrypoint.createRoot(
-      services,
+      this.services,
       filename,
       only,
       code,
-      pluginOptions
+      this.services.options.pluginOptions
     );
 
     if (newEntrypoint.evaluated) {
@@ -469,7 +463,7 @@ class Module {
   };
 
   protected createChild(entrypoint: Entrypoint): Module {
-    return new Module(entrypoint, this.cache, this, this.moduleImpl);
+    return new Module(this.services, entrypoint, this, this.moduleImpl);
   }
 }
 

--- a/packages/babel/src/plugins/babel-transform.ts
+++ b/packages/babel/src/plugins/babel-transform.ts
@@ -6,6 +6,7 @@ import { syncResolve } from '@linaria/utils';
 import type { Core } from '../babel';
 import { TransformCacheCollection } from '../cache';
 import { transformSync } from '../transform';
+import loadLinariaOptions from '../transform/helpers/loadLinariaOptions';
 import type { ICollectAction, SyncScenarioForAction } from '../transform/types';
 import type { IPluginState, PluginOptions } from '../types';
 
@@ -40,6 +41,8 @@ export default function babelTransform(
 
       debug('babel-transform:start', file.opts.filename);
 
+      const pluginOptions = loadLinariaOptions(options);
+
       transformSync(
         {
           babel,
@@ -48,7 +51,7 @@ export default function babelTransform(
             filename: file.opts.filename!,
             root: file.opts.root ?? undefined,
             inputSourceMap: file.opts.inputSourceMap ?? undefined,
-            pluginOptions: options,
+            pluginOptions,
           },
         },
         file.code,

--- a/packages/babel/src/plugins/babel-transform.ts
+++ b/packages/babel/src/plugins/babel-transform.ts
@@ -7,11 +7,7 @@ import type { Core } from '../babel';
 import { TransformCacheCollection } from '../cache';
 import { transformSync } from '../transform';
 import loadLinariaOptions from '../transform/helpers/loadLinariaOptions';
-import type {
-  ICollectAction,
-  Services,
-  SyncScenarioForAction,
-} from '../transform/types';
+import type { ICollectAction, SyncScenarioForAction } from '../transform/types';
 import type { IPluginState, PluginOptions } from '../types';
 
 import { collector } from './collector';

--- a/packages/babel/src/plugins/babel-transform.ts
+++ b/packages/babel/src/plugins/babel-transform.ts
@@ -7,7 +7,11 @@ import type { Core } from '../babel';
 import { TransformCacheCollection } from '../cache';
 import { transformSync } from '../transform';
 import loadLinariaOptions from '../transform/helpers/loadLinariaOptions';
-import type { ICollectAction, SyncScenarioForAction } from '../transform/types';
+import type {
+  ICollectAction,
+  Services,
+  SyncScenarioForAction,
+} from '../transform/types';
 import type { IPluginState, PluginOptions } from '../types';
 
 import { collector } from './collector';
@@ -26,7 +30,8 @@ export default function babelTransform(
         this: ICollectAction
       ): SyncScenarioForAction<ICollectAction> {
         const { valueCache } = this.data;
-        const { loadedAndParsed, pluginOptions } = this.entrypoint;
+        const { loadedAndParsed } = this.entrypoint;
+        const { pluginOptions } = this.services.options;
         if (loadedAndParsed.evaluator === 'ignored') {
           throw new Error('entrypoint was ignored');
         }

--- a/packages/babel/src/transform.ts
+++ b/packages/babel/src/transform.ts
@@ -65,8 +65,7 @@ export function transformSync(
     services,
     options.filename,
     ['__linariaPreval'],
-    originalCode,
-    pluginOptions
+    originalCode
   );
 
   if (entrypoint.ignored) {
@@ -148,8 +147,7 @@ export default async function transform(
     services,
     options.filename,
     ['__linariaPreval'],
-    originalCode,
-    pluginOptions
+    originalCode
   );
 
   if (entrypoint.ignored) {

--- a/packages/babel/src/transform.ts
+++ b/packages/babel/src/transform.ts
@@ -20,6 +20,7 @@ import {
   asyncResolveImports,
   syncResolveImports,
 } from './transform/generators/resolveImports';
+import type { PartialOptions } from './transform/helpers/loadLinariaOptions';
 import loadLinariaOptions from './transform/helpers/loadLinariaOptions';
 import { withDefaultServices } from './transform/helpers/withDefaultServices';
 import type {
@@ -29,9 +30,11 @@ import type {
 } from './transform/types';
 import type { Result } from './types';
 
-type RequiredServices = 'options';
-type PartialServices = Partial<Omit<Services, RequiredServices>> &
-  Pick<Services, RequiredServices>;
+type PartialServices = Partial<Omit<Services, 'options'>> & {
+  options: Omit<Services['options'], 'pluginOptions'> & {
+    pluginOptions?: PartialOptions;
+  };
+};
 
 type AllHandlers<TMode extends 'async' | 'sync'> = Handlers<TMode>;
 
@@ -41,9 +44,15 @@ export function transformSync(
   syncResolve: (what: string, importer: string, stack: string[]) => string,
   customHandlers: Partial<AllHandlers<'sync'>> = {}
 ): Result {
-  const services = withDefaultServices(partialServices);
-  const { options } = services;
+  const { options } = partialServices;
   const pluginOptions = loadLinariaOptions(options.pluginOptions);
+  const services = withDefaultServices({
+    ...partialServices,
+    options: {
+      ...options,
+      pluginOptions,
+    },
+  });
 
   if (
     !isFeatureEnabled(pluginOptions.features, 'globalCache', options.filename)
@@ -111,8 +120,14 @@ export default async function transform(
   customHandlers: Partial<AllHandlers<'sync'>> = {}
 ): Promise<Result> {
   const { options } = partialServices;
-  const services = withDefaultServices(partialServices);
   const pluginOptions = loadLinariaOptions(options.pluginOptions);
+  const services = withDefaultServices({
+    ...partialServices,
+    options: {
+      ...options,
+      pluginOptions,
+    },
+  });
 
   if (
     !isFeatureEnabled(pluginOptions.features, 'globalCache', options.filename)

--- a/packages/babel/src/transform/Entrypoint.helpers.ts
+++ b/packages/babel/src/transform/Entrypoint.helpers.ts
@@ -153,10 +153,13 @@ export function loadAndParse(
   services: Services,
   name: string,
   loadedCode: string | undefined,
-  log: Debugger,
-  pluginOptions: StrictOptions
+  log: Debugger
 ): IEntrypointCode | IIgnoredEntrypoint {
-  const { babel, eventEmitter } = services;
+  const {
+    babel,
+    eventEmitter,
+    options: { pluginOptions },
+  } = services;
 
   const extension = extname(name);
 

--- a/packages/babel/src/transform/Entrypoint.ts
+++ b/packages/babel/src/transform/Entrypoint.ts
@@ -1,7 +1,5 @@
 import { invariant } from 'ts-invariant';
 
-import type { StrictOptions } from '@linaria/utils';
-
 import type { ParentEntrypoint, ITransformFileResult } from '../types';
 
 import { BaseEntrypoint } from './BaseEntrypoint';
@@ -64,7 +62,6 @@ export class Entrypoint extends BaseEntrypoint {
     public readonly initialCode: string | undefined,
     name: string,
     only: string[],
-    public readonly pluginOptions: StrictOptions,
     exports: Record<string | symbol, unknown> | undefined,
     evaluatedOnly: string[],
     loadedAndParsed?: IEntrypointCode | IIgnoredEntrypoint,
@@ -83,8 +80,7 @@ export class Entrypoint extends BaseEntrypoint {
         services,
         name,
         initialCode,
-        parents[0]?.log ?? services.log,
-        pluginOptions
+        parents[0]?.log ?? services.log
       );
 
     if (this.loadedAndParsed.code !== undefined) {
@@ -121,17 +117,9 @@ export class Entrypoint extends BaseEntrypoint {
     services: Services,
     name: string,
     only: string[],
-    loadedCode: string | undefined,
-    pluginOptions: StrictOptions
+    loadedCode: string | undefined
   ): Entrypoint {
-    const created = Entrypoint.create(
-      services,
-      null,
-      name,
-      only,
-      loadedCode,
-      pluginOptions
-    );
+    const created = Entrypoint.create(services, null, name, only, loadedCode);
     invariant(created !== 'loop', 'loop detected');
 
     return created;
@@ -154,8 +142,7 @@ export class Entrypoint extends BaseEntrypoint {
     parent: ParentEntrypoint | null,
     name: string,
     only: string[],
-    loadedCode: string | undefined,
-    pluginOptions: StrictOptions
+    loadedCode: string | undefined
   ): Entrypoint | 'loop' {
     const { cache, eventEmitter } = services;
     return eventEmitter.perf('createEntrypoint', () => {
@@ -172,8 +159,7 @@ export class Entrypoint extends BaseEntrypoint {
           : null,
         name,
         only,
-        loadedCode,
-        pluginOptions
+        loadedCode
       );
 
       if (status !== 'cached') {
@@ -189,8 +175,7 @@ export class Entrypoint extends BaseEntrypoint {
     parent: ParentEntrypoint | null,
     name: string,
     only: string[],
-    loadedCode: string | undefined,
-    pluginOptions: StrictOptions
+    loadedCode: string | undefined
   ): ['loop' | 'created' | 'cached', Entrypoint] {
     const { cache } = services;
 
@@ -245,7 +230,6 @@ export class Entrypoint extends BaseEntrypoint {
       loadedCode,
       name,
       mergedOnly,
-      pluginOptions,
       exports,
       evaluatedOnly,
       undefined,
@@ -330,14 +314,7 @@ export class Entrypoint extends BaseEntrypoint {
     only: string[],
     loadedCode?: string
   ): Entrypoint | 'loop' {
-    return Entrypoint.create(
-      this.services,
-      this,
-      name,
-      only,
-      loadedCode,
-      this.pluginOptions
-    );
+    return Entrypoint.create(this.services, this, name, only, loadedCode);
   }
 
   public createEvaluated() {
@@ -405,7 +382,6 @@ export class Entrypoint extends BaseEntrypoint {
             this.initialCode,
             this.name,
             newOnlyOrEntrypoint,
-            this.pluginOptions,
             this.exports,
             this.evaluatedOnly,
             this.loadedAndParsed,

--- a/packages/babel/src/transform/Entrypoint.types.ts
+++ b/packages/babel/src/transform/Entrypoint.types.ts
@@ -2,7 +2,7 @@ import type { TransformOptions } from '@babel/core';
 import type { File } from '@babel/types';
 
 import type { Debugger } from '@linaria/logger';
-import type { Evaluator, StrictOptions } from '@linaria/utils';
+import type { Evaluator } from '@linaria/utils';
 
 import type { Services } from './types';
 
@@ -30,6 +30,5 @@ export type LoadAndParseFn = (
   services: Services,
   name: string,
   loadedCode: string | undefined,
-  log: Debugger,
-  pluginOptions: StrictOptions
+  log: Debugger
 ) => IEntrypointCode | IIgnoredEntrypoint;

--- a/packages/babel/src/transform/__tests__/entrypoint-helpers.ts
+++ b/packages/babel/src/transform/__tests__/entrypoint-helpers.ts
@@ -1,7 +1,6 @@
 import * as babel from '@babel/core';
 import type { File } from '@babel/types';
 
-import type { StrictOptions } from '@linaria/utils';
 import { EventEmitter } from '@linaria/utils';
 
 import { TransformCacheCollection } from '../../cache';
@@ -70,13 +69,7 @@ export const createEntrypoint = (
   only: string[],
   code?: string
 ) => {
-  const entrypoint = Entrypoint.createRoot(
-    services,
-    name,
-    only,
-    code,
-    services.options.pluginOptions as StrictOptions
-  );
+  const entrypoint = Entrypoint.createRoot(services, name, only, code);
 
   if (entrypoint.ignored) {
     throw new Error('entrypoint was ignored');

--- a/packages/babel/src/transform/generators/collect.ts
+++ b/packages/babel/src/transform/generators/collect.ts
@@ -17,7 +17,7 @@ export function* collect(
   const { babel, options } = this.services;
   const { valueCache } = this.data;
   const { entrypoint } = this;
-  const { loadedAndParsed, name, pluginOptions } = entrypoint;
+  const { loadedAndParsed, name } = entrypoint;
 
   if (loadedAndParsed.evaluator === 'ignored') {
     throw new Error('entrypoint was ignored');
@@ -27,7 +27,7 @@ export function* collect(
     [
       collectorPlugin,
       {
-        ...pluginOptions,
+        ...options.pluginOptions,
         values: valueCache,
       },
     ],

--- a/packages/babel/src/transform/generators/evalFile.ts
+++ b/packages/babel/src/transform/generators/evalFile.ts
@@ -31,7 +31,7 @@ export function* evalFile(
 
   while (evaluated === undefined) {
     try {
-      evaluated = evaluate(this.services.cache, entrypoint);
+      evaluated = evaluate(this.services, entrypoint);
     } catch (e) {
       if (isUnprocessedEntrypointError(e)) {
         entrypoint.log(

--- a/packages/babel/src/transform/helpers/loadLinariaOptions.ts
+++ b/packages/babel/src/transform/helpers/loadLinariaOptions.ts
@@ -23,7 +23,7 @@ const searchPlaces = [
 
 const explorerSync = cosmiconfigSync('linaria', { searchPlaces });
 
-type PartialOptions = Partial<Omit<PluginOptions, 'features'>> & {
+export type PartialOptions = Partial<Omit<PluginOptions, 'features'>> & {
   features?: Partial<FeatureFlags>;
 };
 

--- a/packages/babel/src/transform/types.ts
+++ b/packages/babel/src/transform/types.ts
@@ -2,7 +2,12 @@ import type { BabelFileResult } from '@babel/core';
 
 import type { Debugger } from '@linaria/logger';
 import type { ValueCache } from '@linaria/tags';
-import type { EventEmitter, Artifact, LinariaMetadata } from '@linaria/utils';
+import type {
+  EventEmitter,
+  Artifact,
+  LinariaMetadata,
+  StrictOptions,
+} from '@linaria/utils';
 
 import type { Core } from '../babel';
 import type { TransformCacheCollection } from '../cache';
@@ -23,7 +28,9 @@ export type Services = {
   eventEmitter: EventEmitter;
   loadAndParseFn: LoadAndParseFn;
   log: Debugger;
-  options: Options;
+  options: Options & {
+    pluginOptions: StrictOptions;
+  };
 };
 
 export interface IBaseNode {

--- a/packages/testkit/src/module.test.ts
+++ b/packages/testkit/src/module.test.ts
@@ -67,7 +67,7 @@ const createEntrypoint = (
   only: string[],
   code: string
 ) => {
-  const entrypoint = Entrypoint.createRoot(services, name, only, code, options);
+  const entrypoint = Entrypoint.createRoot(services, name, only, code);
 
   if (entrypoint.ignored) {
     throw new Error('entrypoint was ignored');

--- a/packages/testkit/src/prepareCode.test.ts
+++ b/packages/testkit/src/prepareCode.test.ts
@@ -60,7 +60,7 @@ describe('prepareCode', () => {
       const sourceCode = restLines.join('\n');
       const services = withDefaultServices({
         babel,
-        options: { root, filename: inputFilePath },
+        options: { root, filename: inputFilePath, pluginOptions },
       });
       const entrypoint = Entrypoint.createRoot(
         services,

--- a/packages/testkit/src/prepareCode.test.ts
+++ b/packages/testkit/src/prepareCode.test.ts
@@ -10,7 +10,6 @@ import {
   prepareCode,
   withDefaultServices,
 } from '@linaria/babel-preset';
-import { EventEmitter } from '@linaria/utils';
 
 const testCasesDir = join(__dirname, '__fixtures__', 'prepare-code-test-cases');
 
@@ -66,8 +65,7 @@ describe('prepareCode', () => {
         services,
         inputFilePath,
         only,
-        sourceCode,
-        pluginOptions
+        sourceCode
       );
 
       if (entrypoint.ignored) {
@@ -78,10 +76,9 @@ describe('prepareCode', () => {
       });
 
       const [transformedCode, imports, metadata] = prepareCode(
-        babel,
+        services,
         entrypoint,
-        ast,
-        EventEmitter.dummy
+        ast
       );
 
       expect(transformedCode).toMatchSnapshot('code');


### PR DESCRIPTION
## Motivation

In some cases `pluginOptions` can be lost.

## Summary

Now, the actual version of `pluginOptions` is stored in the Services collection. `pluginOptions` from `Entrypoint` has been deleted.
