### PR TITLE
fix(react): unexpected token in @linaria/react

### DIFF
--- a/.changeset/fifty-plums-poke.md
+++ b/.changeset/fifty-plums-poke.md
@@ -1,0 +1,5 @@
+---
+'@linaria/react': patch
+---
+
+Fix compatibility with Webpack 4.

--- a/packages/react/src/styled.ts
+++ b/packages/react/src/styled.ts
@@ -139,7 +139,7 @@ function styled(tag: any): any {
   if (process.env.NODE_ENV === 'test') {
     // eslint-disable-next-line no-plusplus
     mockedClass += `mocked-styled-${idx++}`;
-    if (tag?.__linaria?.className) {
+    if (tag && tag.__linaria && tag.__linaria.className) {
       mockedClass += ` ${tag.__linaria.className}`;
     }
   }


### PR DESCRIPTION
## Motivation

Old babel-loader in webpack 4 has problems with parsing `@linaria/react`

## Summary

The nullish coalescing operator has been replaced with good old &&.
