### PR TITLE
feat: upgrade stylis to v4

### DIFF
--- a/.changeset/grumpy-flowers-watch.md
+++ b/.changeset/grumpy-flowers-watch.md
@@ -1,0 +1,7 @@
+---
+'@linaria/atomic': patch
+'@linaria/babel-preset': patch
+'@linaria/testkit': patch
+---
+
+Stylis has been upgraded from v3 to v4.

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -56,12 +56,13 @@
     "@linaria/utils": "workspace:^",
     "known-css-properties": "^0.24.0",
     "postcss": "^8.4.31",
-    "stylis": "^3.5.4",
+    "stylis": "^4.3.0",
     "ts-invariant": "^0.10.3"
   },
   "devDependencies": {
     "@babel/types": "^7.22.15",
-    "@types/node": "^17.0.39"
+    "@types/node": "^17.0.39",
+    "@types/stylis": "^4.2.1"
   },
   "peerDependencies": {
     "react": ">=16"

--- a/packages/atomic/src/processors/helpers/atomize.ts
+++ b/packages/atomic/src/processors/helpers/atomize.ts
@@ -1,7 +1,7 @@
 import { all as knownProperties } from 'known-css-properties';
 import type { Document, AtRule, Container, Rule } from 'postcss';
 import postcss from 'postcss';
-import stylis from 'stylis';
+import { compile, serialize, stringify } from 'stylis';
 
 import { slugify } from '@linaria/utils';
 
@@ -38,10 +38,6 @@ const parseCss = (cssText: string) => {
 };
 
 export default function atomize(cssText: string, hasPriority = false) {
-  stylis.set({
-    prefix: false,
-    keyframe: false,
-  });
   const atomicRules: {
     className?: string;
     cssText: string;
@@ -109,7 +105,8 @@ export default function atomize(cssText: string, hasPriority = false) {
       getPropertyPriority(decl.prop) +
       (hasAtRule ? 1 : 0) +
       (hasPriority ? 1 : 0);
-    const processedCss = stylis(`.${className}`.repeat(propertyPriority), css);
+    const selector = `.${className}`.repeat(propertyPriority);
+    const processedCss = serialize(compile(`${selector} {${css}}`), stringify);
 
     atomicRules.push({
       property: atomicProperty.join(' '),

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -47,7 +47,7 @@
     "cosmiconfig": "^8.0.0",
     "happy-dom": "10.8.0",
     "source-map": "^0.7.3",
-    "stylis": "^3.5.4",
+    "stylis": "^4.3.0",
     "ts-invariant": "^0.10.3"
   },
   "devDependencies": {
@@ -58,6 +58,7 @@
     "@types/babel__traverse": "^7.20.1",
     "@types/jest": "^28.1.0",
     "@types/node": "^17.0.39",
+    "@types/stylis": "^4.2.1",
     "dedent": "^1.5.1",
     "jest": "^29.6.2",
     "strip-ansi": "^5.2.0",

--- a/packages/testkit/src/__snapshots__/babel.test.ts.snap
+++ b/packages/testkit/src/__snapshots__/babel.test.ts.snap
@@ -96,8 +96,8 @@ exports[`strategy shaker compiles atomic css with at-rules and property prioriti
 
 CSS:
 
-@media (max-width:500px){.atm_1h9nsec_idpfg4.atm_1h9nsec_idpfg4{padding:0;}}
-@media (min-width:300px){.atm_7xgmf7_14y27yu.atm_7xgmf7_14y27yu.atm_7xgmf7_14y27yu:hover{padding-top:5px;}}
+@media (max-width: 500px){.atm_1h9nsec_idpfg4.atm_1h9nsec_idpfg4{padding:0;}}
+@media (min-width: 300px){.atm_7xgmf7_14y27yu.atm_7xgmf7_14y27yu.atm_7xgmf7_14y27yu:hover{padding-top:5px;}}
 .atm_ci1k5c_i2wt44.atm_ci1k5c_i2wt44:enabled{padding-left:6px;}
 .atm_le_1v6z61t.atm_le_1v6z61t{padding-bottom:7px;}
 
@@ -116,8 +116,8 @@ exports[`strategy shaker compiles atomic css with at-rules and pseudo classes 2`
 
 CSS:
 
-@media (max-width:500px){.atm_1apu8aw_13q2bts.atm_1apu8aw_13q2bts{background:blue;}}
-@media (min-width:300px){.atm_1yli2by_1cnho6b.atm_1yli2by_1cnho6b:hover{background:purple;}}
+@media (max-width: 500px){.atm_1apu8aw_13q2bts.atm_1apu8aw_13q2bts{background:blue;}}
+@media (min-width: 300px){.atm_1yli2by_1cnho6b.atm_1yli2by_1cnho6b:hover{background:purple;}}
 .atm_1hwwax4_1osqo2v:enabled{width:100%;}
 .atm_26_5scuol{background:red;}
 .atm_e2_12xxubj{height:100px;}
@@ -1483,7 +1483,7 @@ exports[`strategy shaker handles interpolation in css function followed by unit 
 CSS:
 
 .atm_tr_18309cv{transform:rotate(var(--y6125t));}
-.atm_vy_1783zgq{width:200;px;}
+.atm_vy_1783zgq{width:200 px;}
 
 Dependencies: NA
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,7 +240,7 @@ importers:
         version: link:../../packages/vite
       babel-preset-solid:
         specifier: ^1.6.2
-        version: 1.6.2(@babel/core@7.22.15)
+        version: 1.6.2(@babel/core@7.23.2)
       compression:
         specifier: ^1.7.4
         version: 1.7.4
@@ -327,8 +327,8 @@ importers:
         specifier: '>=16'
         version: 16.14.0
       stylis:
-        specifier: ^3.5.4
-        version: 3.5.4
+        specifier: ^4.3.0
+        version: 4.3.0
       ts-invariant:
         specifier: ^0.10.3
         version: 0.10.3
@@ -339,6 +339,9 @@ importers:
       '@types/node':
         specifier: ^17.0.39
         version: 17.0.39
+      '@types/stylis':
+        specifier: ^4.2.1
+        version: 4.2.1
 
   packages/babel:
     dependencies:
@@ -385,8 +388,8 @@ importers:
         specifier: ^0.7.3
         version: 0.7.3
       stylis:
-        specifier: ^3.5.4
-        version: 3.5.4
+        specifier: ^4.3.0
+        version: 4.3.0
       ts-invariant:
         specifier: ^0.10.3
         version: 0.10.3
@@ -412,6 +415,9 @@ importers:
       '@types/node':
         specifier: ^17.0.39
         version: 17.0.39
+      '@types/stylis':
+        specifier: ^4.2.1
+        version: 4.2.1
       dedent:
         specifier: ^1.5.1
         version: 1.5.1
@@ -1449,6 +1455,29 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/core@7.23.2:
+    resolution: {integrity: sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@ampproject/remapping': 2.2.1
+      '@babel/code-frame': 7.22.13
+      '@babel/generator': 7.23.0
+      '@babel/helper-compilation-targets': 7.22.15
+      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.23.2)
+      '@babel/helpers': 7.23.2
+      '@babel/parser': 7.23.0
+      '@babel/template': 7.22.15
+      '@babel/traverse': 7.23.2
+      '@babel/types': 7.23.0
+      convert-source-map: 2.0.0
+      debug: 4.3.4
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/eslint-parser@7.22.15(@babel/core@7.22.15)(eslint@8.48.0):
     resolution: {integrity: sha512-yc8OOBIQk1EcRrpizuARSQS0TWAcOMpEJ1aafhNznaeYkeL+OhqnDObGFylB8ka8VFF/sZc+S4RzHyO+3LjQxg==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
@@ -1488,6 +1517,16 @@ packages:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.18
       jsesc: 2.5.2
+
+  /@babel/generator@7.23.0:
+    resolution: {integrity: sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.23.0
+      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/trace-mapping': 0.3.19
+      jsesc: 2.5.2
+    dev: false
 
   /@babel/helper-annotate-as-pure@7.18.6:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
@@ -1593,6 +1632,11 @@ packages:
     resolution: {integrity: sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==}
     engines: {node: '>=6.9.0'}
 
+  /@babel/helper-environment-visitor@7.22.20:
+    resolution: {integrity: sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==}
+    engines: {node: '>=6.9.0'}
+    dev: false
+
   /@babel/helper-environment-visitor@7.22.5:
     resolution: {integrity: sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==}
     engines: {node: '>=6.9.0'}
@@ -1611,6 +1655,14 @@ packages:
     dependencies:
       '@babel/template': 7.22.15
       '@babel/types': 7.22.5
+
+  /@babel/helper-function-name@7.23.0:
+    resolution: {integrity: sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.22.15
+      '@babel/types': 7.23.0
+    dev: false
 
   /@babel/helper-hoist-variables@7.22.5:
     resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
@@ -1677,6 +1729,20 @@ packages:
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.15
+
+  /@babel/helper-module-transforms@7.23.0(@babel/core@7.23.2):
+    resolution: {integrity: sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.23.2
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-module-imports': 7.22.15
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-validator-identifier': 7.22.20
+    dev: false
 
   /@babel/helper-optimise-call-expression@7.18.6:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
@@ -1782,6 +1848,11 @@ packages:
     resolution: {integrity: sha512-4E/F9IIEi8WR94324mbDUMo074YTheJmd7eZF5vITTeYchqAi6sYXRLHUVsmkdmY4QjfKTcB2jB7dVP3NaBElQ==}
     engines: {node: '>=6.9.0'}
 
+  /@babel/helper-validator-identifier@7.22.20:
+    resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
+    engines: {node: '>=6.9.0'}
+    dev: false
+
   /@babel/helper-validator-identifier@7.22.5:
     resolution: {integrity: sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==}
     engines: {node: '>=6.9.0'}
@@ -1821,6 +1892,17 @@ packages:
       '@babel/types': 7.22.15
     transitivePeerDependencies:
       - supports-color
+
+  /@babel/helpers@7.23.2:
+    resolution: {integrity: sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.22.15
+      '@babel/traverse': 7.23.2
+      '@babel/types': 7.23.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@babel/highlight@7.22.10:
     resolution: {integrity: sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==}
@@ -1879,6 +1961,14 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.22.5
+
+  /@babel/parser@7.23.0:
+    resolution: {integrity: sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.23.0
+    dev: false
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.22.15(@babel/core@7.22.15):
     resolution: {integrity: sha512-FB9iYlz7rURmRJyXRKEnalYPPdn87H5no108cyuQQyMwlpJ2SJtpIUBI27kdTin956pz+LPypkPVPUTlxOmrsg==}
@@ -2023,13 +2113,13 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.22.15):
+  /@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.23.2):
     resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.15
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
@@ -2982,6 +3072,24 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/traverse@7.23.2:
+    resolution: {integrity: sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.22.13
+      '@babel/generator': 7.23.0
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-function-name': 7.23.0
+      '@babel/helper-hoist-variables': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/parser': 7.23.0
+      '@babel/types': 7.23.0
+      debug: 4.3.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/types@7.20.2:
     resolution: {integrity: sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==}
     engines: {node: '>=6.9.0'}
@@ -3005,6 +3113,15 @@ packages:
       '@babel/helper-string-parser': 7.22.5
       '@babel/helper-validator-identifier': 7.22.5
       to-fast-properties: 2.0.0
+
+  /@babel/types@7.23.0:
+    resolution: {integrity: sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.20
+      to-fast-properties: 2.0.0
+    dev: false
 
   /@bcoe/v8-coverage@0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -3734,7 +3851,7 @@ packages:
       '@emotion/hash': 0.8.0
       csstype: 3.1.0
       rtl-css-js: 1.15.0
-      stylis: 4.1.1
+      stylis: 4.3.0
       tslib: 2.4.0
     dev: false
 
@@ -4771,6 +4888,10 @@ packages:
 
   /@types/stack-utils@2.0.1:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
+    dev: true
+
+  /@types/stylis@4.2.1:
+    resolution: {integrity: sha512-OSaMrXUKxVigGlKRrET39V2xdhzlztQ9Aqumn1WbCBKHOi9ry7jKSd7rkyj0GzmWaU960Rd+LpOFpLfx5bMQAg==}
     dev: true
 
   /@types/tapable@0.2.5:
@@ -5997,14 +6118,14 @@ packages:
       html-entities: 2.3.2
     dev: false
 
-  /babel-plugin-jsx-dom-expressions@0.35.4(@babel/core@7.22.15):
+  /babel-plugin-jsx-dom-expressions@0.35.4(@babel/core@7.23.2):
     resolution: {integrity: sha512-Ab8W+36+XcNpyb644K537MtuhZRssgE3hmZD/08a1Z99Xfnd38tR2BZaDl7yEQvvHrb46N+eje2YjIg4VGAfVQ==}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.15
+      '@babel/core': 7.23.2
       '@babel/helper-module-imports': 7.16.0
-      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.22.15)
+      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.23.2)
       '@babel/types': 7.22.5
       html-entities: 2.3.2
     dev: false
@@ -6117,13 +6238,13 @@ packages:
       babel-plugin-jsx-dom-expressions: 0.35.4(@babel/core@7.20.2)
     dev: false
 
-  /babel-preset-solid@1.6.2(@babel/core@7.22.15):
+  /babel-preset-solid@1.6.2(@babel/core@7.23.2):
     resolution: {integrity: sha512-5sFI34g7Jtp4r04YFWkuC1o+gnekBdPXQTJb5/6lmxi5YwzazVgKAXRwEAToC3zRaPyIYJbZUVLpOi5mDzPEuw==}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.15
-      babel-plugin-jsx-dom-expressions: 0.35.4(@babel/core@7.22.15)
+      '@babel/core': 7.23.2
+      babel-plugin-jsx-dom-expressions: 0.35.4(@babel/core@7.23.2)
     dev: false
 
   /babel-preset-solid@1.6.3(@babel/core@7.22.15):
@@ -7192,7 +7313,6 @@ packages:
 
   /convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
-    dev: true
 
   /cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
@@ -9536,7 +9656,7 @@ packages:
     requiresBuild: true
     dependencies:
       bindings: 1.5.0
-      nan: 2.17.0
+      nan: 2.18.0
     dev: false
     optional: true
 
@@ -13004,8 +13124,8 @@ packages:
       thenify-all: 1.6.0
     dev: true
 
-  /nan@2.17.0:
-    resolution: {integrity: sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==}
+  /nan@2.18.0:
+    resolution: {integrity: sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==}
     requiresBuild: true
     dev: false
     optional: true
@@ -15942,12 +16062,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /stylis@3.5.4:
-    resolution: {integrity: sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==}
-    dev: false
-
-  /stylis@4.1.1:
-    resolution: {integrity: sha512-lVrM/bNdhVX2OgBFNa2YJ9Lxj7kPzylieHd3TNjuGE0Re9JB7joL5VUKOVH1kdNNJTgGPpT8hmwIAPLaSyEVFQ==}
+  /stylis@4.3.0:
+    resolution: {integrity: sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ==}
     dev: false
 
   /sucrase@3.34.0:


### PR DESCRIPTION
## Motivation

Stylis v4 is faster than v3, and fixes misbehaviors in the older version regarding nested pseudo-classes.

Fixes #649 

## Summary

Update stylis in both the babel and atomic packages.

The changes are pretty straightforward. In the atomic package, rather than configure stylis keyframes/prefix, we simply omit those middlewares for the same effect.

This is a (slightly) breaking change, and the commit is marked as such. In particular, stylis v4 handles nested pseudo-classes differently from v3. The old version joined `.x { :is(.y) }` to `.x:is(.y)` whereas the new version separates them `.x :is(.y)`. The new behavior matches how SCSS and other preprocessors work. Linaria consumers will need to check and possibly update their styles for the new behavior.

## Test plan

Ran all the tests and updated snapshots:

- The babel snapshots updated in an innocuous way: the newer stylis includes a space where it didn't previously.

- The atomic snapshots updated in a way where something that was previously broken one way (`200;px`) is broken in a different way (`200 px`). Not a regression, so no reason to fix as part of this change.
