### PR TITLE
Fix the expressions in at-rule parameters and rules with functions

### DIFF
--- a/.changeset/lemon-parents-accept.md
+++ b/.changeset/lemon-parents-accept.md
@@ -1,0 +1,5 @@
+---
+'@linaria/postcss-linaria': patch
+---
+
+Fix the expressions in at-rule parameters and rules with functions. Fixes #1074

--- a/packages/postcss-linaria/src/stringify.ts
+++ b/packages/postcss-linaria/src/stringify.ts
@@ -83,6 +83,18 @@ class LinariaStringifier extends Stringifier {
     super(wrappedBuilder);
   }
 
+  public override atrule(node: AtRule, semicolon?: boolean) {
+    const { params } = node;
+
+    const expressionStrings = node.root().raws.linariaTemplateExpressions;
+    if (params.includes(placeholderText)) {
+      // eslint-disable-next-line no-param-reassign
+      node.params = substitutePlaceholders(params, expressionStrings);
+    }
+
+    super.atrule(node, semicolon);
+  }
+
   /** @inheritdoc */
   public override comment(node: Comment): void {
     const placeholderPattern = new RegExp(`^${placeholderText}:\\d+$`);

--- a/packages/postcss-linaria/src/stringify.ts
+++ b/packages/postcss-linaria/src/stringify.ts
@@ -7,6 +7,7 @@ import type {
   Builder,
   Declaration,
   Rule,
+  AtRule,
 } from 'postcss';
 import Stringifier from 'postcss/lib/stringifier';
 
@@ -23,7 +24,8 @@ const substitutePlaceholders = (
   const values = stringWithPlaceholders.split(' ');
   const temp: string[] = [];
   values.forEach((val) => {
-    let [, expressionIndexString] = val.split(placeholderText);
+    let [prefix, expressionIndexString] = val.split(placeholderText);
+    prefix = prefix.replace(/(\.|--|\/\*)$/, '');
     // if the val is 'pcss-lin10px', need to remove the px to get the placeholder number
     let suffix = '';
     while (
@@ -43,7 +45,7 @@ const substitutePlaceholders = (
       !Number.isNaN(expressionIndex) &&
       expressions[expressionIndex];
     if (expression) {
-      temp.push(expression + suffix);
+      temp.push(prefix + expression + suffix);
     } else {
       temp.push(val);
     }

--- a/packages/postcss-linaria/src/util.ts
+++ b/packages/postcss-linaria/src/util.ts
@@ -43,7 +43,7 @@ const isRuleSet = (sourceAsString: string, indexAfterExpression: number) => {
   let hasColonOutsideOfExpression = possibleRuleset.includes(':');
   if (hasFuncInExpression) {
     hasColonOutsideOfExpression =
-      possibleRuleset.lastIndexOf(':', indexOfOpenParenthesis) > 0 &&
+      possibleRuleset.lastIndexOf(':', indexOfOpenParenthesis) > 0 ||
       possibleRuleset.indexOf(':', indexOfClosedParenthesis) > 0;
   }
 
@@ -54,7 +54,7 @@ const isRuleSet = (sourceAsString: string, indexAfterExpression: number) => {
   );
 };
 
-export const placeholderText = 'pcss-lin';
+export const placeholderText = 'pcss_lin';
 
 export const createPlaceholder = (
   i: number,


### PR DESCRIPTION
## Motivation

Fixes #1074

## Summary

Cases:
```js
css`
  height: ${(props) => props.size}px;
  transform: translate(${tokens.spacing1}, calc(${tokens.spacing2} + ${tokens.spacing3}));

  @media (max-width: ${breakpoints.desktop}) {
    font-size: 1.15rem;
  }

  .${SomeStyle} & {
    align-items: center;
  }

  &.${SomeStyle} {
    align-items: center;
  }
`;
```