### PR TITLE
fix: Update wyw-in-js to 0.5.3

### DIFF
--- a/.changeset/quick-suns-help.md
+++ b/.changeset/quick-suns-help.md
@@ -1,0 +1,14 @@
+---
+'@linaria/atomic': minor
+'@linaria/core': minor
+'@linaria/babel-plugin-interop': minor
+'linaria': minor
+'@linaria/postcss-linaria': minor
+'@linaria/server': minor
+'@linaria/stylelint': minor
+'@linaria/stylelint-config-standard-linaria': minor
+'@linaria/testkit': minor
+'linaria-website': minor
+---
+
+Update wyw-in-js to 0.5.3


### PR DESCRIPTION
## Motivation

All packages should use wyw@0.5.2, not only `react`. Fixes #1407

## Summary

It's just the changeset.
