### PR TITLE
feat: added favicon icon

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <title>Linaria – zero-runtime CSS in JS library</title>
-
+  <link rel="icon" href="./assets/linaria-logomark.svg"  type="image/svg+xml">
   <link rel="stylesheet" type="text/css" href="/dist/styles.css">
 </head>
 


### PR DESCRIPTION
## problem
favicon icon is not present at title bar. checkout the below image

![image](https://github.com/user-attachments/assets/6a772ab8-4ae1-42d4-90da-5e63f9992282)

## solution
added the link tag inside the index.html and the image is lineria-logomark.svg from assets

## qns : 
There is bug inside CONTRIBUTING.md 
 - the link added with "How to Contribute to an Open Source Project on GitHub" is (https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github) which gives 404. 
 - should i fixed this one in the same branch or create the new one.
 correct link :  https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github 