### PR TITLE
refactor: remove strip-ansi

### DIFF
--- a/packages/stylelint/package.json
+++ b/packages/stylelint/package.json
@@ -31,14 +31,13 @@
   },
   "dependencies": {
     "@wyw-in-js/shared": "^0.5.3",
-    "@wyw-in-js/transform": "^0.5.3",
-    "strip-ansi": "^5.2.0"
+    "@wyw-in-js/transform": "^0.5.3"
   },
   "devDependencies": {
     "@types/node": "^17.0.39"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=16.11.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/stylelint/src/preprocessor.ts
+++ b/packages/stylelint/src/preprocessor.ts
@@ -1,7 +1,8 @@
+import { stripVTControlCharacters as stripAnsi } from 'node:util';
+
 import type { Replacements } from '@wyw-in-js/shared';
 import { asyncResolveFallback } from '@wyw-in-js/shared';
 import { transform } from '@wyw-in-js/transform';
-import stripAnsi from 'strip-ansi';
 
 type Errors = {
   [key: string]:

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -32,7 +32,6 @@
     "debug": "^4.3.4",
     "dedent": "^1.5.1",
     "esbuild": "^0.15.16",
-    "strip-ansi": "^5.2.0",
     "typescript": "^5.2.2"
   },
   "devDependencies": {
@@ -57,7 +56,7 @@
     "ts-jest": "^29.1.1"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=16.11.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/testkit/src/babel.test.ts
+++ b/packages/testkit/src/babel.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-restricted-syntax */
 import { readFileSync } from 'fs';
+import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import { dirname, join, resolve, sep } from 'path';
 
 import * as babel from '@babel/core';
@@ -23,7 +24,6 @@ import type {
   Stage,
 } from '@wyw-in-js/transform';
 import dedent from 'dedent';
-import stripAnsi from 'strip-ansi';
 
 import serializer from './__utils__/linaria-snapshot-serializer';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,8 +259,6 @@ importers:
         specifier: ^0.4.54
         version: 0.4.54(vite@3.2.10)
 
-  examples/vpssr-linaria-solid/dist/server: {}
-
   examples/webpack5:
     dependencies:
       linaria-website:
@@ -488,9 +486,6 @@ importers:
       '@wyw-in-js/transform':
         specifier: ^0.5.3
         version: 0.5.3
-      strip-ansi:
-        specifier: ^5.2.0
-        version: 5.2.0
     devDependencies:
       '@types/node':
         specifier: ^17.0.39
@@ -543,9 +538,6 @@ importers:
       esbuild:
         specifier: ^0.15.16
         version: 0.15.16
-      strip-ansi:
-        specifier: ^5.2.0
-        version: 5.2.0
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -4644,11 +4636,6 @@ packages:
     resolution: {integrity: sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==}
     engines: {node: '>=4'}
     dev: true
-
-  /ansi-regex@4.1.1:
-    resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==}
-    engines: {node: '>=6'}
-    dev: false
 
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -11258,6 +11245,7 @@ packages:
 
   /npmlog@4.1.2:
     resolution: {integrity: sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==}
+    deprecated: This package is no longer supported.
     requiresBuild: true
     dependencies:
       are-we-there-yet: 1.1.7
@@ -13378,13 +13366,6 @@ packages:
     dependencies:
       ansi-regex: 3.0.1
     dev: true
-
-  /strip-ansi@5.2.0:
-    resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
-    engines: {node: '>=6'}
-    dependencies:
-      ansi-regex: 4.1.1
-    dev: false
 
   /strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

One less dependency :D

## Summary

* Removes dependency on strip-ansi in favor of built-in util
* Bumps engines.node from 16.0.0 to 16.11.0

## Test plan

tests pass locally

```

 Tasks:    30 successful, 30 total
Cached:    10 cached, 30 total
  Time:    42.261s 
```
