### PR TITLE
fix: update JSX type for old React support

### DIFF
--- a/.changeset/early-mice-deliver.md
+++ b/.changeset/early-mice-deliver.md
@@ -1,0 +1,5 @@
+---
+'@linaria/react': patch
+---
+
+Update types to support old React

--- a/packages/react/src/styled.ts
+++ b/packages/react/src/styled.ts
@@ -107,25 +107,13 @@ interface IProps {
   style?: Record<string, string>;
 }
 
-// React <19
-declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace JSX {
-    interface IntrinsicElements {}
-  }
-}
-
-// React >=19
-declare module 'react' {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace JSX {
-    interface IntrinsicElements {}
-  }
-}
-
 let idx = 0;
 
-type IntrinsicElements = React.JSX.IntrinsicElements & JSX.IntrinsicElements;
+interface IntrinsicElements
+  // in newer react types JSX is moved under React namespace
+  // @ts-expect-error ts 2694
+  extends React.JSX.IntrinsicElements,
+    JSX.IntrinsicElements {}
 
 // Components with props are not allowed
 function styled(


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

better version of https://github.com/callstack/linaria/pull/1420 which modified external namespace globally
we see error like `Property 'children' is missing in type '...' but required in type 'Props'. (ts 2741)` everywhere in a project using React 17, although it's working fine with projects using React 18 and React 19

## Summary

<!--
Explain how your implementation works and your thoughts behind the solution.
It will help maintainers to review your PR.
You can skip it if PR is trivial.
-->

## Test plan

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->
