### PR TITLE
fix(ci): ensure tests for postcss-linaria run

### DIFF
--- a/packages/postcss-linaria/package.json
+++ b/packages/postcss-linaria/package.json
@@ -29,6 +29,7 @@
     "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "typecheck": "tsc --noEmit --composite false",
+    "test": "jest --config ../../jest.config.js --rootDir .",
     "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
   },
   "dependencies": {


### PR DESCRIPTION
😳 It appears that tests have not been running in CI for this project. This *does* reveal broken tests, which I will address in a follow up commit. For now, opening for visibility, and if someone else wants to pick up fixing the tests, by all means I welcome the help!

## Motivation
When using postcss-linaria as a customSyntax for `stylelint`, certain forms of JS interpolations are improperly transformed.

Example:

```typescript
// Before Fix

const SOME_INTERPOLATION = '--wow-neat-property-bro';
const myStyles = css`.foo {
  color: var(${SOME_INTERPOLATION});
}`


// After StyleLint Auto-Fix:
const SOME_INTERPOLATION = '--wow-neat-property-bro';
const myStyles = css`.foo {
  color: var(/* ${SOME_INTERPOLATION}:0 */);
}`

```

## Summary
In the current form of the PR, only "running the tests in CI"  has been addressed.

## Test plan
CI! We're gonna run the tests that test the code, on every PR. It'll be great.