### PR TITLE
chore: require Node >=20

### DIFF
--- a/.changeset/require-node-20.md
+++ b/.changeset/require-node-20.md
@@ -1,0 +1,5 @@
+---
+linaria: patch
+---
+
+Require Node.js `>=20` (aligned with WyW 1.x).

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
         include:
           - os: windows-latest
             node-version: 20.x

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ See [Configuration](https://wyw-in-js.dev/configuration) to customize how Linari
 
 Linaria relies on WyW (`@wyw-in-js/*`) to evaluate your modules at build time and extract CSS. If you hit issues like slow builds, invalidation storms, or unexpected code being executed during the build, it’s usually related to the WyW evaluation model and how your modules are structured.
 
+Linaria 7 requires Node.js `>=20` (WyW 1.x enforces this via `engines`).
+
 See https://wyw-in-js.dev/stability for practical guidance and common pitfalls.
 
 ## Syntax

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "typescript": "^5.2.2"
   },
   "engines": {
-    "node": ">=16.0.0",
+    "node": ">=20.0.0",
     "pnpm": "^9.0.0"
   },
   "packageManager": "pnpm@9.15.9+sha256.cf86a7ad764406395d4286a6d09d730711720acc6d93e9dce9ac7ac4dc4a28a7"

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,7 +68,7 @@
     "@types/node": "^17.0.39"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -34,7 +34,7 @@
     "dedent": "^1.5.1"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/linaria/package.json
+++ b/packages/linaria/package.json
@@ -50,7 +50,7 @@
     "@linaria/server": "workspace:^"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/postcss-linaria/package.json
+++ b/packages/postcss-linaria/package.json
@@ -48,7 +48,7 @@
     "postcss": "^8.4.31"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -79,7 +79,7 @@
     "react": ">=16"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -37,7 +37,7 @@
     "prettier": "^3.0.3"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/stylelint-config-standard-linaria/package.json
+++ b/packages/stylelint-config-standard-linaria/package.json
@@ -37,7 +37,7 @@
     "stylelint-config-standard": "^28.0.0"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/stylelint/package.json
+++ b/packages/stylelint/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^17.0.39"
   },
   "engines": {
-    "node": ">=16.11.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -56,7 +56,7 @@
     "ts-jest": "^29.1.1"
   },
   "engines": {
-    "node": ">=16.11.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Align Linaria 7.x support targets with WyW 1.x by requiring Node.js >=20 via `engines` and CI matrix.