### PR TITLE
test(react): cover strict TS options for styled

### DIFF
--- a/packages/react/__dtslint__/styled.ts
+++ b/packages/react/__dtslint__/styled.ts
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 import { css } from '@linaria/core';
 
-import { styled } from '../src';
+import { styled } from '..';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function isExtends<C, T>(arg1?: C, arg2?: T): C extends T ? 'extends' : never {

--- a/packages/react/__dtslint__/tsconfig.json
+++ b/packages/react/__dtslint__/tsconfig.json
@@ -8,6 +8,8 @@
     "noImplicitThis": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "noPropertyAccessFromIndexSignature": true,
     "noEmit": true,
 
     "baseUrl": "./"


### PR DESCRIPTION
Adds regression coverage for TS strict flags that previously broke `styled.div` (noPropertyAccessFromIndexSignature + noUncheckedIndexedAccess).

The dtslint test now targets the public entry (`types`) so it matches consumer behavior.