### PR TITLE
fix(react): support React 17 JSX typing

### DIFF
--- a/.changeset/react17-jsx-typing.md
+++ b/.changeset/react17-jsx-typing.md
@@ -1,0 +1,5 @@
+---
+'@linaria/react': patch
+---
+
+Fix TypeScript typings for React 17 projects using the automatic JSX runtime (`jsx: react-jsx`), so `styled.*` intrinsic components don’t incorrectly require `children`.

--- a/packages/react/__dtslint-react17__/index.d.ts
+++ b/packages/react/__dtslint-react17__/index.d.ts
@@ -1,0 +1,1 @@
+// dtslint expects an `index.d.ts` in the test folder.

--- a/packages/react/__dtslint-react17__/react17.tsx
+++ b/packages/react/__dtslint-react17__/react17.tsx
@@ -1,0 +1,8 @@
+import { styled } from '..';
+
+const Button = styled.button``;
+
+// Should not require `children` for intrinsic elements on React 17 projects.
+Button({});
+<Button />;
+<Button>ok</Button>;

--- a/packages/react/__dtslint-react17__/stubs/jsx-runtime.d.ts
+++ b/packages/react/__dtslint-react17__/stubs/jsx-runtime.d.ts
@@ -1,0 +1,17 @@
+declare module 'react/jsx-runtime' {
+  const Fragment: unknown;
+  function jsx(type: unknown, props: unknown, key?: unknown): unknown;
+  function jsxs(type: unknown, props: unknown, key?: unknown): unknown;
+}
+
+declare module 'react/jsx-dev-runtime' {
+  const Fragment: unknown;
+  function jsxDEV(
+    type: unknown,
+    props: unknown,
+    key: unknown,
+    isStaticChildren: boolean,
+    source: unknown,
+    self: unknown
+  ): unknown;
+}

--- a/packages/react/__dtslint-react17__/stubs/react17.d.ts
+++ b/packages/react/__dtslint-react17__/stubs/react17.d.ts
@@ -1,0 +1,27 @@
+// Minimal React 17-like type surface for dtslint.
+// It intentionally does NOT export a module-level `JSX` namespace.
+
+declare namespace React {
+  type ElementType = unknown;
+
+  interface CSSProperties {
+    [key: string]: unknown;
+  }
+
+  interface FunctionComponent<P = Record<string, unknown>> {
+    (props: P & { children?: unknown }): unknown;
+  }
+
+  function createElement(...args: unknown[]): unknown;
+}
+
+export = React;
+export as namespace React;
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      button: Record<string, unknown>;
+    }
+  }
+}

--- a/packages/react/__dtslint-react17__/tsconfig.eslint.json
+++ b/packages/react/__dtslint-react17__/tsconfig.eslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig.json"
+}

--- a/packages/react/__dtslint-react17__/tsconfig.json
+++ b/packages/react/__dtslint-react17__/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": ["es6"],
+    "target": "ES2015",
+    "jsx": "react-jsx",
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "types": [],
+    "noEmit": true,
+    "baseUrl": "./",
+    "paths": {
+      "react": ["./stubs/react17.d.ts"],
+      "react/jsx-runtime": ["./stubs/jsx-runtime.d.ts"],
+      "react/jsx-dev-runtime": ["./stubs/jsx-runtime.d.ts"]
+    }
+  }
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -53,7 +53,7 @@
     "build:declarations": "tsc --emitDeclarationOnly --outDir types",
     "build:dist": "tsup --format cjs,esm",
     "test": "jest --config ../../jest.config.js --rootDir .",
-    "test:dts": "dtslint --localTs ../../node_modules/typescript/lib __dtslint__",
+    "test:dts": "dtslint --localTs ../../node_modules/typescript/lib __dtslint__ && dtslint --localTs ../../node_modules/typescript/lib __dtslint-react17__",
     "typecheck": "tsc --noEmit --composite false",
     "watch": "pnpm build:dist --watch & pnpm build:declarations --watch"
   },

--- a/packages/react/src/styled.ts
+++ b/packages/react/src/styled.ts
@@ -107,16 +107,7 @@ interface IProps {
   style?: Record<string, string>;
 }
 
-// React <19
 declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace JSX {
-    interface IntrinsicElements {}
-  }
-}
-
-// React >=19
-declare module 'react' {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
     interface IntrinsicElements {}
@@ -125,7 +116,16 @@ declare module 'react' {
 
 let idx = 0;
 
-type IntrinsicElements = React.JSX.IntrinsicElements & JSX.IntrinsicElements;
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+type ReactIntrinsicElements = typeof import('react') extends {
+  JSX: { IntrinsicElements: infer T };
+}
+  ? T
+  : never;
+
+type IntrinsicElements = [ReactIntrinsicElements] extends [never]
+  ? JSX.IntrinsicElements
+  : ReactIntrinsicElements;
 
 // Components with props are not allowed
 function styled(

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -7,5 +7,6 @@
       "node"
     ],
   },
+  "include": ["src"],
   "references": [{ "path": "../core" }]
 }


### PR DESCRIPTION
## Motivation

React 17 projects are currently hitting TS errors like:

- `Property 'children' is missing ...` (TS2741)

This is related to how `@linaria/react` wires up `JSX.IntrinsicElements` for `styled.*`.

This PR is a follow-up/superset of the discussion in `#1450`, but avoids relying on `@ts-expect-error` and adds a small regression test.

## Summary

- Avoid exporting an empty `react.JSX.IntrinsicElements` via module augmentation.
- Resolve intrinsic element props from `React.JSX.IntrinsicElements` only when React actually provides it; otherwise fall back to global `JSX.IntrinsicElements`.
- Add a minimal `dtslint` suite (`packages/react/__dtslint-react17__`) that simulates React 17 + `jsx: react-jsx` and asserts `styled.button` does not require `children`.
- Narrow `packages/react/tsconfig.json` to `include: ["src"]` so build/typecheck don’t accidentally pull in `__dtslint*` folders.

## Test plan

- `pnpm turbo run typecheck test:dts --filter @linaria/react`
- `pnpm lint`
