### PR TITLE
docs: clarify Linaria 7 requirements

### DIFF
--- a/.changeset/bump-wyw-1-0-x.md
+++ b/.changeset/bump-wyw-1-0-x.md
@@ -17,6 +17,7 @@ This release updates Linaria's build-time evaluation engine (WyW). See https://w
 
 Notes:
 
+- Linaria 7 requires Node.js 20+ (aligned with WyW 1.x).
 - If you import JSON from code that is evaluated by WyW, add `.json` to `extensions` and ensure `.json` is ignored by evaluation rules (so it's parsed as JSON, not by Babel).
 - Rollup users: WyW 1.x serializes `transform()` by default (`serializeTransform: true`). If you hit Rollup "Unexpected early exit" (unresolved plugin promises / deadlock during resolve), set `serializeTransform: false` (see `examples/rollup/rollup.config.mjs`).
 - WyW 1.x promotes fully-statically-evaluatable modules to `only: ['*']` and can re-evaluate modules when cached exports are incomplete (cached export values might not be reused).

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -7,6 +7,7 @@
 Linaria 7 updates the WyW toolchain (`@wyw-in-js/*`) to `^1.0.0` (stable). This affects build-time evaluation (CSS extraction) and can surface previously hidden issues in evaluated modules.
 
 - Review https://wyw-in-js.dev/stability for the evaluation model, common pitfalls, and performance guidance.
+- Linaria 7 requires Node.js 20+ (aligned with WyW 1.x).
 - If you rely on WyW cache internals, note that WyW 1.x can promote fully-statically-evaluatable modules to `only: ['*']` and may re-evaluate modules when cached exports are incomplete.
 - If you import JSON from code that is evaluated by WyW, add `.json` to `extensions` and ensure `.json` is ignored by evaluation rules (so it's parsed as JSON, not by Babel).
 - Rollup users on WyW 1.0.6: WyW serializes `transform()` by default; if you hit Rollup "Unexpected early exit" (unresolved plugin promises), try `serializeTransform: false` in the WyW Rollup plugin config.


### PR DESCRIPTION
Small release-train doc tweak for Linaria 7:

- Mention Node.js 20+ requirement (aligned with WyW 1.x) in `docs/MIGRATION_GUIDE.md`.
- Add the same note to the 7.0.0 major changeset `bump-wyw-1-0-x.md` so it shows up in release notes.
