### PR TITLE
fix(react): restore styled intrinsic typing

### DIFF
--- a/.changeset/fix-styled-jsx-intrinsics.md
+++ b/.changeset/fix-styled-jsx-intrinsics.md
@@ -1,0 +1,5 @@
+---
+"@linaria/react": patch
+---
+
+Fix `styled.<tag>` typings in environments where only the React JSX runtime types are available (e.g. `jsx: react-jsx`).

--- a/packages/react/src/styled.ts
+++ b/packages/react/src/styled.ts
@@ -116,16 +116,16 @@ declare global {
 
 let idx = 0;
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-type ReactIntrinsicElements = typeof import('react') extends {
-  JSX: { IntrinsicElements: infer T };
-}
-  ? T
-  : never;
+type GlobalJSXIntrinsicElements = JSX.IntrinsicElements;
 
-type IntrinsicElements = [ReactIntrinsicElements] extends [never]
-  ? JSX.IntrinsicElements
-  : ReactIntrinsicElements;
+declare module 'react' {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace JSX {
+    interface IntrinsicElements extends GlobalJSXIntrinsicElements {}
+  }
+}
+
+type IntrinsicElements = React.JSX.IntrinsicElements;
 
 // Components with props are not allowed
 function styled(


### PR DESCRIPTION
Fixes a TS native preview (tsgo) regression where `styled.div` / `styled.<tag>` is missing because `IntrinsicElements` resolves incorrectly.

- Ensure `React.JSX.IntrinsicElements` is always populated by augmenting React's `JSX.IntrinsicElements` from global `JSX.IntrinsicElements`.
- Use `React.JSX.IntrinsicElements` as the source of truth for `styled` intrinsics.

Includes a patch changeset for `@linaria/react`.
