### PR TITLE
fix(react): omit nullish dynamic style variables

### DIFF
--- a/.changeset/fix-nullish-styled-vars.md
+++ b/.changeset/fix-nullish-styled-vars.md
@@ -1,0 +1,5 @@
+---
+'@linaria/react': patch
+---
+
+Omit dynamic CSS custom properties when a runtime interpolation returns `null` or `undefined`.

--- a/packages/react/__tests__/styled.test.tsx
+++ b/packages/react/__tests__/styled.test.tsx
@@ -272,6 +272,37 @@ it('provides linaria component className for composition as last item in props.c
   expect(tree.toJSON()).toMatchSnapshot();
 });
 
+it('omits CSS variables with nullish runtime values', () => {
+  const Test = styled('div')({
+    name: 'TestComponent',
+    class: 'abcdefg',
+    vars: {
+      color: [(props: { color?: string }) => props.color],
+      missing: [(props: { missing?: string }) => props.missing],
+      nullable: [() => null],
+      width: [12, 'px'],
+      height: [() => undefined, 'px'],
+      zero: [0],
+      empty: [''],
+    },
+  });
+
+  const tree = renderer.create(
+    <Test color="tomato" style={{ marginTop: '4px' }}>
+      This is a test
+    </Test>
+  );
+  const json = tree.toJSON();
+
+  expect(json.props.style).toEqual({
+    '--color': 'tomato',
+    '--width': '12px',
+    '--zero': '0',
+    '--empty': '',
+    marginTop: '4px',
+  });
+});
+
 it('throws when using as tag for template literal', () => {
   // styled uses process.env.NODE_ENV to determine if it's running in a test environment
   const nodeEnv = process.env.NODE_ENV;

--- a/packages/react/src/styled.ts
+++ b/packages/react/src/styled.ts
@@ -22,6 +22,8 @@ type Component<TProps> =
 
 type Has<T, TObj> = [T] extends [TObj] ? T : T & TObj;
 
+type CSSVariableValue = string | number | null | void;
+
 type Options = {
   atomic?: boolean;
   class: string;
@@ -29,7 +31,7 @@ type Options = {
   propsAsIs: boolean;
   vars?: {
     [key: string]: [
-      string | number | ((props: unknown) => string | number),
+      CSSVariableValue | ((props: unknown) => CSSVariableValue),
       string | void,
     ];
   };
@@ -209,9 +211,11 @@ function styled(tag: any): any {
           const unit = variable[1] || '';
           const value = typeof result === 'function' ? result(props) : result;
 
-          warnIfInvalid(value, options.name);
+          if (value != null) {
+            warnIfInvalid(value, options.name);
 
-          style[`--${name}`] = `${value}${unit}`;
+            style[`--${name}`] = `${value}${unit}`;
+          }
         }
 
         const ownStyle = filteredProps.style || {};


### PR DESCRIPTION
Fixes #1072.

## Summary
- Skip `null` and `undefined` dynamic `styled` interpolation results when building inline CSS custom properties.
- Preserve other falsy runtime values such as `0` and empty strings.
- Add a regression test and a patch changeset for `@linaria/react`.

## Validation
- `pnpm --filter @linaria/react test -- styled.test.tsx`
- `pnpm --filter @linaria/react typecheck`
- `pnpm check:all`