### PR TITLE
fix(postcss): mark template CSS for Stylelint

### DIFF
--- a/.changeset/fix-stylelint-template-lang.md
+++ b/.changeset/fix-stylelint-template-lang.md
@@ -1,0 +1,5 @@
+---
+'@linaria/postcss-linaria': patch
+---
+
+Mark extracted template CSS roots as `template-literal` so Stylelint 14 rules can lint top-level declarations.

--- a/packages/postcss-linaria/__tests__/stylelint.test.ts
+++ b/packages/postcss-linaria/__tests__/stylelint.test.ts
@@ -6,6 +6,7 @@ import stylelint, { type Config } from 'stylelint';
 // so just import the config directly here
 // eslint-disable-next-line import/no-relative-packages
 import config from '../../stylelint-config-standard-linaria/src';
+import postcssLinaria from '../src';
 
 // note: need to run pnpm install to pick up updates from any parse/stringify changes
 describe('stylelint', () => {
@@ -116,6 +117,37 @@ describe('stylelint', () => {
               .foo { \${expr2}: black; }
             \`;"
     `);
+  });
+
+  it('should lint top-level declarations as template literal CSS', async () => {
+    const source = `
+import { css } from '@linaria/core';
+
+const responsiveWidth = css\`
+test: 1px;
+\`;
+`;
+    const result = await stylelint.lint({
+      code: source,
+      config: {
+        ...config,
+        customSyntax: postcssLinaria,
+        rules: {
+          ...config.rules,
+          'property-no-unknown': true,
+        },
+      } as Config,
+      configBasedir,
+    });
+
+    expect(result.errored).toEqual(true);
+    expect(result.results[0]?.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          rule: 'property-no-unknown',
+        }),
+      ])
+    );
   });
 
   it('should be compatible with indentation rule', async () => {

--- a/packages/postcss-linaria/src/parse.ts
+++ b/packages/postcss-linaria/src/parse.ts
@@ -172,6 +172,11 @@ export const parse: Parser<Root | Document> = (
       map: false,
     }) as Root;
 
+    if (root.source) {
+      (root.source as typeof root.source & { lang?: string }).lang =
+        'template-literal';
+    }
+
     root.raws.linariaPrefixOffsets = prefixOffsets;
     root.raws.linariaTemplateExpressions = expressionStrings;
     root.raws.linariaBaseIndentations = baseIndentations;


### PR DESCRIPTION
Fixes #1266.

## Summary
- Mark extracted Linaria template CSS roots as `template-literal`.
- This lets Stylelint 14 treat top-level declarations inside `css` templates as standard CSS.
- Add a regression test for `property-no-unknown`.

## Validation
- `pnpm --filter @linaria/postcss-linaria test`
- `pnpm --filter @linaria/postcss-linaria typecheck`
- `pnpm --filter @linaria/postcss-linaria build`
- `pnpm check:all`