### PR TITLE
fix(react): improve specificity for styled lazy components

### DIFF
--- a/.changeset/lazy-styled-specificity.md
+++ b/.changeset/lazy-styled-specificity.md
@@ -1,0 +1,5 @@
+---
+"@linaria/react": patch
+---
+
+Increase selector specificity when styling React.lazy targets so wrapper styles can override lazy-loaded component CSS.

--- a/packages/react/src/processors/styled.ts
+++ b/packages/react/src/processors/styled.ts
@@ -106,6 +106,16 @@ type RawStringLiteral = StringLiteral & {
 
 const staticClassSelector = (className: string): string => `.${className}`;
 
+const isReactLazyValue = (value: unknown): boolean => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  return (
+    (value as { $$typeof?: unknown }).$$typeof === Symbol.for('react.lazy')
+  );
+};
+
 const isStaticStyledValue = (value: unknown): value is StaticStyledValue => {
   if (typeof value !== 'object' || value === null) {
     return false;
@@ -374,6 +384,10 @@ export default class StyledProcessor extends TaggedTemplateProcessor {
     while (hasEvalMeta(value)) {
       selector += `.${value.__wyw_meta.className}`;
       value = value.__wyw_meta.extends;
+    }
+
+    if (isReactLazyValue(value)) {
+      selector += `.${this.className}`;
     }
 
     rules[selector] = {

--- a/packages/testkit/src/babel.test.ts
+++ b/packages/testkit/src/babel.test.ts
@@ -1859,6 +1859,38 @@ describe('strategy shaker', () => {
     expect(metadata).toMatchSnapshot();
   });
 
+  it('adds specificity when wrapping a lazy component', async () => {
+    const { metadata } = await transform(
+      dedent`
+      import { styled } from '@linaria/react';
+
+      const lazy = (ctor) => ({
+        $$typeof: Symbol.for('react.lazy'),
+        _ctor: ctor,
+        _status: -1,
+        _result: null,
+      });
+
+      const Title = styled.h1\`
+        color: red;
+      \`;
+
+      const LazyTitle = lazy(() => Promise.resolve({ default: Title }));
+
+      export const BlueTitle = styled(LazyTitle)\`
+        color: blue;
+      \`;
+      `,
+      [evaluator]
+    );
+
+    const selector = Object.keys(metadata.wywInJS.rules ?? {}).find((rule) =>
+      rule.startsWith('.BlueTitle_')
+    );
+
+    expect(selector).toMatch(/^(\.BlueTitle_[^.]+)\1$/);
+  });
+
   it('handles indirect wrapping another styled component', async () => {
     const { code, metadata } = await transform(
       dedent`


### PR DESCRIPTION
Fixes #1415.

## Summary

- Detect React.lazy targets during styled extraction.
- Preserve wrapper override specificity by duplicating the generated wrapper class when the lazy target metadata cannot be resolved.
- Add a regression test for styling a lazy component.

## Why

Linaria normally emits chained selectors when styling another styled component, for example `.Wrapper.Base`, so wrapper styles can override base styles.

For React.lazy targets, the wrapped component metadata is hidden behind the lazy boundary and is not available synchronously during extraction. That left the wrapper rule with only one generated class, so CSS loaded later by the lazy chunk could override it.

## Validation

- `pnpm --filter @linaria/react test`
- `pnpm --filter @linaria/testkit test -- babel.test.ts -t "adds specificity when wrapping a lazy component"`
- pre-commit hook: `check:all`, `lint`, `sp:check`
