### PR TITLE
docs: update webpack dev server example

### DIFF
--- a/docs/BUNDLERS_INTEGRATION.md
+++ b/docs/BUNDLERS_INTEGRATION.md
@@ -155,7 +155,9 @@ module.exports = {
     ],
   },
   devServer: {
-    contentBase: [path.join(__dirname, 'public')],
+    static: {
+      directory: path.join(__dirname, 'public'),
+    },
     historyApiFallback: true,
   },
 };


### PR DESCRIPTION
Fixes #919.

Summary:
- Update the webpack dev server example to use `devServer.static.directory` instead of the removed `contentBase` option.

Checks:
- pnpm check:all