### PR TITLE
fix(atomic): include !important flag in atom value hash

### DIFF
--- a/.changeset/atomic-important-hash.md
+++ b/.changeset/atomic-important-hash.md
@@ -1,0 +1,5 @@
+---
+'@linaria/atomic': patch
+---
+
+Include the `!important` flag in atomic class name hashing. Previously, declarations differing only in importance (e.g. `color: red` and `color: red !important` in different files) produced the same `atm_*` class name while the emitted rule bodies differed, so whichever copy of the rule was loaded applied to every user of the atom — leaking `!important` to unrelated components and defeating their inline-style and cascade overrides. The flag now participates in the value slug (not the property slug, so `cx` deduplication semantics are unchanged), giving each variant its own class.

--- a/packages/atomic/src/processors/helpers/atomize.ts
+++ b/packages/atomic/src/processors/helpers/atomize.ts
@@ -97,7 +97,16 @@ export default function atomize(cssText: string, hasPriority = false) {
 
     const css = root.toString();
     const propertySlug = hashProperty([...atomicProperty].join(';'));
-    const valueSlug = slugify(decl.value);
+    // The `!important` flag lives in `decl.important`, not `decl.value`, but
+    // it is preserved in the emitted cssText — so it must participate in the
+    // value hash. Otherwise `color: red` and `color: red !important` in
+    // different files mint the same class name with divergent rule bodies,
+    // and the importance leaks between unrelated users of the atom. It must
+    // NOT go into the property slug: `cx` deduplicates atoms by property
+    // slug, and both declarations still target the same property.
+    const valueSlug = slugify(
+      decl.important ? `${decl.value} !important` : decl.value
+    );
     const className = `atm_${propertySlug}_${valueSlug}`;
 
     const propertyPriority =

--- a/packages/testkit/src/__snapshots__/babel.test.ts.snap
+++ b/packages/testkit/src/__snapshots__/babel.test.ts.snap
@@ -85,6 +85,25 @@ Dependencies: NA
 
 `;
 
+exports[`strategy shaker compiles atomic css with !important 1`] = `
+"/* @flow */
+
+const x = "atm_7l_5scuol";
+const y = "atm_7l_gn1xdo";
+console.log(x, y);"
+`;
+
+exports[`strategy shaker compiles atomic css with !important 2`] = `
+
+CSS:
+
+.atm_7l_5scuol{color:red;}
+.atm_7l_gn1xdo{color:red!important;}
+
+Dependencies: NA
+
+`;
+
 exports[`strategy shaker compiles atomic css with at-rules and property priorities 1`] = `
 "/* @flow */
 

--- a/packages/testkit/src/babel.test.ts
+++ b/packages/testkit/src/babel.test.ts
@@ -1201,6 +1201,39 @@ describe('strategy shaker', () => {
     expect(metadata).toMatchSnapshot();
   });
 
+  it('compiles atomic css with !important', async () => {
+    const { code, metadata } = await transform(
+      dedent`
+    /* @flow */
+
+    import { css } from '@linaria/atomic';
+
+    const x = css\`
+      color: red;
+    \`;
+
+    const y = css\`
+      color: red !important;
+    \`;
+
+    console.log(x, y);
+
+      `,
+      [evaluator]
+    );
+
+    // Declarations differing only in importance must not share an atom: the
+    // flag is preserved in the emitted rule body, so a shared class name
+    // would leak !important to every user of the non-important atom.
+    const xClasses = code.match(/const x = ["']([^"']+)["']/)?.[1];
+    const yClasses = code.match(/const y = ["']([^"']+)["']/)?.[1];
+    expect(xClasses).toBeTruthy();
+    expect(xClasses).not.toBe(yClasses);
+
+    expect(code).toMatchSnapshot();
+    expect(metadata).toMatchSnapshot();
+  });
+
   it('compiles atomic css with at-rules and pseudo classes', async () => {
     const { code, metadata } = await transform(
       dedent`


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

There is no existing issue for this. I searched the issue tracker and believe this is the first report, though I'm happy to open an issue first if you would prefer.

`@linaria/atomic` hashes atom class names using the declaration's property (plus ancestor selectors/at-rules) together with `slugify(decl.value)`. However, PostCSS stores the `!important` flag in `decl.important`, not in `decl.value`. As a result, the importance flag is excluded from the hash while still being preserved in the emitted CSS rule.

This means that two declarations differing only by `!important` generate the same class name despite having different rule bodies:

```ts
// fileA.ts
const a = css`
  color: red;
`;
// .atm_7l_5scuol { color: red; }

// fileB.ts
const b = css`
  color: red !important;
`;
// .atm_7l_5scuol { color: red !important; }  // same class name
```

In any bundler that code-splits CSS, each chunk emits its own copy of the rule. Since both rules share the same class name, whichever version is loaded ultimately applies to every element using that class. Consequently, a single component's `!important` declaration can silently affect all unrelated consumers of the non-important atom, defeating expected cascade behavior and inline style overrides.

Because the property and value are otherwise identical, the problem is difficult to detect. It only becomes visible when another rule or inline style unexpectedly loses to the leaked `!important`, and the behavior varies with CSS chunk load order (for example, route or navigation order). In practice, this manifests as intermittent, difficult-to-reproduce styling regressions that appear isolated to individual components, which may explain why the issue has not been reported previously.

We encountered this in production in a large Next.js application. Across our CSS output, 36 atom classes were emitted with divergent rule bodies under the same hashed class name. The resulting symptoms appeared as several unrelated visual regressions—including buttons losing variant padding and inputs losing their intended font size—that depended entirely on which pages a user had visited first.

## Summary

The fix incorporates the `!important` flag into the value slug generated by `atomize()`:

```ts
const valueSlug = slugify(decl.important ? `${decl.value} !important` : decl.value);
```

Importantly, this modifies the **value slug**, not the property slug. `cx` deduplicates atoms using the property-slug segment of the class name, and both declarations still target the same CSS property. With this change, `cx(plain, important)` continues to collapse to a single atom (last one wins), preserving the documented application-order semantics. Only the class identity is split, ensuring that each variant consistently maps to exactly one rule body.

No other behavior changes. The emitted `cssText` already preserved the `!important` flag; only the hash omitted it. All existing snapshots continue to pass unchanged, as none of the existing fixtures included an important atom.

## Test Plan

Added a regression test in `packages/testkit/src/babel.test.ts` (compiles atomic CSS with `!important`). Two `css` blocks that differ only by `!important` must now produce distinct class names. The test asserts this explicitly and includes snapshot coverage.

The new snapshot demonstrates the expected split (same property slug, distinct value slugs):

```css
.atm_7l_5scuol{color:red;}
.atm_7l_gn1xdo{color:red!important;}
```

Commands run:

```sh
pnpm install
pnpm turbo run test --filter=@linaria/testkit -- -t "atomic"
```

**Output**

- Tests: **14 passed** (138 skipped of 152 total)
- Snapshots: **2 written**, **26 passed**

The two newly written snapshots belong to the regression test. All 26 pre-existing snapshots pass unchanged, resulting in zero churn to existing fixtures.

**Real-world validation**

Applied this change as a `pnpm` patch to the production Next.js application described above. The number of atom classes with divergent rule bodies across generated CSS chunks dropped from **36** to **0**, with the only output difference being the expected split into distinct class names for affected `!important` declarations.
