### PR TITLE
chore(deps): remove unused package dependencies

### DIFF
--- a/.changeset/clean-unused-dependencies.md
+++ b/.changeset/clean-unused-dependencies.md
@@ -1,0 +1,8 @@
+---
+'@linaria/atomic': patch
+'@linaria/core': patch
+'@linaria/postcss-linaria': patch
+'@linaria/react': patch
+---
+
+Remove package dependencies that are no longer used by Linaria.

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -55,11 +55,9 @@
     "@wyw-in-js/shared": "2.1.0",
     "known-css-properties": "^0.24.0",
     "postcss": "^8.4.31",
-    "stylis": "^4.3.0",
-    "ts-invariant": "^0.10.3"
+    "stylis": "^4.3.0"
   },
   "devDependencies": {
-    "@babel/types": "^7.23.5",
     "@types/node": "^17.0.39",
     "@types/stylis": "^4.2.1"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,10 +61,6 @@
     "@wyw-in-js/processor-utils": "2.1.0"
   },
   "devDependencies": {
-    "@babel/traverse": "^7.23.5",
-    "@babel/types": "^7.23.5",
-    "@types/babel__core": "^7.20.5",
-    "@types/babel__traverse": "^7.20.4",
     "@types/node": "^17.0.39"
   },
   "engines": {

--- a/packages/postcss-linaria/package.json
+++ b/packages/postcss-linaria/package.json
@@ -33,14 +33,12 @@
     "watch": "pnpm build:lib --watch & pnpm build:esm --watch & pnpm build:declarations --watch"
   },
   "dependencies": {
-    "@babel/generator": "^7.23.5",
     "@babel/parser": "^7.23.5",
     "@babel/traverse": "^7.23.5",
     "stylelint": "^14.11.0"
   },
   "devDependencies": {
     "@babel/types": "^7.23.5",
-    "@types/babel__generator": "^7.6.7",
     "@types/babel__traverse": "^7.20.4",
     "postcss": "^8.4.31"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -64,12 +64,9 @@
     "@wyw-in-js/shared": "2.1.0",
     "minimatch": "^9.0.3",
     "react-html-attributes": "^1.4.6",
-    "resolve": "^1.22.8",
-    "ts-invariant": "^0.10.3"
+    "resolve": "^1.22.8"
   },
   "devDependencies": {
-    "@babel/types": "^7.23.5",
-    "@types/babel__core": "^7.20.5",
     "@types/node": "^17.0.39",
     "@types/react": ">=16",
     "react": "^16.14.0",

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -22,38 +22,22 @@
   },
   "dependencies": {
     "@babel/core": "^7.23.5",
-    "@babel/generator": "^7.23.5",
-    "@babel/traverse": "^7.23.5",
     "@linaria/react": "workspace:^",
-    "@swc/core": "^1.3.20",
-    "@wyw-in-js/processor-utils": "2.1.0",
     "@wyw-in-js/shared": "2.1.0",
     "@wyw-in-js/transform": "2.1.0",
-    "debug": "^4.3.4",
     "dedent": "^1.5.1",
-    "esbuild": "^0.15.16",
     "typescript": "^5.2.2"
   },
   "devDependencies": {
-    "@babel/plugin-syntax-jsx": "^7.23.3",
-    "@babel/plugin-syntax-typescript": "^7.23.3",
-    "@babel/plugin-transform-modules-commonjs": "^7.23.3",
-    "@babel/preset-typescript": "^7.23.3",
     "@babel/runtime": "^7.26.10",
-    "@babel/types": "^7.23.5",
     "@linaria/atomic": "workspace:^",
     "@linaria/core": "workspace:^",
     "@types/babel__core": "^7.20.5",
-    "@types/babel__generator": "^7.6.7",
-    "@types/babel__traverse": "^7.20.4",
-    "@types/debug": "^4.1.8",
     "@types/jest": "^28.1.0",
     "@types/node": "^17.0.39",
     "babel-plugin-istanbul": "^6.1.1",
-    "babel-plugin-module-resolver": "^4.1.0",
     "jest": "^29.6.2",
-    "linaria": "workspace:^",
-    "ts-jest": "^29.1.1"
+    "linaria": "workspace:^"
   },
   "engines": {
     "node": ">=22.12.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,13 +328,7 @@ importers:
       stylis:
         specifier: ^4.3.0
         version: 4.3.0
-      ts-invariant:
-        specifier: ^0.10.3
-        version: 0.10.3
     devDependencies:
-      '@babel/types':
-        specifier: ^7.23.5
-        version: 7.23.5
       '@types/node':
         specifier: ^17.0.39
         version: 17.0.39
@@ -348,18 +342,6 @@ importers:
         specifier: 2.1.0
         version: 2.1.0
     devDependencies:
-      '@babel/traverse':
-        specifier: ^7.23.5
-        version: 7.23.5
-      '@babel/types':
-        specifier: ^7.23.5
-        version: 7.23.5
-      '@types/babel__core':
-        specifier: ^7.20.5
-        version: 7.20.5
-      '@types/babel__traverse':
-        specifier: ^7.20.4
-        version: 7.20.4
       '@types/node':
         specifier: ^17.0.39
         version: 17.0.39
@@ -399,9 +381,6 @@ importers:
 
   packages/postcss-linaria:
     dependencies:
-      '@babel/generator':
-        specifier: ^7.23.5
-        version: 7.23.5
       '@babel/parser':
         specifier: ^7.23.5
         version: 7.23.5
@@ -415,9 +394,6 @@ importers:
       '@babel/types':
         specifier: ^7.23.5
         version: 7.23.5
-      '@types/babel__generator':
-        specifier: ^7.6.7
-        version: 7.6.7
       '@types/babel__traverse':
         specifier: ^7.20.4
         version: 7.20.4
@@ -448,16 +424,7 @@ importers:
       resolve:
         specifier: ^1.22.8
         version: 1.22.8
-      ts-invariant:
-        specifier: ^0.10.3
-        version: 0.10.3
     devDependencies:
-      '@babel/types':
-        specifier: ^7.23.5
-        version: 7.23.5
-      '@types/babel__core':
-        specifier: ^7.20.5
-        version: 7.20.5
       '@types/node':
         specifier: ^17.0.39
         version: 17.0.39
@@ -514,58 +481,25 @@ importers:
       '@babel/core':
         specifier: ^7.23.5
         version: 7.23.5
-      '@babel/generator':
-        specifier: ^7.23.5
-        version: 7.23.5
-      '@babel/traverse':
-        specifier: ^7.23.5
-        version: 7.23.5
       '@linaria/react':
         specifier: workspace:^
         version: link:../react
-      '@swc/core':
-        specifier: ^1.3.20
-        version: 1.3.20
-      '@wyw-in-js/processor-utils':
-        specifier: 2.1.0
-        version: 2.1.0
       '@wyw-in-js/shared':
         specifier: 2.1.0
         version: 2.1.0
       '@wyw-in-js/transform':
         specifier: 2.1.0
         version: 2.1.0(typescript@5.2.2)
-      debug:
-        specifier: ^4.3.4
-        version: 4.3.4
       dedent:
         specifier: ^1.5.1
         version: 1.5.1
-      esbuild:
-        specifier: ^0.15.16
-        version: 0.15.16
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
     devDependencies:
-      '@babel/plugin-syntax-jsx':
-        specifier: ^7.23.3
-        version: 7.23.3(@babel/core@7.23.5)
-      '@babel/plugin-syntax-typescript':
-        specifier: ^7.23.3
-        version: 7.23.3(@babel/core@7.23.5)
-      '@babel/plugin-transform-modules-commonjs':
-        specifier: ^7.23.3
-        version: 7.23.3(@babel/core@7.23.5)
-      '@babel/preset-typescript':
-        specifier: ^7.23.3
-        version: 7.23.3(@babel/core@7.23.5)
       '@babel/runtime':
         specifier: ^7.26.10
         version: 7.29.7
-      '@babel/types':
-        specifier: ^7.23.5
-        version: 7.23.5
       '@linaria/atomic':
         specifier: workspace:^
         version: link:../atomic
@@ -575,15 +509,6 @@ importers:
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5
-      '@types/babel__generator':
-        specifier: ^7.6.7
-        version: 7.6.7
-      '@types/babel__traverse':
-        specifier: ^7.20.4
-        version: 7.20.4
-      '@types/debug':
-        specifier: ^4.1.8
-        version: 4.1.8
       '@types/jest':
         specifier: ^28.1.0
         version: 28.1.0
@@ -593,18 +518,12 @@ importers:
       babel-plugin-istanbul:
         specifier: ^6.1.1
         version: 6.1.1
-      babel-plugin-module-resolver:
-        specifier: ^4.1.0
-        version: 4.1.0
       jest:
         specifier: ^29.6.2
         version: 29.6.2(@types/node@17.0.39)
       linaria:
         specifier: workspace:^
         version: link:../linaria
-      ts-jest:
-        specifier: ^29.1.1
-        version: 29.1.1(@babel/core@7.23.5)(@jest/types@29.6.3)(babel-jest@29.6.2(@babel/core@7.23.5))(esbuild@0.15.16)(jest@29.6.2(@types/node@17.0.39))(typescript@5.2.2)
 
   website:
     dependencies:
@@ -3710,10 +3629,6 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  bs-logger@0.2.6:
-    resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
-    engines: {node: '>= 6'}
-
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
 
@@ -6491,9 +6406,6 @@ packages:
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
-  lodash.memoize@4.1.2:
-    resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
-
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -6575,9 +6487,6 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
-
-  make-error@1.3.6:
-    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
@@ -8678,27 +8587,6 @@ packages:
   ts-invariant@0.10.3:
     resolution: {integrity: sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==}
     engines: {node: '>=8'}
-
-  ts-jest@29.1.1:
-    resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@jest/types': ^29.0.0
-      babel-jest: ^29.0.0
-      esbuild: '*'
-      jest: ^29.0.0
-      typescript: '>=4.3 <6'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@jest/types':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
 
   ts-toolbelt@9.6.0:
     resolution: {integrity: sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==}
@@ -11795,6 +11683,7 @@ snapshots:
       '@swc/core-win32-arm64-msvc': 1.3.20
       '@swc/core-win32-ia32-msvc': 1.3.20
       '@swc/core-win32-x64-msvc': 1.3.20
+    optional: true
 
   '@tootallnate/once@1.1.2': {}
 
@@ -13099,10 +12988,6 @@ snapshots:
       electron-to-chromium: 1.5.392
       node-releases: 2.0.51
       update-browserslist-db: 1.2.3(browserslist@4.28.6)
-
-  bs-logger@0.2.6:
-    dependencies:
-      fast-json-stable-stringify: 2.1.0
 
   bser@2.1.1:
     dependencies:
@@ -16252,8 +16137,6 @@ snapshots:
 
   lodash.debounce@4.0.8: {}
 
-  lodash.memoize@4.1.2: {}
-
   lodash.merge@4.6.2: {}
 
   lodash.sortby@4.7.0: {}
@@ -16334,8 +16217,6 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.5.4
-
-  make-error@1.3.6: {}
 
   makeerror@1.0.12:
     dependencies:
@@ -18905,24 +18786,6 @@ snapshots:
   ts-invariant@0.10.3:
     dependencies:
       tslib: 2.6.2
-
-  ts-jest@29.1.1(@babel/core@7.23.5)(@jest/types@29.6.3)(babel-jest@29.6.2(@babel/core@7.23.5))(esbuild@0.15.16)(jest@29.6.2(@types/node@17.0.39))(typescript@5.2.2):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.6.2(@types/node@17.0.39)
-      jest-util: 29.6.2
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.5.4
-      typescript: 5.2.2
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.23.5
-      '@jest/types': 29.6.3
-      babel-jest: 29.6.2(@babel/core@7.23.5)
-      esbuild: 0.15.16
 
   ts-toolbelt@9.6.0: {}
 


### PR DESCRIPTION
## Summary

- remove 27 unused Babel, SWC, esbuild, and utility dependency declarations
- keep the Babel dependencies still required by PostCSS parsing, Babel interop, and test coverage
- refresh the pnpm lockfile

## Why

Several package manifests still declared dependencies from evaluator implementations replaced by `@wyw-in-js/transform`, which now uses OXC internally. Other entries remained after processor AST imports moved to `@wyw-in-js/processor-utils`.

Removing these declarations reduces the installed dependency surface without changing runtime behavior.

## Validation

- `pnpm install --frozen-lockfile --strict-peer-dependencies`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:dts`
- `pnpm test` on Node.js 22.18.0
- forced full test run on Node.js 24.11.1
- `pnpm sp:check`
- packed and inspected the changed public packages