### PR TITLE
fix(react): reduce polymorphic as type instantiations

### DIFF
--- a/.changeset/calm-styled-types.md
+++ b/.changeset/calm-styled-types.md
@@ -1,0 +1,5 @@
+---
+"@linaria/react": patch
+---
+
+Reduce TypeScript memory usage for polymorphic `as` props while preserving intrinsic element prop inference.

--- a/packages/react/__dtslint__/styled-jsx.tsx
+++ b/packages/react/__dtslint__/styled-jsx.tsx
@@ -7,3 +7,5 @@ const Button = styled.button``;
 <Button as="a" href="/" />;
 // @ts-expect-error href requires an anchor-like target
 <Button href="/" />;
+// @ts-expect-error href is not a button property
+<Button as="button" href="/" />;

--- a/packages/react/__dtslint__/styled.ts
+++ b/packages/react/__dtslint__/styled.ts
@@ -32,6 +32,8 @@ StyledButton({ as: 'a', href: '/' });
 StyledButton.defaultProps = { as: 'a' };
 // @ts-expect-error href requires an anchor-like target
 StyledButton({ href: '/' });
+// @ts-expect-error href is not a button property
+StyledButton({ as: 'button', href: '/' });
 
 const A = (): React.ReactElement => React.createElement('div', null);
 // @ts-expect-error

--- a/packages/react/src/styled.ts
+++ b/packages/react/src/styled.ts
@@ -267,9 +267,14 @@ type FunctionComponentStatic<
   ? React.FunctionComponent<TProps>[TKey]
   : never;
 
+// Avoid materializing every intrinsic element's props while TypeScript inspects
+// an unresolved polymorphic component. A concrete `as` still selects its props.
+type IntrinsicElementProps<TName extends keyof IntrinsicElements> =
+  keyof IntrinsicElements extends TName ? unknown : IntrinsicElements[TName];
+
 type StyledComponentWithAs<TProps> = {
   <TAs extends keyof IntrinsicElements>(
-    props: TProps & { as: TAs } & IntrinsicElements[TAs],
+    props: TProps & { as: TAs } & NoInfer<IntrinsicElementProps<TAs>>,
     context?: any
   ): ReturnType<React.FunctionComponent>;
   (


### PR DESCRIPTION
## Summary

- defer `JSX.IntrinsicElements[TAs]` expansion until `as` resolves to a concrete intrinsic tag
- prevent target props from widening `TAs`
- preserve intrinsic prop inference for usages such as `as="a"`
- add negative tests for props that do not belong to the selected tag

## Why

`@linaria/react@8.1.0` made every styled component expose a generic overload indexed by the full `JSX.IntrinsicElements` map. In styled-heavy React 19 projects, TypeScript can materialize that map for every component, causing millions of type instantiations and out-of-memory failures.

The new helper avoids expanding the map while `TAs` is still unresolved. Once `as` is a concrete intrinsic tag, its corresponding props are selected normally.

Fixes #1489.

## Validation

- `pnpm check:all`
