### PR TITLE
fix(postcss): preserve adjacent interpolations through stylelint --fix

### DIFF
--- a/.changeset/tame-lions-jump.md
+++ b/.changeset/tame-lions-jump.md
@@ -1,0 +1,7 @@
+---
+'@linaria/postcss-linaria': patch
+---
+
+Fix adjacent interpolations being mangled by `stylelint --fix`
+
+`substitutePlaceholders` split each whitespace-separated token on the placeholder marker and only read the first two parts, so a token holding more than one interpolation — an attribute selector like `&[${a}][${b}]`, or a value like `margin: ${a}${b}` — silently lost everything from the second interpolation onward, corrupting the output into invalid CSS (#1498).

--- a/packages/postcss-linaria/__tests__/__utils__/index.ts
+++ b/packages/postcss-linaria/__tests__/__utils__/index.ts
@@ -184,4 +184,43 @@ export const sourceWithExpression = {
       }
     \`;
   `,
+  adjacentSelectorExpressions: `
+    const firstAttribute = 'data-visible';
+    const secondAttribute = 'data-has-content';
+    css\`
+      .foo {
+        &[\${firstAttribute}][\${secondAttribute}] {
+          display: block;
+        }
+      }
+    \`;
+  `,
+  adjacentValueExpressions: `
+    const expr1 = '10px';
+    const expr2 = '5px';
+    css\`
+      .foo {
+        margin: \${expr1}\${expr2};
+      }
+    \`;
+  `,
+  adjacentExpressionsWithDoubleDigitIndex: `
+    css\`
+        .filler { color: \${x}; }
+        .filler { color: \${x}; }
+        .filler { color: \${x}; }
+        .filler { color: \${x}; }
+        .filler { color: \${x}; }
+        .filler { color: \${x}; }
+        .filler { color: \${x}; }
+        .filler { color: \${x}; }
+        .filler { color: \${x}; }
+        .filler { color: \${x}; }
+        .foo {
+          &[\${x}][\${x}] {
+            display: block;
+          }
+        }
+    \`;
+  `,
 };

--- a/packages/postcss-linaria/__tests__/stringify.test.ts
+++ b/packages/postcss-linaria/__tests__/stringify.test.ts
@@ -21,6 +21,9 @@ const {
   multilineAtRuleParams,
   multilineAtRuleParamsLeadingExpression,
   atRuleExpressionInAfterName,
+  adjacentSelectorExpressions,
+  adjacentValueExpressions,
+  adjacentExpressionsWithDoubleDigitIndex,
 } = sourceWithExpression;
 
 describe('stringify', () => {
@@ -121,6 +124,26 @@ describe('stringify', () => {
     // verbatim without going through `raw()`.
     it('should stringify an expression that lands in the at-rule afterName raw', () => {
       const { source, ast } = createTestAst(atRuleExpressionInAfterName);
+      const output = ast.toString(syntax);
+      expect(output).toEqual(source);
+    });
+
+    it('should stringify adjacent expressions within a selector', () => {
+      const { source, ast } = createTestAst(adjacentSelectorExpressions);
+      const output = ast.toString(syntax);
+      expect(output).toEqual(source);
+    });
+
+    it('should stringify adjacent expressions within a declaration value', () => {
+      const { source, ast } = createTestAst(adjacentValueExpressions);
+      const output = ast.toString(syntax);
+      expect(output).toEqual(source);
+    });
+
+    it('should stringify adjacent expressions when an index is two digits', () => {
+      const { source, ast } = createTestAst(
+        adjacentExpressionsWithDoubleDigitIndex
+      );
       const output = ast.toString(syntax);
       expect(output).toEqual(source);
     });

--- a/packages/postcss-linaria/src/stringify.ts
+++ b/packages/postcss-linaria/src/stringify.ts
@@ -18,6 +18,15 @@ const commentPlaceholderPattern = new RegExp(
   'g'
 );
 
+// Matches one placeholder occurrence, together with the synthetic marker
+// (`.` or `--`) `createPlaceholder` may have prefixed it with to keep it
+// parseable in its original context. Global so that adjacent placeholders,
+// as in an attribute selector like `[${a}][${b}]`, are all substituted.
+const placeholderOccurrencePattern = new RegExp(
+  `(?:\\.|--)?${placeholderText}(\\d+)`,
+  'g'
+);
+
 const substitutePlaceholders = (
   stringWithPlaceholders: string,
   expressions: string[]
@@ -27,43 +36,22 @@ const substitutePlaceholders = (
   }
 
   // A comment placeholder reaches this point when it sits inside a declaration
-  // value rather than standing on its own as a comment node. The scan below
-  // splits on spaces, which cannot see it: the delimiters are separate tokens.
+  // value rather than standing on its own as a comment node. Its `pcss-lin:0`
+  // form has a colon where the pattern below expects the index, so it needs
+  // its own pass.
   const substituted = stringWithPlaceholders.replace(
     commentPlaceholderPattern,
     (match, index: string) => expressions[Number(index)] ?? match
   );
 
-  const values = substituted.split(' ');
-  const temp: string[] = [];
-  values.forEach((val) => {
-    let [prefix, expressionIndexString] = val.split(placeholderText);
-    prefix = prefix.replace(/(\.|--|\/\*)$/, '');
-    // if the val is 'pcss-lin10px', need to remove the px to get the placeholder number
-    let suffix = '';
-    while (
-      Number.isNaN(Number(expressionIndexString)) &&
-      expressionIndexString &&
-      expressionIndexString.length > 0
-    ) {
-      suffix = expressionIndexString[expressionIndexString.length - 1] + suffix;
-      expressionIndexString = expressionIndexString.slice(
-        0,
-        expressionIndexString.length - 1
-      );
+  // if a match is 'pcss-lin10px', the greedy digit capture leaves the 'px' alone
+  return substituted.replace(
+    placeholderOccurrencePattern,
+    (match, indexString: string) => {
+      const expression = expressions[Number(indexString)];
+      return expression ?? match;
     }
-    const expressionIndex = Number(expressionIndexString);
-    const expression =
-      expressions &&
-      !Number.isNaN(expressionIndex) &&
-      expressions[expressionIndex];
-    if (expression) {
-      temp.push(prefix + expression + suffix);
-    } else {
-      temp.push(val);
-    }
-  });
-  return temp.join(' ');
+  );
 };
 
 /**


### PR DESCRIPTION
## Motivation

Fixes #1498.

## Summary

`substitutePlaceholders` split the string on spaces and then split each token on the placeholder text, destructuring only the first two parts. A token holding more than one placeholder — an attribute selector like `&[${a}][${b}]`, which has no whitespace between the interpolations — lost everything from the second placeholder onward, so `stylelint --fix` silently rewrote the selector to `&[${a}][.` and wrote invalid CSS back to the file. A following Stylelint run then reports `Unclosed bracket`.

The token scan is replaced with a single global regex that matches every placeholder occurrence together with the synthetic marker (`.` or `--`) that `createPlaceholder` may have prefixed it with. The greedy `(\d+)` capture preserves the existing `pcss-lin10px` behaviour — the unit suffix simply falls outside the match — so the manual suffix-peeling loop is no longer needed.

Declaration values were broken in the same way (`margin: ${a}${b}` dropped the second interpolation) and are fixed by the same change.

## Test plan

Three round-trip cases added to `packages/postcss-linaria/__tests__/stringify.test.ts`, covering adjacent interpolations in a selector, in a declaration value, and with a two-digit expression index. All three fail on `master` and pass with this change.

```sh
pnpm --filter @linaria/postcss-linaria test
pnpm lint
pnpm typecheck
```
