### PR TITLE
fix(postcss): preserve interpolations in multi-line selectors and at-rule params

### DIFF
--- a/.changeset/olive-crabs-smile.md
+++ b/.changeset/olive-crabs-smile.md
@@ -1,0 +1,11 @@
+---
+'@linaria/postcss-linaria': patch
+---
+
+Fix interpolations and comments being dropped from multi-line selectors and at-rule params
+
+An interpolation that continues a selector onto the next line looks like a ruleset, so it gets a comment placeholder. PostCSS keeps that comment only in `raws.selector.raw`, and the re-indented selector was read from `selector`, so `~ .${styles.parent}` came out as `~ .` on any `stylelint --fix`. Multi-line at-rule params had the same problem via `raws.params.raw`.
+
+The same defect was fixed for `decl.value` in the previous release (#1494); the selector and params paths were missed. All three now read the raw form through `computeCorrectedRawValue`.
+
+Hand-written comments were dropped by the same code path, so a comment inside a multi-line selector or multi-line at-rule params now survives too, interpolations or not.

--- a/packages/postcss-linaria/__tests__/__utils__/index.ts
+++ b/packages/postcss-linaria/__tests__/__utils__/index.ts
@@ -223,4 +223,27 @@ export const sourceWithExpression = {
         }
     \`;
   `,
+  multilineSelectorWithMidlineExpression: `
+    const styles = { parent: 'p', child: 'c' };
+    css\`
+      .foo {
+        &:hover {
+          ~ .\${styles.parent}
+            .\${styles.child} {
+            text-decoration: underline;
+          }
+        }
+      }
+    \`;
+  `,
+  multilineAtRuleParamsMidlineExpression: `
+    const expr = 'print';
+    css\`
+      @media screen
+        and \${expr}
+        and (min-width: 100px) {
+        .foo { color: black; }
+      }
+    \`;
+  `,
 };

--- a/packages/postcss-linaria/__tests__/stringify.test.ts
+++ b/packages/postcss-linaria/__tests__/stringify.test.ts
@@ -24,6 +24,8 @@ const {
   adjacentSelectorExpressions,
   adjacentValueExpressions,
   adjacentExpressionsWithDoubleDigitIndex,
+  multilineSelectorWithMidlineExpression,
+  multilineAtRuleParamsMidlineExpression,
 } = sourceWithExpression;
 
 describe('stringify', () => {
@@ -147,6 +149,22 @@ describe('stringify', () => {
       const output = ast.toString(syntax);
       expect(output).toEqual(source);
     });
+
+    it('should stringify a multiline selector with an expression mid-selector', () => {
+      const { source, ast } = createTestAst(
+        multilineSelectorWithMidlineExpression
+      );
+      const output = ast.toString(syntax);
+      expect(output).toEqual(source);
+    });
+
+    it('should stringify an expression in the middle of multi-line at-rule params', () => {
+      const { source, ast } = createTestAst(
+        multilineAtRuleParamsMidlineExpression
+      );
+      const output = ast.toString(syntax);
+      expect(output).toEqual(source);
+    });
   });
 
   // A newline inside `afterName` needs its base indentation restored just like
@@ -256,6 +274,37 @@ describe('stringify', () => {
         /* random comment about this line */
         .foo {
           color: hotpink; 
+        }
+      \`;
+    `);
+
+    const output = ast.toString(syntax);
+
+    expect(output).toEqual(source);
+  });
+
+  // Not the same as the placeholder cases above: these have no interpolations.
+  it('should keep a comment inside a multi-line selector', () => {
+    const { source, ast } = createTestAst(`
+      css\`
+        .foo,
+          /* about .bar */ .bar {
+          color: hotpink;
+        }
+      \`;
+    `);
+
+    const output = ast.toString(syntax);
+
+    expect(output).toEqual(source);
+  });
+
+  it('should keep a comment inside multi-line at-rule params', () => {
+    const { source, ast } = createTestAst(`
+      css\`
+        @media screen
+          and /* only wide ones */ (min-width: 100px) {
+          .foo { color: hotpink; }
         }
       \`;
     `);

--- a/packages/postcss-linaria/src/locationCorrection.ts
+++ b/packages/postcss-linaria/src/locationCorrection.ts
@@ -138,7 +138,11 @@ function computeCorrectedString(
 }
 
 /**
- * Computes the re-indented value of a given node's raw value
+ * Computes the re-indented value of a given node's raw value.
+ *
+ * Reads `raws[key].raw` rather than the property itself: PostCSS strips
+ * comments out of `selector`, `value` and `params`, and a comment placeholder
+ * there is all that is left of an interpolation classified as a ruleset.
  * @param {T} node Node to re-indent raw value of
  * @param {string} key Raw value key to re-indent
  * @param {Map=} baseIndentations Indentation map
@@ -146,10 +150,11 @@ function computeCorrectedString(
  */
 function computeCorrectedRawValue<T extends AnyNode>(
   node: T,
-  key: keyof T,
+  key: 'selector' | 'value' | 'params',
   baseIndentations?: Map<number, number>
 ): string | null {
-  const value = node[key];
+  const raws = node.raws as Record<string, { raw?: string } | undefined>;
+  const value = raws[key]?.raw ?? node[key as keyof T];
 
   if (typeof value !== 'string' || !node.source?.start) {
     return null;
@@ -250,18 +255,7 @@ function computeBeforeAfter(
   }
 
   if (node.type === 'decl' && node.value.includes('\n')) {
-    // PostCSS strips comments out of `value` but keeps them in `raws.value.raw`.
-    // A comment placeholder ends up inside the value when the declaration spans
-    // lines within parentheses, so read the raw form: taking `value` here drops
-    // the placeholder and the interpolation cannot be restored on stringify.
-    const rawSource = node.raws.value?.raw ?? node.value;
-    const rawValue = node.source?.start
-      ? computeCorrectedString(
-          rawSource,
-          node.source.start.line,
-          baseIndentations
-        )
-      : null;
+    const rawValue = computeCorrectedRawValue(node, 'value', baseIndentations);
 
     if (rawValue !== null) {
       (node.raws as unknown as Record<string, unknown>).linariaValue = rawValue;


### PR DESCRIPTION
## Motivation

With no rules configured, `stylelint --fix` silently drops an interpolation that continues a selector onto the next line:

```ts
css`
  .foo {
    &:hover {
      ~ .${styles.parent}
        .${styles.child} {
        text-decoration: underline;
      }
    }
  }
`;
```

`~ .${styles.parent}` comes back as `~ .`, leaving a dangling dot that is no longer valid CSS. Multi-line at-rule params lose an interpolation the same way, so `@media screen` / `and ${expr}` / `and (min-width: 100px)` comes back with the middle line reduced to `and `.

This is the same defect as #1494, on two paths that its fix did not cover. `createPlaceholder` classifies an interpolation as a ruleset when its line has no colon, opening brace, or comma, and emits a comment placeholder. PostCSS keeps that comment only in `raws.<key>.raw`, but `computeCorrectedRawValue` reads the property, so the placeholder is already gone by the time the stringifier runs. #1495 fixed this for `decl.value` by inlining a raw-reading copy into that one branch, which left `Rule.selector` and `AtRule.params` on the old path.

## Summary

`computeCorrectedRawValue` now reads `raws[key].raw` and falls back to the property. All three branches share that one point again, so the copy inlined into the `decl` branch folds back into it and no branch can be fixed in isolation a third time.

`key` is narrowed from `keyof T` to the three properties PostCSS actually backs with a raw (`selector`, `value`, `params`), which is what makes indexing `raws` with it meaningful. The generic node type means that indexing needs a cast, in the same shape the surrounding code already uses to write the `linaria*` raws.

Hand-written comments travel the same path, so a comment inside a multi-line selector or multi-line at-rule params now survives as well. Previously it was deleted on any fix, templates containing no interpolations at all included.

## Test plan

Four round-trip cases added to `packages/postcss-linaria/__tests__/stringify.test.ts`: an interpolation mid-selector, an interpolation mid-params, and a plain comment in each. All four fail on `master` and pass with this change; no existing test is affected.

```sh
pnpm --filter @linaria/postcss-linaria test        # 91 tests, 4 new
pnpm --filter @linaria/postcss-linaria typecheck
pnpm lint
```