### PR TITLE
fix(postcss): preserve source escapes during fixes

### DIFF
--- a/.changeset/olive-moons-repeat.md
+++ b/.changeset/olive-moons-repeat.md
@@ -1,0 +1,11 @@
+---
+'@linaria/postcss-linaria': patch
+---
+
+Stop `stylelint --fix` from rewriting templates it should leave alone
+
+Backslashes inside a template were doubled on the way out and doubled again on every later run (#1497). Restored `${...}` expressions were passed through the same CSS escaping, so a backtick inside an expression was escaped and could leave the JavaScript unparseable.
+
+The parser now records each source-derived field before Stylelint rules run. The stringifier leaves backslashes in unchanged fields alone, retains the existing escaping for fields written by fixers, and restores interpolation placeholders only after escaping. The complete JavaScript expression source therefore stays unchanged, and repeated parse/stringify passes are idempotent.
+
+Fixers can continue to write CSS values with their normal escaping; the stringifier still translates those values into safe JavaScript template source.

--- a/packages/postcss-linaria/__tests__/stringify.test.ts
+++ b/packages/postcss-linaria/__tests__/stringify.test.ts
@@ -492,6 +492,69 @@ describe('stringify', () => {
     );
   });
 
+  // https://github.com/callstack/linaria/issues/1497. Backslashes inside a
+  // template used to be doubled on every pass, so the file grew a new layer of
+  // escaping each time `--fix` ran over it.
+  it('should keep backslashes inside a template unchanged, however often it runs', () => {
+    const source = `
+      css\`
+        .foo {
+          &:before {
+            content: '\\u2022';
+            color: red;
+          }
+        }
+      \`;
+    `;
+
+    let current = source;
+    for (let pass = 0; pass < 3; pass += 1) {
+      const { ast } = createTestAst(current);
+      current = ast.toString(syntax);
+      expect(current).toEqual(source);
+    }
+  });
+
+  it('should leave JavaScript expressions unchanged', () => {
+    const source = `
+      css\`
+        &:checked ~ \${\`.\${bodyStyle}\`}::before {
+          content: \${'\\u2022'};
+        }
+      \`;
+    `;
+
+    let current = source;
+    for (let pass = 0; pass < 3; pass += 1) {
+      const { ast } = createTestAst(current);
+      current = ast.toString(syntax);
+      expect(current).toEqual(source);
+    }
+  });
+
+  it('should escape a backtick a rule introduces exactly once', () => {
+    const { ast } = createTestAst(`
+      css\`.foo { color: hotpink; }\`;
+    `);
+
+    const root = ast.nodes[0] as Root;
+    const rule = root.nodes[0] as Rule;
+    const colour = rule.nodes[0] as Declaration;
+    colour.raws.between = ': /*`*/';
+
+    const escaped = ast.toString(syntax);
+    expect(escaped).toEqual(
+      `
+      css\`.foo { color: /*\\\`*/hotpink; }\`;
+    `
+    );
+
+    // Reading that output back and writing it out again must not add another
+    // layer of escaping to the backtick the first pass already escaped.
+    const { ast: reparsed } = createTestAst(escaped);
+    expect(reparsed.toString(syntax)).toEqual(escaped);
+  });
+
   it('should not escape unrelated backslashes', () => {
     const { ast } = createTestAst(`
       const foo = 'abc\\def';

--- a/packages/postcss-linaria/src/originalState.ts
+++ b/packages/postcss-linaria/src/originalState.ts
@@ -1,0 +1,104 @@
+import type { AnyNode } from 'postcss';
+
+interface OriginalState {
+  fields: Record<string, unknown>;
+  raws: Record<string, unknown>;
+}
+
+const fieldNames = [
+  'important',
+  'name',
+  'params',
+  'prop',
+  'selector',
+  'text',
+  'value',
+] as const;
+
+const rawNames = [
+  'after',
+  'afterName',
+  'before',
+  'between',
+  'important',
+  'left',
+  'ownSemicolon',
+  'params',
+  'right',
+  'selector',
+  'value',
+] as const;
+
+const originalStates = new WeakMap<AnyNode, OriginalState>();
+
+const snapshot = (value: unknown): unknown => {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return { ...(value as Record<string, unknown>) };
+  }
+
+  return value;
+};
+
+const matchesSnapshot = (snapshotValue: unknown, value: unknown): boolean => {
+  if (snapshotValue === value) {
+    return true;
+  }
+
+  if (
+    !snapshotValue ||
+    typeof snapshotValue !== 'object' ||
+    !value ||
+    typeof value !== 'object' ||
+    Array.isArray(snapshotValue) ||
+    Array.isArray(value)
+  ) {
+    return false;
+  }
+
+  const snapshotRecord = snapshotValue as Record<string, unknown>;
+  const valueRecord = value as Record<string, unknown>;
+  const snapshotKeys = Object.keys(snapshotRecord);
+  const valueKeys = Object.keys(valueRecord);
+
+  return (
+    snapshotKeys.length === valueKeys.length &&
+    snapshotKeys.every((key) => snapshotRecord[key] === valueRecord[key])
+  );
+};
+
+export const captureOriginalState = (node: AnyNode): void => {
+  const fields: Record<string, unknown> = {};
+  const nodeRecord = node as unknown as Record<string, unknown>;
+  for (const name of fieldNames) {
+    fields[name] = nodeRecord[name];
+  }
+
+  const raws: Record<string, unknown> = {};
+  const rawRecord = node.raws as Record<string, unknown>;
+  for (const name of rawNames) {
+    raws[name] = snapshot(rawRecord[name]);
+  }
+
+  originalStates.set(node, { fields, raws });
+};
+
+export const isOriginalField = (
+  node: AnyNode,
+  name: string,
+  value: unknown
+): boolean => {
+  const originalState = originalStates.get(node);
+  return originalState !== undefined && originalState.fields[name] === value;
+};
+
+export const isOriginalRaw = (
+  node: AnyNode,
+  name: string,
+  value: unknown
+): boolean => {
+  const originalState = originalStates.get(node);
+  return (
+    originalState !== undefined &&
+    matchesSnapshot(originalState.raws[name], snapshot(value))
+  );
+};

--- a/packages/postcss-linaria/src/parse.ts
+++ b/packages/postcss-linaria/src/parse.ts
@@ -7,6 +7,7 @@ import { Document, Input } from 'postcss';
 import postcssParse from 'postcss/lib/parse';
 
 import { locationCorrectionWalker } from './locationCorrection';
+import { captureOriginalState } from './originalState';
 import { createPlaceholder } from './util';
 
 // This function returns
@@ -196,7 +197,11 @@ export const parse: Parser<Root | Document> = (
     (root as Root & { document: Document }).document = doc;
     const walker = locationCorrectionWalker(node, sourceAsString);
     walker(root);
-    root.walk(walker);
+    root.walk((child) => {
+      walker(child);
+      captureOriginalState(child);
+    });
+    captureOriginalState(root);
     doc.nodes.push(root);
 
     currentOffset = node.quasi.range[1] - 1;

--- a/packages/postcss-linaria/src/stringify.ts
+++ b/packages/postcss-linaria/src/stringify.ts
@@ -11,6 +11,7 @@ import type {
 } from 'postcss';
 import Stringifier from 'postcss/lib/stringifier';
 
+import { isOriginalField, isOriginalRaw } from './originalState';
 import { placeholderText } from './util';
 
 const commentPlaceholderPattern = new RegExp(
@@ -26,6 +27,23 @@ const placeholderOccurrencePattern = new RegExp(
   `(?:\\.|--)?${placeholderText}(\\d+)`,
   'g'
 );
+
+// The parse phase feeds the template's raw text into PostCSS, so backslashes
+// that survive the round trip are already written the way the source writes
+// them. A backtick is the only character that still needs attention: an
+// unescaped one would end the surrounding template literal. A run of
+// backslashes before it is even when the backtick is bare.
+const backtickPattern = /(\\*)`/g;
+
+const escapeBacktick = (value: string): string =>
+  value.replace(backtickPattern, (_match, backslashes: string) =>
+    backslashes.length % 2 === 0 ? `${backslashes}\\\`` : `${backslashes}\``
+  );
+
+const escapeChangedField = (value: string): string =>
+  value.replace(/\\/g, '\\\\').replace(/`/g, '\\`');
+
+const rawValueFields = new Set(['params', 'selector', 'value']);
 
 const substitutePlaceholders = (
   stringWithPlaceholders: string,
@@ -54,115 +72,117 @@ const substitutePlaceholders = (
   );
 };
 
+const escapeNodeField = (
+  node: AnyNode,
+  name: string,
+  value: string
+): string => {
+  const currentValue = (node as unknown as Record<string, unknown>)[name];
+  const currentRaw = (node.raws as Record<string, unknown>)[name];
+  const isSourceDerived =
+    isOriginalField(node, name, currentValue) &&
+    (!rawValueFields.has(name) || isOriginalRaw(node, name, currentRaw));
+  return isSourceDerived ? escapeBacktick(value) : escapeChangedField(value);
+};
+
+const escapeRawField = (node: AnyNode, name: string, value: string): string => {
+  const currentValue = (node.raws as Record<string, unknown>)[name];
+  return isOriginalRaw(node, name, currentValue)
+    ? escapeBacktick(value)
+    : escapeChangedField(value);
+};
+
+const restoreExpressions = (node: AnyNode, value: string): string =>
+  substitutePlaceholders(value, node.root().raws.linariaTemplateExpressions);
+
 /**
  * Stringifies PostCSS nodes while taking interpolated expressions
  * into account.
  */
 class LinariaStringifier extends Stringifier {
-  /** @inheritdoc */
-  public constructor(builder: Builder) {
-    const wrappedBuilder: Builder = (
-      str: string,
-      node?: AnyNode,
-      type?: 'start' | 'end'
-    ): void => {
-      // We purposely ignore the root node since the only thing we should
-      // be stringifying here is already JS (before/after raws) so likely
-      // already contains backticks on purpose.
-      //
-      // Similarly, if there is no node, we're probably stringifying
-      // pure JS which never contained any CSS. Or something really weird
-      // we don't want to touch anyway.
-      //
-      // For everything else, we want to escape backticks.
-      if (!node || node?.type === 'root') {
-        builder(str, node, type);
-      } else {
-        builder(str.replace(/\\/g, '\\\\').replace(/`/g, '\\`'), node, type);
-      }
-    };
-    super(wrappedBuilder);
+  public override atrule(node: AtRule, semicolon?: boolean): void {
+    let name = `@${escapeNodeField(node, 'name', node.name)}`;
+    const params = node.params
+      ? escapeNodeField(node, 'params', this.rawValue(node, 'params'))
+      : '';
+
+    const afterName = isOriginalRaw(node, 'afterName', node.raws.afterName)
+      ? node.raws.linariaAfterName ?? node.raws.afterName
+      : node.raws.afterName;
+    if (typeof afterName === 'string') {
+      name += escapeRawField(node, 'afterName', afterName);
+    } else if (params) {
+      name += ' ';
+    }
+
+    if (node.nodes) {
+      this.block(node, name + params);
+    } else {
+      const between = escapeRawField(node, 'between', node.raws.between || '');
+      const end = between + (semicolon ? ';' : '');
+      this.builder(restoreExpressions(node, name + params + end), node);
+    }
   }
 
-  public override atrule(node: AtRule, semicolon?: boolean) {
-    // Unlike `decl` and `rule`, this method hands the params back to
-    // `super.atrule`, which re-reads them through `rawValue`, and that prefers
-    // `raws.linariaParams`. Substituting into `node.params` alone is therefore
-    // discarded whenever the params span several lines, so read and write the
-    // same place the stringifier will.
-    const params = this.rawValue(node, 'params');
-    const expressionStrings = node.root().raws.linariaTemplateExpressions;
+  public override block(node: AtRule | Rule, start: string): void {
+    const between = escapeRawField(
+      node,
+      'between',
+      this.raw(node, 'between', 'beforeOpen')
+    );
+    this.builder(
+      restoreExpressions(node, `${start}${between}{`),
+      node,
+      'start'
+    );
 
-    if (params.includes(placeholderText)) {
-      const substituted = substitutePlaceholders(params, expressionStrings);
-
-      if (node.raws.linariaParams === undefined) {
-        // eslint-disable-next-line no-param-reassign
-        node.params = substituted;
-      } else {
-        // eslint-disable-next-line no-param-reassign
-        node.raws.linariaParams = substituted;
-      }
+    let after: string;
+    if (node.nodes?.length) {
+      this.body(node);
+      after = this.raw(node, 'after', undefined);
+    } else {
+      after = this.raw(node, 'after', 'emptyBody');
     }
 
-    // `super.atrule` reads `raws.afterName` straight off the node instead of
-    // going through `raw()`, so both the re-indented form and any placeholder
-    // substitution have to be written back onto it here. An interpolation on
-    // the line after the at-rule name lands in this raw rather than the params.
-    const afterName = node.raws.linariaAfterName ?? node.raws.afterName;
-    if (typeof afterName === 'string') {
-      // eslint-disable-next-line no-param-reassign
-      node.raws.afterName = afterName.includes(placeholderText)
-        ? substitutePlaceholders(afterName, expressionStrings)
-        : afterName;
-    }
-
-    super.atrule(node, semicolon);
+    if (after) this.builder(after);
+    this.builder('}', node, 'end');
   }
 
   /** @inheritdoc */
   public override comment(node: Comment): void {
-    const placeholderPattern = new RegExp(`^${placeholderText}:\\d+$`);
-    if (placeholderPattern.test(node.text)) {
-      const [, expressionIndexString] = node.text.split(':');
-      const expressionIndex = Number(expressionIndexString);
-      const root = node.root();
-      const expressionStrings = root.raws.linariaTemplateExpressions;
-
-      if (expressionStrings && !Number.isNaN(expressionIndex)) {
-        const expression = expressionStrings[expressionIndex];
-
-        if (expression) {
-          this.builder(expression, node);
-          return;
-        }
-      }
-    }
-
-    super.comment(node);
+    const left = escapeRawField(
+      node,
+      'left',
+      this.raw(node, 'left', 'commentLeft')
+    );
+    const text = escapeNodeField(node, 'text', node.text);
+    const right = escapeRawField(
+      node,
+      'right',
+      this.raw(node, 'right', 'commentRight')
+    );
+    const value = `/*${left}${text}${right}*/`;
+    this.builder(restoreExpressions(node, value), node);
   }
 
-  public override decl(node: Declaration, semicolon: boolean): void {
-    const between = this.raw(node, 'between', 'colon');
-    let { prop } = node;
-    const expressionStrings = node.root().raws.linariaTemplateExpressions;
-    if (prop.includes(placeholderText)) {
-      prop = substitutePlaceholders(prop, expressionStrings);
-    }
-
-    let value = this.rawValue(node, 'value');
-    if (value.includes(placeholderText)) {
-      value = substitutePlaceholders(value, expressionStrings);
-    }
-
+  /** @inheritdoc */
+  public override decl(node: Declaration, semicolon?: boolean): void {
+    const prop = escapeNodeField(node, 'prop', node.prop);
+    const between = escapeRawField(
+      node,
+      'between',
+      this.raw(node, 'between', 'colon')
+    );
+    const value = escapeNodeField(node, 'value', this.rawValue(node, 'value'));
     let string = prop + between + value;
 
     if (node.important) {
-      string += node.raws.important || ' !important';
+      const important = node.raws.important || ' !important';
+      string += escapeRawField(node, 'important', important);
     }
 
     if (semicolon) string += ';';
-    this.builder(string, node);
+    this.builder(restoreExpressions(node, string), node);
   }
 
   /** @inheritdoc */
@@ -180,13 +200,28 @@ class LinariaStringifier extends Stringifier {
     own: string,
     detect: string | undefined
   ): string {
-    if (own === 'before' && node.raws.before && node.raws.linariaBefore) {
+    if (
+      own === 'before' &&
+      node.raws.before &&
+      node.raws.linariaBefore &&
+      isOriginalRaw(node, own, node.raws.before)
+    ) {
       return node.raws.linariaBefore;
     }
-    if (own === 'after' && node.raws.after && node.raws.linariaAfter) {
+    if (
+      own === 'after' &&
+      node.raws.after &&
+      node.raws.linariaAfter &&
+      isOriginalRaw(node, own, node.raws.after)
+    ) {
       return node.raws.linariaAfter;
     }
-    if (own === 'between' && node.raws.between && node.raws.linariaBetween) {
+    if (
+      own === 'between' &&
+      node.raws.between &&
+      node.raws.linariaBetween &&
+      isOriginalRaw(node, own, node.raws.between)
+    ) {
       return node.raws.linariaBetween;
     }
     return super.raw(node, own, detect);
@@ -195,7 +230,13 @@ class LinariaStringifier extends Stringifier {
   /** @inheritdoc */
   public override rawValue(node: AnyNode, prop: string): string {
     const linariaProp = `linaria${prop[0]?.toUpperCase()}${prop.slice(1)}`;
-    if (Object.prototype.hasOwnProperty.call(node.raws, linariaProp)) {
+    const currentValue = (node as unknown as Record<string, unknown>)[prop];
+    const currentRaw = (node.raws as Record<string, unknown>)[prop];
+    if (
+      Object.prototype.hasOwnProperty.call(node.raws, linariaProp) &&
+      isOriginalField(node, prop, currentValue) &&
+      isOriginalRaw(node, prop, currentRaw)
+    ) {
       return `${node.raws[linariaProp]}`;
     }
 
@@ -219,14 +260,19 @@ class LinariaStringifier extends Stringifier {
   }
 
   public override rule(node: Rule): void {
-    let value = this.rawValue(node, 'selector');
-    if (value.includes(placeholderText)) {
-      const expressionStrings = node.root().raws.linariaTemplateExpressions;
-      value = substitutePlaceholders(value, expressionStrings);
-    }
-    this.block(node, value);
+    const selector = escapeNodeField(
+      node,
+      'selector',
+      this.rawValue(node, 'selector')
+    );
+    this.block(node, selector);
     if (node.raws.ownSemicolon) {
-      this.builder(node.raws.ownSemicolon, node, 'end');
+      const ownSemicolon = escapeRawField(
+        node,
+        'ownSemicolon',
+        node.raws.ownSemicolon
+      );
+      this.builder(restoreExpressions(node, ownSemicolon), node, 'end');
     }
   }
 }


### PR DESCRIPTION
## Summary

- preserve source-derived escapes while stringifying CSS template literals
- retain the existing escaping behavior for fields changed by Stylelint fixers
- restore JavaScript interpolation placeholders only after CSS escaping

## Root cause

The stringifier escaped every backslash emitted for a PostCSS node, including values already taken from the raw template source. Repeated parse/stringify passes therefore added another escape layer, while restored JavaScript interpolations were escaped as CSS too.

## Impact

`stylelint --fix` no longer rewrites unchanged escape sequences or JavaScript interpolations. Fixers can continue writing normally escaped CSS values.

## Validation

- 94 Jest tests and 13 snapshots
- TypeScript typecheck
- ESLint

Closes #1497
