### PR TITLE
fix(postcss): preserve source prefixes before interpolations

### DIFF
--- a/.changeset/quiet-bags-remember.md
+++ b/.changeset/quiet-bags-remember.md
@@ -1,0 +1,7 @@
+---
+'@linaria/postcss-linaria': patch
+---
+
+Preserve source prefixes before interpolations
+
+The parser now records whether it added a synthetic `.` or `--` to keep an interpolation parseable. The stringifier removes only that recorded marker, so `stylelint --fix` no longer drops a real leading dot from selectors such as `.\${className}` (#1501).

--- a/packages/postcss-linaria/__tests__/stringify.test.ts
+++ b/packages/postcss-linaria/__tests__/stringify.test.ts
@@ -60,6 +60,21 @@ describe('stringify', () => {
       expect(output).toEqual(source);
     });
 
+    // https://github.com/callstack/linaria/issues/1501. A dot written in the
+    // source must not be mistaken for the synthetic dot `createPlaceholder`
+    // adds when an interpolation needs to remain parseable as a selector.
+    it('should preserve a leading dot before a selector expression', () => {
+      const { source, ast } = createTestAst(`
+        const a = 'some-class';
+        css\`
+          .\${a} { color: red; }
+        \`;
+      `);
+
+      const output = ast.toString(syntax);
+      expect(output).toEqual(source);
+    });
+
     it('should stringify a declaration property expression', () => {
       const { source, ast } = createTestAst(declarationProperty);
       const output = ast.toString(syntax);

--- a/packages/postcss-linaria/src/parse.ts
+++ b/packages/postcss-linaria/src/parse.ts
@@ -8,7 +8,7 @@ import postcssParse from 'postcss/lib/parse';
 
 import { locationCorrectionWalker } from './locationCorrection';
 import { captureOriginalState } from './originalState';
-import { createPlaceholder } from './util';
+import { createPlaceholder, placeholderText } from './util';
 
 // This function returns
 // 1) styleText with placeholders for the expressions.
@@ -21,8 +21,13 @@ import { createPlaceholder } from './util';
 const generateStyleTextWithExpressionPlaceholders = (
   node: TaggedTemplateExpression,
   sourceAsString: string
-): { expressionStrings: string[]; styleText: string } => {
+): {
+  expressionPlaceholderPrefixes: string[];
+  expressionStrings: string[];
+  styleText: string;
+} => {
   let styleText = '';
+  const expressionPlaceholderPrefixes: string[] = [];
   const expressionStrings: string[] = [];
 
   for (let i = 0; i < node.quasi.quasis.length; i++) {
@@ -37,16 +42,24 @@ const generateStyleTextWithExpressionPlaceholders = (
           template.range[1],
           nextTemplate.range[0]
         );
-        styleText += createPlaceholder(
+        const placeholder = createPlaceholder(
           i,
           sourceAsString,
           nextTemplate.range[0]
+        );
+        styleText += placeholder;
+        expressionPlaceholderPrefixes.push(
+          placeholder.slice(0, placeholder.indexOf(placeholderText))
         );
         expressionStrings.push(exprText);
       }
     }
   }
-  return { styleText, expressionStrings };
+  return {
+    styleText,
+    expressionStrings,
+    expressionPlaceholderPrefixes,
+  };
 };
 
 const getDeindentedStyleTextAndOffsets = (
@@ -162,7 +175,11 @@ export const parse: Parser<Root | Document> = (
 
     const startIndex = node.quasi.range[0] + 1;
 
-    const { styleText, expressionStrings } =
+    const {
+      styleText,
+      expressionStrings,
+      expressionPlaceholderPrefixes,
+    } =
       generateStyleTextWithExpressionPlaceholders(node, sourceAsString);
 
     const { deindentedStyleText, prefixOffsets, baseIndentations } =
@@ -180,6 +197,8 @@ export const parse: Parser<Root | Document> = (
 
     root.raws.linariaPrefixOffsets = prefixOffsets;
     root.raws.linariaTemplateExpressions = expressionStrings;
+    root.raws.linariaTemplateExpressionPrefixes =
+      expressionPlaceholderPrefixes;
     root.raws.linariaBaseIndentations = baseIndentations;
     // TODO: remove this if stylelint/stylelint#5767 ever gets fixed,
     // or they drop the indentation rule. Their indentation rule depends on

--- a/packages/postcss-linaria/src/parse.ts
+++ b/packages/postcss-linaria/src/parse.ts
@@ -175,11 +175,7 @@ export const parse: Parser<Root | Document> = (
 
     const startIndex = node.quasi.range[0] + 1;
 
-    const {
-      styleText,
-      expressionStrings,
-      expressionPlaceholderPrefixes,
-    } =
+    const { styleText, expressionStrings, expressionPlaceholderPrefixes } =
       generateStyleTextWithExpressionPlaceholders(node, sourceAsString);
 
     const { deindentedStyleText, prefixOffsets, baseIndentations } =
@@ -197,8 +193,7 @@ export const parse: Parser<Root | Document> = (
 
     root.raws.linariaPrefixOffsets = prefixOffsets;
     root.raws.linariaTemplateExpressions = expressionStrings;
-    root.raws.linariaTemplateExpressionPrefixes =
-      expressionPlaceholderPrefixes;
+    root.raws.linariaTemplateExpressionPrefixes = expressionPlaceholderPrefixes;
     root.raws.linariaBaseIndentations = baseIndentations;
     // TODO: remove this if stylelint/stylelint#5767 ever gets fixed,
     // or they drop the indentation rule. Their indentation rule depends on

--- a/packages/postcss-linaria/src/stringify.ts
+++ b/packages/postcss-linaria/src/stringify.ts
@@ -47,7 +47,8 @@ const rawValueFields = new Set(['params', 'selector', 'value']);
 
 const substitutePlaceholders = (
   stringWithPlaceholders: string,
-  expressions: string[]
+  expressions: string[],
+  expressionPlaceholderPrefixes?: string[]
 ) => {
   if (!stringWithPlaceholders.includes(placeholderText) || !expressions) {
     return stringWithPlaceholders;
@@ -66,8 +67,21 @@ const substitutePlaceholders = (
   return substituted.replace(
     placeholderOccurrencePattern,
     (match, indexString: string) => {
-      const expression = expressions[Number(indexString)];
-      return expression ?? match;
+      const index = Number(indexString);
+      const expression = expressions[index];
+      if (expression === undefined) {
+        return match;
+      }
+
+      const matchedPrefix = match.slice(0, match.indexOf(placeholderText));
+      const placeholderPrefix = expressionPlaceholderPrefixes?.[index];
+
+      // Without parser metadata, preserve the historical behaviour. With it,
+      // remove only a marker the parser itself added; an otherwise identical
+      // `.` or `--` from the source belongs in the output.
+      return placeholderPrefix === undefined || matchedPrefix === placeholderPrefix
+        ? expression
+        : matchedPrefix + expression;
     }
   );
 };
@@ -93,7 +107,11 @@ const escapeRawField = (node: AnyNode, name: string, value: string): string => {
 };
 
 const restoreExpressions = (node: AnyNode, value: string): string =>
-  substitutePlaceholders(value, node.root().raws.linariaTemplateExpressions);
+  substitutePlaceholders(
+    value,
+    node.root().raws.linariaTemplateExpressions,
+    node.root().raws.linariaTemplateExpressionPrefixes
+  );
 
 /**
  * Stringifies PostCSS nodes while taking interpolated expressions

--- a/packages/postcss-linaria/src/stringify.ts
+++ b/packages/postcss-linaria/src/stringify.ts
@@ -79,7 +79,8 @@ const substitutePlaceholders = (
       // Without parser metadata, preserve the historical behaviour. With it,
       // remove only a marker the parser itself added; an otherwise identical
       // `.` or `--` from the source belongs in the output.
-      return placeholderPrefix === undefined || matchedPrefix === placeholderPrefix
+      return placeholderPrefix === undefined ||
+        matchedPrefix === placeholderPrefix
         ? expression
         : matchedPrefix + expression;
     }


### PR DESCRIPTION
## Motivation

`stylelint --fix` drops the leading dot from an interpolated class selector, changing `.${className}` into `${className}` and silently turning a class selector into a type selector.

Closes #1501.

## Summary

The parser now records whether it added a synthetic `.` or `--` to keep each interpolation parseable. The stringifier removes a prefix only when it matches that parser metadata, preserving otherwise identical prefixes from the source.

## Validation

- 95 Jest tests and 13 snapshots
- TypeScript typecheck
- ESLint
