### PR TITLE
perf: declare built-in WyW processor semantics

### DIFF
--- a/.changeset/declare-processor-semantics.md
+++ b/.changeset/declare-processor-semantics.md
@@ -1,0 +1,7 @@
+---
+'@linaria/atomic': patch
+'@linaria/core': patch
+'@linaria/react': patch
+---
+
+Declare built-in WyW semantics for the `css` and `styled` processors so static processor values can be resolved without evaluating their modules. Atomic `styled` uses the same target semantics, while atomic `css` keeps its post-extraction JS contract.

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -38,7 +38,7 @@
   "wyw-in-js": {
     "tags": {
       "css": "./dist/processors/css.js",
-      "styled": "./dist/processors/styled.js"
+      "styled": "./processors/styled.processor.json"
     }
   },
   "scripts": {

--- a/packages/atomic/processors/styled.processor.json
+++ b/packages/atomic/processors/styled.processor.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "name": "@linaria/atomic/styled",
+  "implementation": "../dist/processors/styled.js",
+  "tags": ["styled"],
+  "semantics": {
+    "kind": "styled-target",
+    "targets": ["class-name", "selector-chain", "opaque-component"]
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,7 +44,7 @@
   ],
   "wyw-in-js": {
     "tags": {
-      "css": "./dist/processors/css.js"
+      "css": "./processors/css.processor.json"
     }
   },
   "scripts": {

--- a/packages/core/processors/css.processor.json
+++ b/packages/core/processors/css.processor.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "name": "@linaria/core/css",
+  "implementation": "../dist/processors/css.js",
+  "tags": ["css"],
+  "semantics": {
+    "kind": "css-template",
+    "outputs": ["class-name", "css-text"],
+    "runtimeDependencies": "explicit",
+    "staticInterpolations": [
+      "serializable",
+      "class-name",
+      "selector-chain"
+    ]
+  }
+}

--- a/packages/core/src/processors/css.ts
+++ b/packages/core/src/processors/css.ts
@@ -6,12 +6,6 @@ import type {
 } from '@wyw-in-js/processor-utils';
 import { TaggedTemplateProcessor } from '@wyw-in-js/processor-utils';
 
-type StaticClassNameValue = {
-  className: string;
-  kind: 'class-name';
-  value: string;
-};
-
 export default class CssProcessor extends TaggedTemplateProcessor {
   public override get asSelector(): string {
     return this.className;
@@ -57,13 +51,5 @@ export default class CssProcessor extends TaggedTemplateProcessor {
     };
 
     return rules;
-  }
-
-  public getStaticValue(): StaticClassNameValue {
-    return {
-      className: this.className,
-      kind: 'class-name',
-      value: this.className,
-    };
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -44,7 +44,7 @@
   ],
   "wyw-in-js": {
     "tags": {
-      "styled": "./dist/processors/styled.js"
+      "styled": "./processors/styled.processor.json"
     }
   },
   "scripts": {

--- a/packages/react/processors/styled.processor.json
+++ b/packages/react/processors/styled.processor.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "name": "@linaria/react/styled",
+  "implementation": "../dist/processors/styled.js",
+  "tags": ["styled"],
+  "semantics": {
+    "kind": "styled-target",
+    "targets": ["class-name", "selector-chain", "opaque-component"]
+  }
+}


### PR DESCRIPTION
## Summary

- declare WyW v1 `css-template` semantics for `@linaria/core/css`
- declare `styled-target` semantics for `@linaria/react/styled` and `@linaria/atomic/styled`
- remove the duplicate core `getStaticValue` implementation now supplied by the built-in semantics
- keep atomic `css` on its JavaScript processor contract because atomization determines its final runtime class list

This lets WyW resolve static processor values from package metadata where possible, while the JavaScript processors remain authoritative for extraction and runtime replacement.

## Performance

Measured with three clean production-build runs before and after this change, using the same exact WyW 2.4.0 revision. The focused WyW timings indicate the following potential improvements:

- processor lookup: 12–23% faster
- static metadata resolution: 13–19% faster
- overall pre-evaluation: 2–6% faster

These are indicative local measurements rather than a guaranteed end-to-end build improvement. Transform and eval action counts stayed unchanged, and all generated CSS hashes matched the control runs.

## Checks

- `pnpm check:all`
- focused complex-interpolation regression tests
- downstream production builds and typechecks
- generated CSS output comparison
